### PR TITLE
🎨(programs): Change pricing display from per-week to total

### DIFF
--- a/mobile/mockups/app-mockups.html
+++ b/mobile/mockups/app-mockups.html
@@ -778,28 +778,28 @@
                                             <div class="activity-image" aria-hidden="true">🎨</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Art World</div>
-                                                <div class="activity-price">€180 Total</div>
+                                                <div class="activity-price">€180 total</div>
                                             </div>
                                         </a>
                                         <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Chess Club program, 140 euros total">
                                             <div class="activity-image" aria-hidden="true">♟️</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Chess Club</div>
-                                                <div class="activity-price">€140 Total</div>
+                                                <div class="activity-price">€140 total</div>
                                             </div>
                                         </a>
                                         <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Music Lessons program, 240 euros total">
                                             <div class="activity-image" aria-hidden="true">🎵</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Music Lessons</div>
-                                                <div class="activity-price">€240 Total</div>
+                                                <div class="activity-price">€240 total</div>
                                             </div>
                                         </a>
                                         <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Rock Climbing program, 200 euros total">
                                             <div class="activity-image" aria-hidden="true">🧗</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Rock Climbing</div>
-                                                <div class="activity-price">€200 Total</div>
+                                                <div class="activity-price">€200 total</div>
                                             </div>
                                         </a>
                                 </section>
@@ -871,12 +871,12 @@
                                         <div style="width: 80px; height: 80px; background: var(--color-yellow-light); border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; font-size: 2rem;">🎨</div>
                                         <div style="flex: 1;">
                                             <h4 style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-800);">Creative Art World</h4>
-                                            <p style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-600); font-size: var(--font-size-sm);">Ages 6-12 • Wednesdays 4-6 PM</p>
+                                            <p style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-600); font-size: var(--font-size-sm);">Ages 6-12 • Wednesdays 4-6 PM • 4 weeks</p>
                                             <div style="margin: 0 0 var(--space-sm) 0; padding: var(--space-xs); background: var(--color-green-light); border-radius: var(--radius-sm);">
                                                 <span style="color: var(--color-green-dark); font-size: var(--font-size-sm); font-weight: var(--font-weight-medium);">✓ 8 spots available</span>
                                             </div>
                                             <div style="display: flex; justify-content: space-between; align-items: center;">
-                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€180 Total</span>
+                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€180 total</span>
                                                 <button class="btn btn-secondary btn-sm">View Details</button>
                                             </div>
                                         </div>
@@ -888,12 +888,12 @@
                                         <div style="width: 80px; height: 80px; background: var(--color-cyan-light); border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; font-size: 2rem;">♟️</div>
                                         <div style="flex: 1;">
                                             <h4 style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-800);">Chess Masters</h4>
-                                            <p style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-600); font-size: var(--font-size-sm);">Ages 8-16 • Fridays 3:30-5 PM</p>
+                                            <p style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-600); font-size: var(--font-size-sm);">Ages 8-16 • Fridays 3:30-5 PM • 4 weeks</p>
                                             <div style="margin: 0 0 var(--space-sm) 0; padding: var(--space-xs); background: var(--color-red-light); border: 1px solid var(--color-red); border-radius: var(--radius-sm);">
                                                 <span style="color: var(--color-red-dark); font-size: var(--font-size-sm); font-weight: var(--font-weight-bold);">⚠️ Only 3 spots left!</span>
                                             </div>
                                             <div style="display: flex; justify-content: space-between; align-items: center;">
-                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€140 Total</span>
+                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€140 total</span>
                                                 <button class="btn btn-secondary btn-sm">View Details</button>
                                             </div>
                                         </div>
@@ -905,12 +905,12 @@
                                         <div style="width: 80px; height: 80px; background: var(--color-magenta-light); border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; font-size: 2rem;">🎵</div>
                                         <div style="flex: 1;">
                                             <h4 style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-800);">Music Exploration</h4>
-                                            <p style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-600); font-size: var(--font-size-sm);">Ages 5-10 • Tuesdays 4-5:30 PM</p>
+                                            <p style="margin: 0 0 var(--space-xs) 0; color: var(--color-gray-600); font-size: var(--font-size-sm);">Ages 5-10 • Tuesdays 4-5:30 PM • 4 weeks</p>
                                             <div style="margin: 0 0 var(--space-sm) 0; padding: var(--space-xs); background: var(--color-blue-light); border-radius: var(--radius-sm);">
                                                 <span style="color: var(--color-blue-dark); font-size: var(--font-size-sm); font-weight: var(--font-weight-medium);">📊 12 spots available</span>
                                             </div>
                                             <div style="display: flex; justify-content: space-between; align-items: center;">
-                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€240 Total</span>
+                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€240 total</span>
                                                 <button class="btn btn-secondary btn-sm">View Details</button>
                                             </div>
                                         </div>
@@ -957,7 +957,7 @@
                                         <p style="margin: 0; color: var(--color-gray-600);">Ages 6-12 • Wednesdays 4-6 PM</p>
                                     </div>
                                     <div style="text-align: right;">
-                                        <div style="color: var(--color-cyan); font-size: var(--font-size-xl); font-weight: var(--font-weight-bold); margin-bottom: var(--space-xs);">€180 Total</div>
+                                        <div style="color: var(--color-cyan); font-size: var(--font-size-xl); font-weight: var(--font-weight-bold); margin-bottom: var(--space-xs);">€180 total</div>
                                         <div style="color: var(--color-gray-600); font-size: var(--font-size-sm); margin-bottom: var(--space-xs);">Sept 1 - Oct 26, 2025</div>
                                         <div style="color: var(--color-gray-500); font-size: var(--font-size-sm);">€45/week • 4 weeks</div>
                                         <div style="color: var(--color-green-dark); font-size: var(--font-size-xs); margin-top: var(--space-xs); font-weight: var(--font-weight-medium);">✓ No hidden fees</div>

--- a/mobile/mockups/app-mockups.html
+++ b/mobile/mockups/app-mockups.html
@@ -774,32 +774,32 @@
                                 <section aria-labelledby="programs-section" class="section">
                                     <h2 id="programs-section" class="section-header">What's Next</h2>
                                     <div class="activity-grid" role="list" aria-label="Recommended programs">
-                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Art World program, 45 euros per week">
+                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Art World program, 180 euros total">
                                             <div class="activity-image" aria-hidden="true">🎨</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Art World</div>
-                                                <div class="activity-price">€45/week</div>
+                                                <div class="activity-price">€180 Total</div>
                                             </div>
                                         </a>
-                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Chess Club program, 35 euros per week">
+                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Chess Club program, 140 euros total">
                                             <div class="activity-image" aria-hidden="true">♟️</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Chess Club</div>
-                                                <div class="activity-price">€35/week</div>
+                                                <div class="activity-price">€140 Total</div>
                                             </div>
                                         </a>
-                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Music Lessons program, 60 euros per week">
+                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Music Lessons program, 240 euros total">
                                             <div class="activity-image" aria-hidden="true">🎵</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Music Lessons</div>
-                                                <div class="activity-price">€60/week</div>
+                                                <div class="activity-price">€240 Total</div>
                                             </div>
                                         </a>
-                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Rock Climbing program, 50 euros per week">
+                                        <a href="#" class="activity-card-small" role="listitem" tabindex="0" aria-label="Rock Climbing program, 200 euros total">
                                             <div class="activity-image" aria-hidden="true">🧗</div>
                                             <div class="activity-info">
                                                 <div class="activity-title">Rock Climbing</div>
-                                                <div class="activity-price">€50/week</div>
+                                                <div class="activity-price">€200 Total</div>
                                             </div>
                                         </a>
                                 </section>
@@ -876,7 +876,7 @@
                                                 <span style="color: var(--color-green-dark); font-size: var(--font-size-sm); font-weight: var(--font-weight-medium);">✓ 8 spots available</span>
                                             </div>
                                             <div style="display: flex; justify-content: space-between; align-items: center;">
-                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€45/week</span>
+                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€180 Total</span>
                                                 <button class="btn btn-secondary btn-sm">View Details</button>
                                             </div>
                                         </div>
@@ -893,7 +893,7 @@
                                                 <span style="color: var(--color-red-dark); font-size: var(--font-size-sm); font-weight: var(--font-weight-bold);">⚠️ Only 3 spots left!</span>
                                             </div>
                                             <div style="display: flex; justify-content: space-between; align-items: center;">
-                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€35/week</span>
+                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€140 Total</span>
                                                 <button class="btn btn-secondary btn-sm">View Details</button>
                                             </div>
                                         </div>
@@ -910,7 +910,7 @@
                                                 <span style="color: var(--color-blue-dark); font-size: var(--font-size-sm); font-weight: var(--font-weight-medium);">📊 12 spots available</span>
                                             </div>
                                             <div style="display: flex; justify-content: space-between; align-items: center;">
-                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€60/week</span>
+                                                <span style="color: var(--color-cyan); font-weight: var(--font-weight-medium);">€240 Total</span>
                                                 <button class="btn btn-secondary btn-sm">View Details</button>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Issue

Closes #3

## Why is this change needed?

Changed programs pricing display from per-week amounts to total program costs for better user clarity.

## What would you like reviewers to focus on?

- Verify pricing calculations are correct (€45→€180, €35→€140, €60→€240, €50→€200)
- Check visual consistency with existing Activity Detail pattern

## Testing Verification

- Updated Home screen 'What's Next' section and Programs screen cards
- Updated aria-labels for accessibility
- Maintained existing styling