### PR TITLE
feat(home): simplify progress bar and add badge heading

### DIFF
--- a/mobile/mockups/app-mockups.html
+++ b/mobile/mockups/app-mockups.html
@@ -725,22 +725,23 @@
                                             <!-- Progress Bar -->
                                             <div style="margin-bottom: var(--space-md);">
                                                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--space-sm);">
-                                                    <span style="font-size: var(--font-size-sm); color: rgba(255, 255, 255, 0.9);">Next Milestone:</span>
-                                                    <span style="font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); color: var(--color-white);">12 sessions to go!</span>
+                                                    <span style="font-size: var(--font-size-sm); color: rgba(255, 255, 255, 0.9);">0</span>
+                                                    <span style="font-size: var(--font-size-sm); color: rgba(255, 255, 255, 0.9);">25</span>
                                                 </div>
                                                 <div style="width: 100%; height: 8px; background: rgba(255, 255, 255, 0.3); border-radius: 4px; overflow: hidden;">
                                                     <div style="width: 52%; height: 100%; background: linear-gradient(90deg, var(--color-yellow), var(--color-yellow-dark));"></div>
                                                 </div>
                                             </div>
                                             
-                                            <!-- Milestone Label -->
-                                            <div style="text-align: center; padding: var(--space-sm); background: rgba(255, 255, 255, 0.2); border-radius: var(--radius-md);">
-                                                <div style="font-size: var(--font-size-base); font-weight: var(--font-weight-medium); color: var(--color-white);">🎯 Next: "Momentum Building!"</div>
-                                                <div style="font-size: var(--font-size-sm); color: rgba(255, 255, 255, 0.8);">Achieve 25 total sessions</div>
+                                            <!-- Slogan -->
+                                            <div style="text-align: center; padding: var(--space-sm);">
+                                                <div style="font-size: var(--font-size-base); font-weight: var(--font-weight-medium); color: var(--color-white);">Momentum Building!</div>
                                             </div>
                                         </div>
                                     </div>
-                                    
+
+                                    <h3 style="font-size: var(--font-size-lg); font-weight: var(--font-weight-bold); color: var(--color-gray-800); margin: var(--space-lg) 0 var(--space-md) 0; text-align: center;">Prime Youth Badges</h3>
+
                                     <div class="badges-grid">
                                         <div class="badge-item">
                                             <div class="badge-icon earned" style="background: var(--prime-yellow);">


### PR DESCRIPTION
## Summary
- Replace verbose progress text ("12 sessions to go!", "Achieve 25 total sessions") with clean numerical endpoints (0 and 25)
- Move slogan "Momentum Building!" below progress bar for cleaner interface
- Add "Prime Youth Badges" heading above badge icons for better organization

## Implementation Details
- Updated progress bar labels in home screen mockup
- Simplified milestone section styling  
- Added proper heading structure for badges section

## Testing
- ✅ Visual testing completed in browser
- ✅ All changes display correctly in mobile mockup
- ✅ Progress bar maintains proper 52% fill visualization

Closes #2