### PR TITLE
Update app name to Prime Youth Connect

### DIFF
--- a/lib/prime_youth_web/components/composite_components.ex
+++ b/lib/prime_youth_web/components/composite_components.ex
@@ -390,9 +390,9 @@ defmodule PrimeYouthWeb.CompositeComponents do
     <footer class="footer footer-center p-10 bg-slate-900 text-slate-300">
       <div class="grid grid-cols-1 md:grid-cols-4 gap-8 w-full max-w-6xl">
         <div class="text-left">
-          <h3 class="font-bold text-lg text-white mb-4">Prime Youth</h3>
+          <h3 class="font-bold text-lg text-white mb-4">Prime Youth Connect</h3>
           <p class="text-sm">
-            Empowering children through engaging afterschool activities, camps, and educational programs.
+            Building the future of youth education by connecting communities.
           </p>
         </div>
 
@@ -450,7 +450,7 @@ defmodule PrimeYouthWeb.CompositeComponents do
       </div>
 
       <div class="border-t border-base-300 pt-6 mt-6 w-full">
-        <p class="text-sm">&copy; 2024 Prime Youth. All rights reserved.</p>
+        <p class="text-sm">&copy; 2025 Prime Youth Connect. All rights reserved.</p>
         <div class="flex gap-4 justify-center mt-2 text-xs">
           <.link navigate={~p"/privacy"} class="link link-hover">Privacy Policy</.link>
           <span class="text-gray-400">•</span>

--- a/lib/prime_youth_web/components/layouts/app.html.heex
+++ b/lib/prime_youth_web/components/layouts/app.html.heex
@@ -26,10 +26,10 @@
           <div class="flex items-center gap-2">
             <img
               src={~p"/images/logo-standard.png"}
-              alt="Prime Youth Logo"
+              alt="Prime Youth Connect Logo"
               class="w-8 h-8 object-contain"
             />
-            <span class="text-slate-900 font-bold">Prime Youth</span>
+            <span class="text-slate-900 font-bold">Prime Youth Connect</span>
           </div>
         </a>
       </div>
@@ -216,10 +216,10 @@
         <div class="flex items-center gap-2 mb-8">
           <img
             src={~p"/images/logo-standard.png"}
-            alt="Prime Youth Logo"
+            alt="Prime Youth Connect Logo"
             class="w-8 h-8 object-contain"
           />
-          <span class="text-slate-900 font-bold text-lg">Prime Youth</span>
+          <span class="text-slate-900 font-bold text-lg">Prime Youth Connect</span>
         </div>
 
         <ul class="menu w-full text-slate-900">

--- a/lib/prime_youth_web/components/layouts/root.html.heex
+++ b/lib/prime_youth_web/components/layouts/root.html.heex
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="Prime Youth" suffix=" · Afterschool Activities & Camps">
+    <.live_title default="Prime Youth Connect" suffix=" · Afterschool Activities & Camps">
       {assigns[:page_title]}
     </.live_title>
     

--- a/lib/prime_youth_web/live/about_live.ex
+++ b/lib/prime_youth_web/live/about_live.ex
@@ -92,7 +92,7 @@ defmodule PrimeYouthWeb.AboutLive do
         gradient_class={Theme.gradient(:hero)}
         show_back_button
       >
-        <:title>About Prime Youth</:title>
+        <:title>About Prime Youth Connect</:title>
         <:subtitle>Empowering young minds through quality after-school programs</:subtitle>
       </.hero_section>
 
@@ -106,7 +106,7 @@ defmodule PrimeYouthWeb.AboutLive do
           </:header>
           <:body>
             <p class={[Theme.text_color(:secondary), "leading-relaxed"]}>
-              At Prime Youth, we believe every child deserves access to enriching after-school activities that nurture their talents and interests. We partner with qualified instructors to provide a diverse range of programs in arts, sports, academics, and technology.
+              At Prime Youth Connect, we believe every child deserves access to enriching after-school activities that nurture their talents and interests. We partner with qualified instructors to provide a diverse range of programs in arts, sports, academics, and technology.
             </p>
             <p class={[Theme.text_color(:secondary), "leading-relaxed mt-4"]}>
               Our platform makes it easy for parents to discover, book, and manage activities while providing instructors with the tools they need to run successful programs.
@@ -140,7 +140,7 @@ defmodule PrimeYouthWeb.AboutLive do
         <.card>
           <:header>
             <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading)]}>
-              Why Choose Prime Youth?
+              Why Choose Prime Youth Connect?
             </h2>
           </:header>
           <:body>

--- a/lib/prime_youth_web/live/booking_live.ex
+++ b/lib/prime_youth_web/live/booking_live.ex
@@ -344,7 +344,7 @@ defmodule PrimeYouthWeb.BookingLive do
             <div class="space-y-2 font-mono text-sm">
               <div class="flex justify-between">
                 <span class={Theme.text_color(:secondary)}>Account Name:</span>
-                <span class="font-semibold">Prime Youth Activities Ltd</span>
+                <span class="font-semibold">Prime Youth Connect</span>
               </div>
               <div class="flex justify-between">
                 <span class={Theme.text_color(:secondary)}>IBAN:</span>

--- a/lib/prime_youth_web/live/highlights_live.ex
+++ b/lib/prime_youth_web/live/highlights_live.ex
@@ -118,7 +118,7 @@ defmodule PrimeYouthWeb.HighlightsLive do
             :if={@posts_empty?}
             icon_path="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
             title="No highlights yet"
-            description="Stay tuned for updates, photos, and announcements from instructors and the Prime Youth community."
+            description="Stay tuned for updates, photos, and announcements from instructors and the Prime Youth Connect community."
           />
         </div>
       </div>

--- a/lib/prime_youth_web/live/home_live.ex
+++ b/lib/prime_youth_web/live/home_live.ex
@@ -12,7 +12,9 @@ defmodule PrimeYouthWeb.HomeLive do
 
     socket =
       socket
-      |> assign(page_title: "Prime Youth - Afterschool Adventures Await")
+      |> assign(
+        page_title: "Prime Youth Connect - Connecting Families with Trusted Youth Educators"
+      )
       |> assign(featured_programs: featured)
 
     {:ok, socket}
@@ -38,8 +40,8 @@ defmodule PrimeYouthWeb.HomeLive do
         gradient_class={Theme.gradient(:hero)}
         show_logo
       >
-        <:title>Prime Youth</:title>
-        <:subtitle>Afterschool Adventures Await</:subtitle>
+        <:title>Prime Youth Connect</:title>
+        <:subtitle>Connecting Families with Trusted Youth Educators</:subtitle>
         <:actions>
           <button
             phx-click="get_started"
@@ -74,10 +76,10 @@ defmodule PrimeYouthWeb.HomeLive do
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
           <div class="text-center mb-16">
             <h2 class={[Theme.typography(:page_title), "mb-4", Theme.text_color(:heading)]}>
-              Why Families Choose Prime Youth
+              Why Prime Youth Connect?
             </h2>
             <p class={["text-xl", Theme.text_color(:secondary)]}>
-              Expert instructors, comprehensive tracking, and flexible scheduling for your family
+              Safety, quality, and convenience for modern families.
             </p>
           </div>
 
@@ -85,20 +87,20 @@ defmodule PrimeYouthWeb.HomeLive do
             <.feature_card
               gradient_class={Theme.gradient(:cool)}
               icon_path="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-              title="Expert Instructors & Small Class Sizes"
-              description="All instructors are background-checked and classes are limited to ensure personalized attention"
+              title="Safety First"
+              description="Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
             />
             <.feature_card
               gradient_class={Theme.gradient(:primary)}
               icon_path="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-              title="Comprehensive Progress Tracking"
-              description="Monitor your child's development with regular updates, achievements, and progress reports"
+              title="Easy Scheduling"
+              description="Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
             />
             <.feature_card
               gradient_class={Theme.gradient(:primary)}
               icon_path="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-              title="Flexible Scheduling & Pricing"
-              description="Find programs that fit your family's schedule with transparent pricing and easy online booking"
+              title="Community Focused"
+              description="Built for the Berlin international community. Connect with local families and trusted educators nearby."
             />
           </div>
         </div>
@@ -109,10 +111,10 @@ defmodule PrimeYouthWeb.HomeLive do
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div class="text-center mb-12">
             <h2 class={[Theme.typography(:page_title), "mb-4", Theme.text_color(:heading)]}>
-              Popular Programs
+              Featured Programs
             </h2>
             <p class={["text-xl", Theme.text_color(:secondary)]}>
-              Discover what families are enrolling in this season
+              Explore top-rated activities for your children
             </p>
           </div>
 

--- a/lib/prime_youth_web/live/privacy_policy_live.ex
+++ b/lib/prime_youth_web/live/privacy_policy_live.ex
@@ -22,7 +22,7 @@ defmodule PrimeYouthWeb.PrivacyPolicyLive do
         gradient: Theme.gradient(:cool),
         title: "Introduction",
         content: """
-        <p class="mb-4">Welcome to Prime Youth's Privacy Policy. At Prime Youth, we connect families with enriching afterschool programs, camps, and educational activities. We understand that when you entrust us with your family's information, you expect us to handle it responsibly and transparently.</p>
+        <p class="mb-4">Welcome to Prime Youth Connect's Privacy Policy. At Prime Youth Connect, we connect families with enriching afterschool programs, camps, and educational activities. We understand that when you entrust us with your family's information, you expect us to handle it responsibly and transparently.</p>
         <p class="mb-4">This Privacy Policy explains what information we collect, how we use it, and your rights regarding your personal data. We are committed to protecting your privacy and complying with data protection laws, including GDPR.</p>
         <p class="font-semibold text-gray-900">Last Updated: #{last_updated()}</p>
         """
@@ -147,7 +147,7 @@ defmodule PrimeYouthWeb.PrivacyPolicyLive do
         gradient: Theme.gradient(:cool_magenta),
         title: "Children's Privacy",
         content: """
-        <p class="mb-4">Prime Youth is designed to help parents manage their children's activities. We take special care with children's information:</p>
+        <p class="mb-4">Prime Youth Connect is designed to help parents manage their children's activities. We take special care with children's information:</p>
         <ul class="list-disc pl-6 space-y-2 mb-4">
           <li><strong>Parental Consent:</strong> Parents or legal guardians must create accounts and provide consent for their children's participation</li>
           <li><strong>COPPA Compliance:</strong> We comply with the Children's Online Privacy Protection Act (COPPA) for children under 13</li>
@@ -165,7 +165,7 @@ defmodule PrimeYouthWeb.PrivacyPolicyLive do
         gradient: Theme.gradient(:warm_yellow),
         title: "Cookies & Tracking",
         content: """
-        <p class="mb-4">Prime Youth uses minimal tracking to provide essential functionality:</p>
+        <p class="mb-4">Prime Youth Connect uses minimal tracking to provide essential functionality:</p>
         <h4 class="font-semibold text-gray-900 mb-2">Essential Cookies:</h4>
         <p class="mb-4">We use session cookies that are necessary for authentication and platform functionality. These cookies do not track you across other websites and are automatically deleted when you close your browser or log out.</p>
         <h4 class="font-semibold text-gray-900 mb-2">No Third-Party Tracking:</h4>
@@ -201,7 +201,7 @@ defmodule PrimeYouthWeb.PrivacyPolicyLive do
         <ul class="list-disc pl-6 space-y-2 mb-4">
           <li>We will update the "Last Updated" date at the top of this policy</li>
           <li>For material changes, we will send an email notification to all active users</li>
-          <li>Continued use of Prime Youth after changes constitute acceptance of the updated policy</li>
+          <li>Continued use of Prime Youth Connect after changes constitute acceptance of the updated policy</li>
         </ul>
         <p>We encourage you to review this policy periodically to stay informed about how we protect your information.</p>
         """

--- a/lib/prime_youth_web/live/terms_of_service_live.ex
+++ b/lib/prime_youth_web/live/terms_of_service_live.ex
@@ -22,8 +22,8 @@ defmodule PrimeYouthWeb.TermsOfServiceLive do
         gradient: Theme.gradient(:primary),
         title: "Agreement to Terms",
         content: """
-        <p class="mb-4">By accessing and using Prime Youth ("the Platform"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use our services.</p>
-        <p class="mb-4">These terms constitute a legally binding agreement between you and Prime Youth. Please read them carefully.</p>
+        <p class="mb-4">By accessing and using Prime Youth Connect ("the Platform"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use our services.</p>
+        <p class="mb-4">These terms constitute a legally binding agreement between you and Prime Youth Connect. Please read them carefully.</p>
         <p class="font-semibold text-gray-900">Last Updated: #{last_updated()}</p>
         """
       },
@@ -113,7 +113,7 @@ defmodule PrimeYouthWeb.TermsOfServiceLive do
         </ul>
         <h4 class="font-semibold text-gray-900 mb-2">Program Cancellations:</h4>
         <ul class="list-disc pl-6 space-y-2">
-          <li>If Prime Youth or an instructor cancels a program, you will receive a full refund</li>
+          <li>If Prime Youth Connect or an instructor cancels a program, you will receive a full refund</li>
           <li>Weather-related cancellations will be rescheduled when possible</li>
           <li>We will notify you as soon as possible of any cancellations</li>
         </ul>
@@ -151,7 +151,7 @@ defmodule PrimeYouthWeb.TermsOfServiceLive do
         title: "Limitation of Liability",
         content: """
         <h4 class="font-semibold text-gray-900 mb-2">Platform Use:</h4>
-        <p class="mb-4">Prime Youth provides a platform to connect families with program instructors. While we verify instructor credentials and monitor program quality, the actual programs are provided by independent instructors.</p>
+        <p class="mb-4">Prime Youth Connect provides a platform to connect families with program instructors. While we verify instructor credentials and monitor program quality, the actual programs are provided by independent instructors.</p>
         <h4 class="font-semibold text-gray-900 mb-2">Liability Limits:</h4>
         <ul class="list-disc pl-6 space-y-2 mb-4">
           <li>We are not liable for injuries or accidents that occur during programs</li>
@@ -162,7 +162,7 @@ defmodule PrimeYouthWeb.TermsOfServiceLive do
         <h4 class="font-semibold text-gray-900 mb-2">Service Availability:</h4>
         <p class="mb-4">We strive to keep the Platform available, but we cannot guarantee uninterrupted access. We are not liable for service interruptions or technical issues.</p>
         <p class="mt-4 text-sm italic text-gray-600">
-          To the extent permitted by law, Prime Youth's total liability shall not exceed the amount you paid for services in the 12 months preceding any claim.
+          To the extent permitted by law, Prime Youth Connect's total liability shall not exceed the amount you paid for services in the 12 months preceding any claim.
         </p>
         """
       },
@@ -173,7 +173,7 @@ defmodule PrimeYouthWeb.TermsOfServiceLive do
         title: "Intellectual Property",
         content: """
         <h4 class="font-semibold text-gray-900 mb-2">Platform Content:</h4>
-        <p class="mb-4">All content on Prime Youth, including text, graphics, logos, and software, is owned by Prime Youth or licensed to us and protected by copyright and trademark laws.</p>
+        <p class="mb-4">All content on Prime Youth Connect, including text, graphics, logos, and software, is owned by Prime Youth Connect or licensed to us and protected by copyright and trademark laws.</p>
         <h4 class="font-semibold text-gray-900 mb-2">User Content:</h4>
         <ul class="list-disc pl-6 space-y-2 mb-4">
           <li>You retain ownership of any content you submit (reviews, photos with permission)</li>
@@ -199,7 +199,7 @@ defmodule PrimeYouthWeb.TermsOfServiceLive do
         <ul class="list-disc pl-6 space-y-2 mb-4">
           <li>We will update the "Last Updated" date at the top of these terms</li>
           <li>For material changes, we will send an email notification to all active users</li>
-          <li>Continued use of Prime Youth after changes constitute acceptance of the updated terms</li>
+          <li>Continued use of Prime Youth Connect after changes constitute acceptance of the updated terms</li>
           <li>If you disagree with changes, you may terminate your account</li>
         </ul>
         <p>We encourage you to review these terms periodically to stay informed.</p>
@@ -253,7 +253,7 @@ defmodule PrimeYouthWeb.TermsOfServiceLive do
         </div>
         <p class="mt-4">You can also reach us through our <a href="/contact" class="text-blue-600 hover:underline">Contact Page</a>.</p>
         <p class="mt-6 p-4 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-700">
-          By using Prime Youth, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service and our Privacy Policy.
+          By using Prime Youth Connect, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service and our Privacy Policy.
         </p>
         """
       }

--- a/test/prime_youth_web/live/about_live_test.exs
+++ b/test/prime_youth_web/live/about_live_test.exs
@@ -7,14 +7,14 @@ defmodule PrimeYouthWeb.AboutLiveTest do
     test "renders about page successfully", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/about")
 
-      assert has_element?(view, "h1", "About Prime Youth")
+      assert has_element?(view, "h1", "About Prime Youth Connect")
     end
 
     test "displays hero section with page variant", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/about")
 
       # Verify hero section content
-      assert html =~ "About Prime Youth"
+      assert html =~ "About Prime Youth Connect"
       assert html =~ "Empowering young minds through quality after-school programs"
     end
 
@@ -52,7 +52,7 @@ defmodule PrimeYouthWeb.AboutLiveTest do
       {:ok, _view, html} = live(conn, ~p"/about")
 
       # Verify key features heading
-      assert html =~ "Why Choose Prime Youth?"
+      assert html =~ "Why Choose Prime Youth Connect?"
 
       # Verify all four key features are present
       assert html =~ "Easy Discovery"
@@ -105,7 +105,7 @@ defmodule PrimeYouthWeb.AboutLiveTest do
       {:ok, _view, html} = live(conn, ~p"/about")
 
       # Verify page title is set
-      assert html =~ "About Prime Youth"
+      assert html =~ "About Prime Youth Connect"
     end
 
     test "responsive grid layout for key features", %{conn: conn} do
@@ -128,7 +128,7 @@ defmodule PrimeYouthWeb.AboutLiveTest do
 
       # The hero_section component with show_back_button should render a back button
       # This is a navigation aid for the page variant
-      assert html =~ "About Prime Youth"
+      assert html =~ "About Prime Youth Connect"
     end
 
     test "mission section contains complete description", %{conn: conn} do
@@ -168,7 +168,7 @@ defmodule PrimeYouthWeb.AboutLiveTest do
       # Verify multiple sections use card component (indicated by structured content)
       assert html =~ "Our Mission"
       assert html =~ "Our Values"
-      assert html =~ "Why Choose Prime Youth?"
+      assert html =~ "Why Choose Prime Youth Connect?"
       assert html =~ "Ready to Get Started?"
     end
   end

--- a/test/prime_youth_web/live/home_live_test.exs
+++ b/test/prime_youth_web/live/home_live_test.exs
@@ -7,16 +7,16 @@ defmodule PrimeYouthWeb.HomeLiveTest do
     test "renders home page successfully", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/")
 
-      assert has_element?(view, "h1", "Prime Youth")
-      assert render(view) =~ "Afterschool Adventures Await"
+      assert has_element?(view, "h1", "Prime Youth Connect")
+      assert render(view) =~ "Connecting Families with Trusted Youth Educators"
     end
 
     test "displays hero section with landing variant", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/")
 
       # Verify hero section content
-      assert html =~ "Prime Youth"
-      assert html =~ "Afterschool Adventures Await"
+      assert html =~ "Prime Youth Connect"
+      assert html =~ "Connecting Families with Trusted Youth Educators"
       assert html =~ "Get Started Free"
       assert html =~ "Explore Programs"
     end
@@ -25,20 +25,20 @@ defmodule PrimeYouthWeb.HomeLiveTest do
       {:ok, _view, html} = live(conn, ~p"/")
 
       # Verify features section heading
-      assert html =~ "Why Families Choose Prime Youth"
+      assert html =~ "Why Prime Youth Connect?"
 
       # Verify all three feature cards are present
-      assert html =~ "Expert Instructors"
-      assert html =~ "Comprehensive Progress Tracking"
-      assert html =~ "Flexible Scheduling"
+      assert html =~ "Safety First"
+      assert html =~ "Easy Scheduling"
+      assert html =~ "Community Focused"
     end
 
     test "displays featured programs section", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/")
 
       # Verify featured programs section heading
-      assert html =~ "Popular Programs"
-      assert html =~ "Discover what families are enrolling in this season"
+      assert html =~ "Featured Programs"
+      assert html =~ "Explore top-rated activities for your children"
 
       # Verify "View All Programs" button exists
       assert html =~ "View All Programs"
@@ -112,7 +112,7 @@ defmodule PrimeYouthWeb.HomeLiveTest do
 
       # Verify page title is set (though it may not be directly visible in HTML)
       # This is more about ensuring the mount function sets it properly
-      assert html =~ "Prime Youth"
+      assert html =~ "Prime Youth Connect"
     end
 
     test "featured programs are displayed from sample data", %{conn: conn} do
@@ -121,7 +121,7 @@ defmodule PrimeYouthWeb.HomeLiveTest do
       # Verify that sample programs are rendered
       # The featured_programs() fixture should provide sample data
       # We check for program card elements
-      assert html =~ "Popular Programs"
+      assert html =~ "Featured Programs"
 
       # Verify program cards are clickable and trigger explore_programs
       assert html =~ "phx-click=\"explore_programs\""


### PR DESCRIPTION
Updates all text references from "Prime Youth" to "Prime Youth Connect" for brand consistency.

**Changes:**
- App name in layouts, navigation, and page titles
- Home page hero, features, and content sections
- About, Privacy Policy, and Terms of Service pages
- Footer and community references
- Test assertions updated to match