### PR TITLE
refactor: streamline repository error handling and return types

### DIFF
--- a/lib/prime_youth/attendance/application/use_cases/complete_session.ex
+++ b/lib/prime_youth/attendance/application/use_cases/complete_session.ex
@@ -45,18 +45,13 @@ defmodule PrimeYouth.Attendance.Application.UseCases.CompleteSession do
   end
 
   defp get_attendance_count(session_id) do
-    case attendance_repository().list_by_session(session_id) do
-      {:ok, records} ->
-        count =
-          records
-          |> Enum.count(fn record -> record.status in [:checked_in, :checked_out] end)
+    records = attendance_repository().list_by_session(session_id)
 
-        {:ok, count}
+    count =
+      records
+      |> Enum.count(fn record -> record.status in [:checked_in, :checked_out] end)
 
-      {:error, _reason} ->
-        # Fallback to 0 if we can't get the count
-        {:ok, 0}
-    end
+    {:ok, count}
   end
 
   defp publish_session_completed_event(session, attendance_count) do

--- a/lib/prime_youth/attendance/application/use_cases/get_attendance_history.ex
+++ b/lib/prime_youth/attendance/application/use_cases/get_attendance_history.ex
@@ -23,23 +23,22 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistory do
   - `filter_value` - Value to filter by (child_id, session_id, or parent_id)
 
   ## Returns
-  - `{:ok, [record]}` - List of matching attendance records
-  - `{:error, reason}` - Query failed
-    - Database errors (`:database_connection_error`, etc.)
+  - `[AttendanceRecord.t()]` - List of matching attendance records (may be empty)
+  - `{:error, {:invalid_filter_type, atom()}}` - Invalid filter type provided
 
   ## Examples
 
       iex> GetAttendanceHistory.execute(:by_child, child_id)
-      {:ok, [%AttendanceRecord{}, ...]}
+      [%AttendanceRecord{}, ...]
 
       iex> GetAttendanceHistory.execute(:by_session, session_id)
-      {:ok, [%AttendanceRecord{}, ...]}
+      [%AttendanceRecord{}, ...]
 
       iex> GetAttendanceHistory.execute(:by_parent, parent_id)
-      {:ok, [%AttendanceRecord{}, ...]}
+      [%AttendanceRecord{}, ...]
 
       iex> GetAttendanceHistory.execute(:invalid_filter, "value")
-      {:error, :invalid_filter_type}
+      {:error, {:invalid_filter_type, :invalid_filter}}
   """
   def execute(:by_child, child_id) when is_binary(child_id) do
     attendance_repository().list_by_child(child_id)

--- a/lib/prime_youth/attendance/application/use_cases/get_session_with_roster.ex
+++ b/lib/prime_youth/attendance/application/use_cases/get_session_with_roster.ex
@@ -26,8 +26,8 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetSessionWithRoster do
     - Database errors
   """
   def execute(session_id) when is_binary(session_id) do
-    with {:ok, session} <- session_repository().get_by_id(session_id),
-         {:ok, records} <- attendance_repository().list_by_session(session_id) do
+    with {:ok, session} <- session_repository().get_by_id(session_id) do
+      records = attendance_repository().list_by_session(session_id)
       {:ok, Map.put(session, :attendance_records, records)}
     end
   end
@@ -49,8 +49,8 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetSessionWithRoster do
     - Database errors
   """
   def execute_enriched(session_id) when is_binary(session_id) do
-    with {:ok, session} <- session_repository().get_by_id(session_id),
-         {:ok, enriched_records} <- attendance_repository().list_by_session_enriched(session_id) do
+    with {:ok, session} <- session_repository().get_by_id(session_id) do
+      enriched_records = attendance_repository().list_by_session_enriched(session_id)
       {:ok, Map.put(session, :attendance_records, enriched_records)}
     end
   end

--- a/lib/prime_youth/attendance/application/use_cases/list_provider_sessions.ex
+++ b/lib/prime_youth/attendance/application/use_cases/list_provider_sessions.ex
@@ -25,14 +25,12 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListProviderSessions do
   - `date` - Date to filter sessions
 
   ## Returns
-  - `{:ok, [session]}` - List of matching sessions
-  - `{:error, reason}` - Query failed
-    - Database errors
+  - `[ProgramSession.t()]` - List of matching sessions (may be empty)
 
   ## Examples
 
       iex> ListProviderSessions.execute(provider_id, ~D[2025-01-15])
-      {:ok, [%ProgramSession{}, ...]}
+      [%ProgramSession{}, ...]
   """
   def execute(provider_id, %Date{} = date) when is_binary(provider_id) do
     session_repository().list_by_provider_and_date(provider_id, date)

--- a/lib/prime_youth/attendance/application/use_cases/list_sessions.ex
+++ b/lib/prime_youth/attendance/application/use_cases/list_sessions.ex
@@ -22,20 +22,19 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListSessions do
   - `filter_value` - Value to filter by (program_id or date)
 
   ## Returns
-  - `{:ok, [session]}` - List of matching sessions
-  - `{:error, reason}` - Query failed
-    - Database errors (`:database_connection_error`, etc.)
+  - `[ProgramSession.t()]` - List of matching sessions (may be empty)
+  - `{:error, {:invalid_filter_type, atom()}}` - Invalid filter type provided
 
   ## Examples
 
       iex> ListSessions.execute(:by_program, program_id)
-      {:ok, [%ProgramSession{}, ...]}
+      [%ProgramSession{}, ...]
 
       iex> ListSessions.execute(:today, ~D[2025-01-15])
-      {:ok, [%ProgramSession{}, ...]}
+      [%ProgramSession{}, ...]
 
       iex> ListSessions.execute(:invalid_filter, "value")
-      {:error, :invalid_filter_type}
+      {:error, {:invalid_filter_type, :invalid_filter}}
   """
   def execute(:by_program, program_id) when is_binary(program_id) do
     session_repository().list_by_program(program_id)

--- a/lib/prime_youth/attendance/domain/ports/for_managing_attendance.ex
+++ b/lib/prime_youth/attendance/domain/ports/for_managing_attendance.ex
@@ -2,38 +2,43 @@ defmodule PrimeYouth.Attendance.Domain.Ports.ForManagingAttendance do
   @moduledoc """
   Repository port for attendance record persistence.
 
-  ## Error Types
+  ## Expected Return Values
 
-  - `:database_connection_error`, `:database_query_error`, `:database_unavailable`
-  - `:not_found`, `:duplicate_attendance` (unique: session_id + child_id)
+  - `create/1` - Returns `{:ok, record}` or `{:error, :duplicate_attendance}`
+  - `get_by_id/1`, `get_by_session_and_child/2` - Returns `{:ok, record}` or `{:error, :not_found}`
+  - `update/1` - Returns `{:ok, record}` or `{:error, :stale_data | :not_found}`
+  - List operations - Return list of records directly
+
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
 
-  @doc "Creates record. Unique constraint: one record per session/child combination."
-  @callback create(struct()) :: {:ok, struct()} | {:error, atom()}
+  @doc "Creates record. Returns `{:error, :duplicate_attendance}` on unique violation."
+  @callback create(struct()) :: {:ok, struct()} | {:error, :duplicate_attendance | term()}
 
-  @doc "Retrieves record by ID."
-  @callback get_by_id(binary()) :: {:ok, struct()} | {:error, atom()}
+  @doc "Retrieves record by ID. Returns `{:error, :not_found}` if not found."
+  @callback get_by_id(binary()) :: {:ok, struct()} | {:error, :not_found}
 
   @doc "Retrieves multiple records by their IDs."
-  @callback get_many_by_ids([binary()]) :: {:ok, [struct()]} | {:error, atom()}
+  @callback get_many_by_ids([binary()]) :: [struct()]
 
-  @doc "Retrieves record by session_id and child_id."
-  @callback get_by_session_and_child(binary(), binary()) :: {:ok, struct()} | {:error, atom()}
+  @doc "Retrieves record by session_id and child_id. Returns `{:error, :not_found}` if not found."
+  @callback get_by_session_and_child(binary(), binary()) :: {:ok, struct()} | {:error, :not_found}
 
-  @doc "Updates existing record atomically."
-  @callback update(struct()) :: {:ok, struct()} | {:error, atom()}
+  @doc "Updates existing record. Returns `{:error, :stale_data}` on optimistic lock conflict."
+  @callback update(struct()) :: {:ok, struct()} | {:error, :stale_data | :not_found | term()}
 
   @doc "Lists records for session, ordered by child name."
-  @callback list_by_session(binary()) :: {:ok, [struct()]} | {:error, atom()}
+  @callback list_by_session(binary()) :: [struct()]
 
   @doc "Lists records for child, ordered by session_date desc."
-  @callback list_by_child(binary()) :: {:ok, [struct()]} | {:error, atom()}
+  @callback list_by_child(binary()) :: [struct()]
 
   @doc "Lists records for parent, ordered by session_date desc."
-  @callback list_by_parent(binary()) :: {:ok, [struct()]} | {:error, atom()}
+  @callback list_by_parent(binary()) :: [struct()]
 
   @doc "Lists records for multiple sessions (batch fetch). Ordered by session_id, then child_id."
-  @callback list_by_session_ids([binary()]) :: {:ok, [struct()]} | {:error, atom()}
+  @callback list_by_session_ids([binary()]) :: [struct()]
 
   @doc """
   Atomic check-in: creates or updates record in single database operation.
@@ -42,5 +47,5 @@ defmodule PrimeYouth.Attendance.Domain.Ports.ForManagingAttendance do
   Uses upsert pattern on (session_id, child_id) unique constraint.
   """
   @callback check_in_atomic(binary(), binary(), binary(), String.t() | nil) ::
-              {:ok, struct()} | {:error, atom()}
+              {:ok, struct()} | {:error, term()}
 end

--- a/lib/prime_youth/attendance/domain/ports/for_managing_sessions.ex
+++ b/lib/prime_youth/attendance/domain/ports/for_managing_sessions.ex
@@ -2,26 +2,31 @@ defmodule PrimeYouth.Attendance.Domain.Ports.ForManagingSessions do
   @moduledoc """
   Repository port for session persistence.
 
-  ## Error Types
+  ## Expected Return Values
 
-  - `:database_connection_error`, `:database_query_error`, `:database_unavailable`
-  - `:not_found`, `:duplicate_session` (unique: program_id + session_date + start_time)
+  - `create/1` - Returns `{:ok, session}` or `{:error, :duplicate_session}`
+  - `get_by_id/1` - Returns `{:ok, session}` or `{:error, :not_found}`
+  - `update/1` - Returns `{:ok, session}` or `{:error, :stale_data | :not_found}`
+  - List operations - Return list of sessions directly
+
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
 
-  @doc "Creates session. Unique constraint: one session per program/date/start_time combination."
-  @callback create(struct()) :: {:ok, struct()} | {:error, atom()}
+  @doc "Creates session. Returns `{:error, :duplicate_session}` on unique violation."
+  @callback create(struct()) :: {:ok, struct()} | {:error, :duplicate_session | term()}
 
-  @doc "Retrieves session by ID."
-  @callback get_by_id(binary()) :: {:ok, struct()} | {:error, atom()}
+  @doc "Retrieves session by ID. Returns `{:error, :not_found}` if not found."
+  @callback get_by_id(binary()) :: {:ok, struct()} | {:error, :not_found}
 
   @doc "Lists sessions for program, ordered by session_date, then start_time."
-  @callback list_by_program(binary()) :: {:ok, [struct()]} | {:error, atom()}
+  @callback list_by_program(binary()) :: [struct()]
 
   @doc "Lists sessions for date, ordered by start_time."
-  @callback list_today_sessions(Date.t()) :: {:ok, [struct()]} | {:error, atom()}
+  @callback list_today_sessions(Date.t()) :: [struct()]
 
-  @doc "Updates existing session atomically."
-  @callback update(struct()) :: {:ok, struct()} | {:error, atom()}
+  @doc "Updates existing session. Returns `{:error, :stale_data}` on optimistic lock conflict."
+  @callback update(struct()) :: {:ok, struct()} | {:error, :stale_data | :not_found | term()}
 
   @doc """
   Lists sessions for a provider on a specific date, ordered by start_time.
@@ -29,8 +34,8 @@ defmodule PrimeYouth.Attendance.Domain.Ports.ForManagingSessions do
   Note: Requires provider-program relationship in schema for full filtering.
   Currently filters by date only until schema is updated.
   """
-  @callback list_by_provider_and_date(binary(), Date.t()) :: {:ok, [struct()]} | {:error, atom()}
+  @callback list_by_provider_and_date(binary(), Date.t()) :: [struct()]
 
   @doc "Retrieves multiple sessions by their IDs (batch fetch)."
-  @callback get_many_by_ids([binary()]) :: {:ok, [struct()]} | {:error, atom()}
+  @callback get_many_by_ids([binary()]) :: [struct()]
 end

--- a/lib/prime_youth/family/adapters/driven/persistence/repositories/child_repository.ex
+++ b/lib/prime_youth/family/adapters/driven/persistence/repositories/child_repository.ex
@@ -2,27 +2,12 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
   @moduledoc """
   Repository implementation for child persistence.
 
-  Implements the ForStoringChildren port with comprehensive error handling,
-  structured logging, and database interaction patterns.
+  Implements the ForStoringChildren port with:
+  - Domain entity mapping via ChildMapper
+  - Idiomatic "let it crash" error handling
 
-  ## Operations
-
-  - `get_by_id/1` - Retrieve a child by unique identifier
-  - `create/1` - Create a new child record
-  - `list_by_parent/1` - List all children for a parent (ordered alphabetically)
-
-  ## Error Handling
-
-  All operations follow a consistent error categorization pattern:
-  - `:database_connection_error` - Network/connection issues
-  - `:database_query_error` - Query execution failures
-  - `:database_unavailable` - Generic database failures
-  - `:not_found` - Child not found (get_by_id only)
-
-  ## Logging
-
-  All operations log with `[ChildRepository]` prefix for easy filtering.
-  Error logs include error IDs from ErrorIds module for tracking.
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
 
   @behaviour PrimeYouth.Family.Domain.Ports.ForStoringChildren
@@ -43,68 +28,37 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
       child_id: child_id
     )
 
-    try do
-      case Repo.get(ChildSchema, child_id) do
-        nil ->
-          Logger.info(
-            "[ChildRepository] Child not found",
-            child_id: child_id
-          )
+    # Use dump/1 to validate UUID format - cast/1 incorrectly accepts 16-byte binaries
+    case Ecto.UUID.dump(child_id) do
+      {:ok, _binary} ->
+        case Repo.get(ChildSchema, child_id) do
+          nil ->
+            Logger.info(
+              "[ChildRepository] Child not found",
+              child_id: child_id
+            )
 
-          {:error, :not_found}
+            {:error, :not_found}
 
-        schema ->
-          child = ChildMapper.to_domain(schema)
+          schema ->
+            child = ChildMapper.to_domain(schema)
 
-          Logger.info(
-            "[ChildRepository] Successfully retrieved child",
-            child_id: child.id,
-            parent_id: child.parent_id
-          )
+            Logger.info(
+              "[ChildRepository] Successfully retrieved child",
+              child_id: child.id,
+              parent_id: child.parent_id
+            )
 
-          {:ok, child}
-      end
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ChildRepository] Database connection failed during get_by_id",
-          error_id: ErrorIds.child_get_connection_error(),
-          child_id: child_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
+            {:ok, child}
+        end
 
-        {:error, :database_connection_error}
-
-      _error in [Ecto.Query.CastError] ->
+      :error ->
         Logger.info(
-          "[ChildRepository] Invalid UUID format during get_by_id",
+          "[ChildRepository] Invalid UUID format",
           child_id: child_id
         )
 
         {:error, :not_found}
-
-      error in [Postgrex.Error] ->
-        Logger.error(
-          "[ChildRepository] Database query error during get_by_id",
-          error_id: ErrorIds.child_get_query_error(),
-          child_id: child_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ChildRepository] Unexpected database error during get_by_id",
-          error_id: ErrorIds.child_get_generic_error(),
-          child_id: child_id,
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
     end
   end
 
@@ -119,60 +73,28 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
 
     changeset = ChildSchema.changeset(%ChildSchema{}, attrs)
 
-    try do
-      case Repo.insert(changeset) do
-        {:ok, schema} ->
-          child = ChildMapper.to_domain(schema)
+    case Repo.insert(changeset) do
+      {:ok, schema} ->
+        child = ChildMapper.to_domain(schema)
 
-          Logger.info(
-            "[ChildRepository] Successfully created child",
-            child_id: child.id,
-            parent_id: child.parent_id,
-            first_name: child.first_name,
-            last_name: child.last_name
-          )
-
-          {:ok, child}
-
-        {:error, changeset} ->
-          Logger.warning(
-            "[ChildRepository] Changeset validation failed during create",
-            error_id: ErrorIds.child_create_query_error(),
-            errors: changeset.errors
-          )
-
-          {:error, :database_query_error}
-      end
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ChildRepository] Database connection failed during create",
-          error_id: ErrorIds.child_create_connection_error(),
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
+        Logger.info(
+          "[ChildRepository] Successfully created child",
+          child_id: child.id,
+          parent_id: child.parent_id,
+          first_name: child.first_name,
+          last_name: child.last_name
         )
 
-        {:error, :database_connection_error}
+        {:ok, child}
 
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ChildRepository] Database query error during create",
-          error_id: ErrorIds.child_create_query_error(),
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
+      {:error, changeset} ->
+        Logger.warning(
+          "[ChildRepository] Changeset validation failed during create",
+          error_id: ErrorIds.child_validation_error(),
+          errors: changeset.errors
         )
 
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ChildRepository] Unexpected database error during create",
-          error_id: ErrorIds.child_create_generic_error(),
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
+        {:error, changeset}
     end
   end
 
@@ -183,55 +105,19 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
       parent_id: parent_id
     )
 
-    query =
-      from c in ChildSchema,
-        where: c.parent_id == ^parent_id,
-        order_by: [asc: c.first_name, asc: c.last_name]
+    children =
+      ChildSchema
+      |> where([c], c.parent_id == ^parent_id)
+      |> order_by([c], asc: c.first_name, asc: c.last_name)
+      |> Repo.all()
+      |> ChildMapper.to_domain_list()
 
-    try do
-      schemas = Repo.all(query)
-      children = ChildMapper.to_domain_list(schemas)
+    Logger.info(
+      "[ChildRepository] Successfully listed children",
+      parent_id: parent_id,
+      count: length(children)
+    )
 
-      Logger.info(
-        "[ChildRepository] Successfully listed children",
-        parent_id: parent_id,
-        count: length(children)
-      )
-
-      {:ok, children}
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ChildRepository] Database connection failed during list_by_parent",
-          error_id: ErrorIds.child_list_connection_error(),
-          parent_id: parent_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_connection_error}
-
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ChildRepository] Database query error during list_by_parent",
-          error_id: ErrorIds.child_list_query_error(),
-          parent_id: parent_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ChildRepository] Unexpected database error during list_by_parent",
-          error_id: ErrorIds.child_list_generic_error(),
-          parent_id: parent_id,
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
-    end
+    children
   end
 end

--- a/lib/prime_youth/family/domain/ports/for_storing_children.ex
+++ b/lib/prime_youth/family/domain/ports/for_storing_children.ex
@@ -5,70 +5,38 @@ defmodule PrimeYouth.Family.Domain.Ports.ForStoringChildren do
   Defines the contract for storing and retrieving children without exposing
   infrastructure details. Implementations will be provided by repository adapters.
 
-  ## Error Types
+  ## Expected Return Values
 
-  - `:database_connection_error` - Cannot connect to database
-  - `:database_query_error` - Query execution failed (constraint violations, invalid data)
-  - `:database_unavailable` - Database temporarily unavailable
-  - `:not_found` - Child ID doesn't exist (domain error, not infrastructure)
+  - `get_by_id/1` - Returns `{:ok, Child.t()}` or `{:error, :not_found}`
+  - `create/1` - Returns `{:ok, Child.t()}` or `{:error, changeset}`
+  - `list_by_parent/1` - Returns list of children directly
 
-  ## Callbacks
-
-  - `get_by_id/1` - Retrieve a child by their unique identifier
-  - `create/1` - Create a new child record
-  - `list_by_parent/1` - List all children for a given parent
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
-
-  alias PrimeYouth.Family.Domain.Models.Child
-
-  @type child_id :: String.t()
-  @type parent_id :: String.t()
-
-  @type database_error ::
-          :database_connection_error
-          | :database_query_error
-          | :database_unavailable
-
-  @type persistence_error :: database_error | :not_found
 
   @doc """
   Retrieves a child by their unique identifier.
 
-  Primary method for attendance lookups to resolve child names.
-
-  ## Returns
-
+  Returns:
   - `{:ok, Child.t()}` - Child found successfully
   - `{:error, :not_found}` - Child ID doesn't exist
-  - `{:error, database_error}` - Database operation failed
   """
-  @callback get_by_id(child_id) ::
-              {:ok, Child.t()} | {:error, persistence_error}
+  @callback get_by_id(binary()) :: {:ok, term()} | {:error, :not_found}
 
   @doc """
   Creates a new child record.
 
-  Accepts a map of validated attributes (from use case layer) and returns
-  the created child as a domain entity.
-
-  ## Returns
-
+  Returns:
   - `{:ok, Child.t()}` - Child created successfully
-  - `{:error, database_error}` - Database operation failed
+  - `{:error, changeset}` - Validation failed
   """
-  @callback create(map()) ::
-              {:ok, Child.t()} | {:error, database_error}
+  @callback create(map()) :: {:ok, term()} | {:error, term()}
 
   @doc """
   Lists all children for a given parent.
 
-  Used for family dashboard and parent-specific child management.
-
-  ## Returns
-
-  - `{:ok, [Child.t()]}` - List of children (may be empty)
-  - `{:error, database_error}` - Database operation failed
+  Returns list of children (may be empty).
   """
-  @callback list_by_parent(parent_id) ::
-              {:ok, [Child.t()]} | {:error, database_error}
+  @callback list_by_parent(binary()) :: [term()]
 end

--- a/lib/prime_youth/parenting/adapters/driven/persistence/repositories/parent_repository.ex
+++ b/lib/prime_youth/parenting/adapters/driven/persistence/repositories/parent_repository.ex
@@ -4,23 +4,14 @@ defmodule PrimeYouth.Parenting.Adapters.Driven.Persistence.Repositories.ParentRe
 
   Implements the ForStoringParents port with:
   - Domain entity mapping via ParentMapper
-  - Comprehensive logging for database operations
-  - Bidirectional conversion for create/read operations
+  - Idiomatic "let it crash" error handling
 
   Data integrity is enforced at the database level through:
   - NOT NULL constraint on identity_id
   - UNIQUE constraint on identity_id (prevents duplicate profiles)
 
-  ## Error Handling
-
-  Translates Ecto/database errors to domain error atoms:
-  - `Ecto.Changeset` (unique constraint on identity_id) → `:duplicate_identity`
-  - `DBConnection.ConnectionError` → `:database_connection_error`
-  - `Postgrex.Error` → `:database_query_error`
-  - `Ecto.Query.CastError` → `:database_query_error`
-  - Other errors → `:database_unavailable`
-
-  All errors logged with unique ErrorIds for production monitoring.
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
 
   @behaviour PrimeYouth.Parenting.Domain.Ports.ForStoringParents
@@ -29,7 +20,6 @@ defmodule PrimeYouth.Parenting.Adapters.Driven.Persistence.Repositories.ParentRe
 
   alias PrimeYouth.Parenting.Adapters.Driven.Persistence.Mappers.ParentMapper
   alias PrimeYouth.Parenting.Adapters.Driven.Persistence.Schemas.ParentSchema
-  alias PrimeYouth.Parenting.Domain.Models.Parent
   alias PrimeYouth.Repo
   alias PrimeYouth.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias PrimeYouthWeb.ErrorIds
@@ -40,101 +30,47 @@ defmodule PrimeYouth.Parenting.Adapters.Driven.Persistence.Repositories.ParentRe
   @doc """
   Creates a new parent profile in the database.
 
-  Accepts a map with parent attributes. The identity_id is required.
-  All other fields are optional. Auto-generates UUID for id field if not provided.
-
   Returns:
-  - {:ok, Parent.t()} on success
-  - {:error, :duplicate_identity} - Parent profile already exists for this identity_id
-  - {:error, :database_connection_error} - Connection/network failure
-  - {:error, :database_query_error} - SQL error or constraint violation
-  - {:error, :database_unavailable} - Unexpected error
-
-  ## Examples
-
-      iex> ParentRepository.create_parent_profile(%{identity_id: "550e8400-..."})
-      {:ok, %Parent{...}}
-
-      iex> ParentRepository.create_parent_profile(%{identity_id: "existing-id"})
-      {:error, :duplicate_identity}
+  - `{:ok, Parent.t()}` on success
+  - `{:error, :duplicate_identity}` - Parent profile already exists for this identity_id
+  - `{:error, changeset}` - Validation failure
   """
-  @spec create_parent_profile(map()) ::
-          {:ok, Parent.t()}
-          | {:error,
-             :duplicate_identity
-             | :database_connection_error
-             | :database_query_error
-             | :database_unavailable}
   def create_parent_profile(attrs) when is_map(attrs) do
     Logger.info("[ParentRepository] Creating parent profile",
       identity_id: attrs[:identity_id]
     )
 
-    try do
-      %ParentSchema{}
-      |> ParentSchema.changeset(attrs)
-      |> Repo.insert()
-      |> case do
-        {:ok, schema} ->
-          parent = ParentMapper.to_domain(schema)
+    %ParentSchema{}
+    |> ParentSchema.changeset(attrs)
+    |> Repo.insert()
+    |> case do
+      {:ok, schema} ->
+        parent = ParentMapper.to_domain(schema)
 
-          Logger.info(
-            "[ParentRepository] Successfully created parent profile (ID: #{parent.id}) for identity_id: #{parent.identity_id}"
+        Logger.info(
+          "[ParentRepository] Successfully created parent profile (ID: #{parent.id}) for identity_id: #{parent.identity_id}"
+        )
+
+        {:ok, parent}
+
+      {:error, %Ecto.Changeset{errors: errors} = changeset} ->
+        if EctoErrorHelpers.unique_constraint_violation?(errors, :identity_id) do
+          Logger.warning(
+            "[ParentRepository] Duplicate parent profile",
+            error_id: ErrorIds.parent_duplicate_identity(),
+            identity_id: attrs[:identity_id]
           )
 
-          {:ok, parent}
+          {:error, :duplicate_identity}
+        else
+          Logger.warning(
+            "[ParentRepository] Validation error creating parent profile",
+            identity_id: attrs[:identity_id],
+            errors: inspect(changeset.errors)
+          )
 
-        {:error, %Ecto.Changeset{errors: errors} = changeset} ->
-          if EctoErrorHelpers.unique_constraint_violation?(errors, :identity_id) do
-            Logger.warning(
-              "[ParentRepository] Duplicate parent profile for identity_id: #{attrs[:identity_id]}"
-            )
-
-            {:error, :duplicate_identity}
-          else
-            Logger.error(
-              "[ParentRepository] Validation error creating parent profile",
-              error_id: ErrorIds.parent_create_query_error(),
-              identity_id: attrs[:identity_id],
-              errors: inspect(changeset.errors)
-            )
-
-            {:error, :database_query_error}
-          end
-      end
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ParentRepository] Database connection failed during parent profile creation",
-          error_id: ErrorIds.parent_create_connection_error(),
-          identity_id: attrs[:identity_id],
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_connection_error}
-
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ParentRepository] Database query error during parent profile creation",
-          error_id: ErrorIds.parent_create_query_error(),
-          identity_id: attrs[:identity_id],
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ParentRepository] Unexpected database error during parent profile creation",
-          error_id: ErrorIds.parent_create_generic_error(),
-          identity_id: attrs[:identity_id],
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
+          {:error, changeset}
+        end
     end
   end
 
@@ -142,86 +78,27 @@ defmodule PrimeYouth.Parenting.Adapters.Driven.Persistence.Repositories.ParentRe
   @doc """
   Retrieves a parent profile by identity ID from the database.
 
-  Returns the parent profile associated with the given identity_id if found.
-
   Returns:
-  - {:ok, Parent.t()} when parent profile is found
-  - {:error, :not_found} when no parent profile exists with the given identity_id
-  - {:error, :database_connection_error} - Connection/network failure
-  - {:error, :database_query_error} - SQL error or constraint violation
-  - {:error, :database_unavailable} - Unexpected error
-
-  ## Examples
-
-      iex> ParentRepository.get_by_identity_id("550e8400-e29b-41d4-a716-446655440001")
-      {:ok, %Parent{identity_id: "550e8400-e29b-41d4-a716-446655440001", ...}}
-
-      iex> ParentRepository.get_by_identity_id("non-existent-id")
-      {:error, :not_found}
+  - `{:ok, Parent.t()}` when parent profile is found
+  - `{:error, :not_found}` when no parent profile exists with the given identity_id
   """
-  @spec get_by_identity_id(String.t()) ::
-          {:ok, Parent.t()}
-          | {:error,
-             :not_found
-             | :database_connection_error
-             | :database_query_error
-             | :database_unavailable}
   def get_by_identity_id(identity_id) when is_binary(identity_id) do
     Logger.info("[ParentRepository] Retrieving parent profile by identity_id: #{identity_id}")
 
-    query = from p in ParentSchema, where: p.identity_id == ^identity_id
+    case Repo.one(from p in ParentSchema, where: p.identity_id == ^identity_id) do
+      nil ->
+        Logger.info("[ParentRepository] Parent profile not found for identity_id: #{identity_id}")
 
-    try do
-      case Repo.one(query) do
-        nil ->
-          Logger.info(
-            "[ParentRepository] Parent profile not found for identity_id: #{identity_id}"
-          )
+        {:error, :not_found}
 
-          {:error, :not_found}
+      schema ->
+        parent = ParentMapper.to_domain(schema)
 
-        schema ->
-          parent = ParentMapper.to_domain(schema)
-
-          Logger.info(
-            "[ParentRepository] Successfully retrieved parent profile (ID: #{parent.id}) for identity_id: #{identity_id}"
-          )
-
-          {:ok, parent}
-      end
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ParentRepository] Database connection failed while fetching parent profile",
-          error_id: ErrorIds.parent_get_connection_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
+        Logger.info(
+          "[ParentRepository] Successfully retrieved parent profile (ID: #{parent.id}) for identity_id: #{identity_id}"
         )
 
-        {:error, :database_connection_error}
-
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ParentRepository] Database query error while fetching parent profile",
-          error_id: ErrorIds.parent_get_query_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ParentRepository] Unexpected database error while fetching parent profile",
-          error_id: ErrorIds.parent_get_generic_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
+        {:ok, parent}
     end
   end
 
@@ -229,78 +106,22 @@ defmodule PrimeYouth.Parenting.Adapters.Driven.Persistence.Repositories.ParentRe
   @doc """
   Checks if a parent profile exists for the given identity ID.
 
-  Returns boolean indicating whether a parent profile exists.
-
-  Returns:
-  - {:ok, true} when parent profile exists
-  - {:ok, false} when no parent profile exists
-  - {:error, :database_connection_error} - Connection/network failure
-  - {:error, :database_query_error} - SQL error
-  - {:error, :database_unavailable} - Unexpected error
-
-  ## Examples
-
-      iex> ParentRepository.has_profile?("550e8400-e29b-41d4-a716-446655440001")
-      {:ok, true}
-
-      iex> ParentRepository.has_profile?("non-existent-id")
-      {:ok, false}
+  Returns boolean directly.
   """
-  @spec has_profile?(String.t()) ::
-          {:ok, boolean()}
-          | {:error, :database_connection_error | :database_query_error | :database_unavailable}
   def has_profile?(identity_id) when is_binary(identity_id) do
     Logger.info(
       "[ParentRepository] Checking if parent profile exists for identity_id: #{identity_id}"
     )
 
-    query =
-      from p in ParentSchema,
-        where: p.identity_id == ^identity_id,
-        select: count(p.id)
+    exists =
+      ParentSchema
+      |> where([p], p.identity_id == ^identity_id)
+      |> Repo.exists?()
 
-    try do
-      count = Repo.one!(query)
-      exists = count > 0
+    Logger.info(
+      "[ParentRepository] Parent profile existence check for identity_id #{identity_id}: #{exists}"
+    )
 
-      Logger.info(
-        "[ParentRepository] Parent profile existence check for identity_id #{identity_id}: #{exists}"
-      )
-
-      {:ok, exists}
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ParentRepository] Database connection failed during profile existence check",
-          error_id: ErrorIds.parent_exists_connection_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_connection_error}
-
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ParentRepository] Database query error during profile existence check",
-          error_id: ErrorIds.parent_exists_query_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ParentRepository] Unexpected database error during profile existence check",
-          error_id: ErrorIds.parent_exists_generic_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
-    end
+    exists
   end
 end

--- a/lib/prime_youth/parenting/domain/ports/for_storing_parents.ex
+++ b/lib/prime_youth/parenting/domain/ports/for_storing_parents.ex
@@ -5,87 +5,43 @@ defmodule PrimeYouth.Parenting.Domain.Ports.ForStoringParents do
   This is a behaviour (interface) that defines the contract for parent persistence.
   It is implemented by adapters in the infrastructure layer (e.g., Ecto repositories).
 
-  This port follows the Ports & Adapters architecture pattern, keeping the domain
-  layer independent of infrastructure concerns.
+  ## Expected Return Values
+
+  - `create_parent_profile/1` - Returns `{:ok, Parent.t()}` or domain errors
+  - `get_by_identity_id/1` - Returns `{:ok, Parent.t()}` or `{:error, :not_found}`
+  - `has_profile?/1` - Returns boolean directly
+
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
-
-  alias PrimeYouth.Parenting.Domain.Models.Parent
-
-  @typedoc """
-  Specific error types for parent storage operations.
-
-  - `:database_connection_error` - Network/connection issues (potentially retryable)
-  - `:database_query_error` - SQL syntax, constraints, schema issues (non-retryable)
-  - `:database_unavailable` - Generic/unexpected errors (fallback)
-  - `:duplicate_identity` - Parent profile already exists for this identity_id
-  - `:invalid_identity` - Identity ID does not exist in Accounts context
-  - `{:validation_error, [String.t()]}` - Domain validation errors (list of error messages)
-  """
-  @type storage_error ::
-          :database_connection_error
-          | :database_query_error
-          | :database_unavailable
-          | :duplicate_identity
-          | :invalid_identity
-          | {:validation_error, [String.t()]}
 
   @doc """
   Creates a new parent profile in the repository.
 
   Accepts a map with parent attributes including identity_id (required).
-  Auto-generates UUID for id field if not provided.
 
   Returns:
   - `{:ok, Parent.t()}` - Parent profile created successfully
   - `{:error, :duplicate_identity}` - Parent profile already exists for this identity_id
-  - `{:error, :invalid_identity}` - Identity ID does not exist
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, parent} = create_parent_profile(%{identity_id: "550e8400-..."})
-      {:error, :duplicate_identity} = create_parent_profile(%{identity_id: "existing-id"})
+  - `{:error, changeset}` - Validation failure
   """
-  @callback create_parent_profile(map()) :: {:ok, Parent.t()} | {:error, storage_error()}
+  @callback create_parent_profile(attrs :: map()) ::
+              {:ok, term()} | {:error, :duplicate_identity | term()}
 
   @doc """
   Retrieves a parent profile by identity ID.
 
-  Returns the parent profile associated with the given identity_id if found.
-
   Returns:
   - `{:ok, Parent.t()}` - Parent found with matching identity_id
   - `{:error, :not_found}` - No parent profile exists for this identity_id
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, parent} = get_by_identity_id("550e8400-e29b-41d4-a716-446655440001")
-      {:error, :not_found} = get_by_identity_id("non-existent-id")
   """
-  @callback get_by_identity_id(String.t()) ::
-              {:ok, Parent.t()} | {:error, :not_found | storage_error()}
+  @callback get_by_identity_id(identity_id :: binary()) ::
+              {:ok, term()} | {:error, :not_found}
 
   @doc """
   Checks if a parent profile exists for the given identity ID.
 
-  Returns boolean indicating whether a parent profile exists.
-
-  Returns:
-  - `{:ok, true}` - Parent profile exists for this identity_id
-  - `{:ok, false}` - No parent profile exists for this identity_id
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, true} = has_profile?("550e8400-e29b-41d4-a716-446655440001")
-      {:ok, false} = has_profile?("non-existent-id")
+  Returns boolean directly (no error tuple for simple existence check).
   """
-  @callback has_profile?(String.t()) :: {:ok, boolean()} | {:error, storage_error()}
+  @callback has_profile?(identity_id :: binary()) :: boolean()
 end

--- a/lib/prime_youth/program_catalog/application/use_cases/list_all_programs.ex
+++ b/lib/prime_youth/program_catalog/application/use_cases/list_all_programs.ex
@@ -22,14 +22,10 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllPrograms do
 
   ## Usage
 
-      {:ok, programs} = ListAllPrograms.execute()
-      {:error, :database_connection_error} = ListAllPrograms.execute()
-      {:error, :database_query_error} = ListAllPrograms.execute()
-      {:error, :database_unavailable} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
   """
 
   alias PrimeYouth.ProgramCatalog.Domain.Models.Program
-  alias PrimeYouth.ProgramCatalog.Domain.Ports.ForListingPrograms
 
   @doc """
   Executes the use case to list all available programs.
@@ -39,28 +35,20 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllPrograms do
   order by title.
 
   Returns:
-  - `{:ok, [Program.t()]}` - List of valid programs (may be empty)
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
+  - `[Program.t()]` - List of valid programs (may be empty)
 
   ## Examples
 
       # Successful retrieval
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
       Enum.each(programs, fn program ->
         IO.puts(program.title)
       end)
 
       # Empty database
-      {:ok, []} = ListAllPrograms.execute()
-
-      # Database errors
-      {:error, :database_connection_error} = ListAllPrograms.execute()
-      {:error, :database_query_error} = ListAllPrograms.execute()
-      {:error, :database_unavailable} = ListAllPrograms.execute()
+      [] = ListAllPrograms.execute()
   """
-  @spec execute() :: {:ok, [Program.t()]} | {:error, ForListingPrograms.list_error()}
+  @spec execute() :: [Program.t()]
   def execute do
     repository_module().list_all_programs()
   end

--- a/lib/prime_youth/program_catalog/application/use_cases/list_featured_programs.ex
+++ b/lib/prime_youth/program_catalog/application/use_cases/list_featured_programs.ex
@@ -22,17 +22,14 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListFeaturedPrograms do
 
   ## Usage
 
-      {:ok, featured} = ListFeaturedPrograms.execute()
+      featured = ListFeaturedPrograms.execute()
       # Returns first 2 programs ordered by title
 
-      {:ok, []} = ListFeaturedPrograms.execute()
+      [] = ListFeaturedPrograms.execute()
       # Returns empty list if no programs exist
-
-      {:error, :database_connection_error} = ListFeaturedPrograms.execute()
   """
 
   alias PrimeYouth.ProgramCatalog.Domain.Models.Program
-  alias PrimeYouth.ProgramCatalog.Domain.Ports.ForListingPrograms
 
   @featured_count 2
 
@@ -44,35 +41,23 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListFeaturedPrograms do
   for the home page.
 
   Returns:
-  - `{:ok, [Program.t()]}` - List of featured programs (up to #{@featured_count}, may be empty)
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
+  - `[Program.t()]` - List of featured programs (up to #{@featured_count}, may be empty)
 
   ## Examples
 
       # Successful retrieval with multiple programs
-      {:ok, [program1, program2]} = ListFeaturedPrograms.execute()
+      [program1, program2] = ListFeaturedPrograms.execute()
 
       # Database has only 1 program
-      {:ok, [program1]} = ListFeaturedPrograms.execute()
+      [program1] = ListFeaturedPrograms.execute()
 
       # Empty database
-      {:ok, []} = ListFeaturedPrograms.execute()
-
-      # Database errors
-      {:error, :database_connection_error} = ListFeaturedPrograms.execute()
+      [] = ListFeaturedPrograms.execute()
   """
-  @spec execute() :: {:ok, [Program.t()]} | {:error, ForListingPrograms.list_error()}
+  @spec execute() :: [Program.t()]
   def execute do
-    case repository_module().list_all_programs() do
-      {:ok, programs} ->
-        featured = Enum.take(programs, @featured_count)
-        {:ok, featured}
-
-      error ->
-        error
-    end
+    repository_module().list_all_programs()
+    |> Enum.take(@featured_count)
   end
 
   # Private helper to get the configured repository module

--- a/lib/prime_youth/program_catalog/application/use_cases/list_programs_paginated.ex
+++ b/lib/prime_youth/program_catalog/application/use_cases/list_programs_paginated.ex
@@ -13,10 +13,11 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListProgramsPaginated d
       # Get next page using cursor from previous result
       {:ok, next_page} = ListProgramsPaginated.execute(20, page_result.next_cursor)
 
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
 
   alias PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramRepository
-  alias PrimeYouth.Shared.Domain.Types.Pagination.PageResult
 
   @doc """
   Lists programs with pagination.
@@ -30,13 +31,8 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListProgramsPaginated d
 
     * `{:ok, PageResult.t()}` - Page of programs with pagination metadata
     * `{:error, :invalid_cursor}` - Cursor is malformed or invalid
-    * `{:error, :database_connection_error}` - Database connection failed
-    * `{:error, :database_query_error}` - Query execution failed
-    * `{:error, :database_unavailable}` - Unexpected database error
 
   """
-  @spec execute(pos_integer(), String.t() | nil) ::
-          {:ok, PageResult.t()} | {:error, atom()}
   def execute(limit, cursor) do
     ProgramRepository.list_programs_paginated(limit, cursor)
   end

--- a/lib/prime_youth/program_catalog/domain/ports/for_listing_programs.ex
+++ b/lib/prime_youth/program_catalog/domain/ports/for_listing_programs.ex
@@ -7,24 +7,16 @@ defmodule PrimeYouth.ProgramCatalog.Domain.Ports.ForListingPrograms do
 
   This port follows the Ports & Adapters architecture pattern, keeping the domain
   layer independent of infrastructure concerns.
+
+  ## Expected Return Values
+
+  - `list_all_programs/0` - Returns list of Program structs
+  - `get_by_id/1` - Returns `{:ok, Program.t()}` or `{:error, :not_found}`
+  - `list_programs_paginated/2` - Returns `{:ok, PageResult.t()}` or `{:error, :invalid_cursor}`
+
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
-
-  alias PrimeYouth.ProgramCatalog.Domain.Models.Program
-  alias PrimeYouth.Shared.Domain.Types.Pagination.PageResult
-
-  @typedoc """
-  Specific error types for program listing operations.
-
-  - `:database_connection_error` - Network/connection issues (potentially retryable)
-  - `:database_query_error` - SQL syntax, constraints, schema issues (non-retryable)
-  - `:database_unavailable` - Generic/unexpected errors (fallback)
-  - `:invalid_cursor` - Cursor decoding/validation failure (non-retryable)
-  """
-  @type list_error ::
-          :database_connection_error
-          | :database_query_error
-          | :database_unavailable
-          | :invalid_cursor
 
   @doc """
   Lists all valid programs from the repository.
@@ -32,39 +24,18 @@ defmodule PrimeYouth.ProgramCatalog.Domain.Ports.ForListingPrograms do
   Only programs with all required fields populated are returned.
   Programs are returned in ascending order by title.
 
-  Returns:
-  - `{:ok, [Program.t()]}` - List of valid programs (may be empty)
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, programs} = list_all_programs()
-      {:error, :database_connection_error} = list_all_programs()
-      {:error, :database_query_error} = list_all_programs()
+  Returns a list of Program structs (may be empty).
   """
-  @callback list_all_programs() :: {:ok, [Program.t()]} | {:error, list_error()}
+  @callback list_all_programs() :: [term()]
 
   @doc """
   Retrieves a single program by its unique ID (UUID).
 
-  Returns the program with all required fields populated if found.
-
   Returns:
   - `{:ok, Program.t()}` - Program found with matching ID
   - `{:error, :not_found}` - No program exists with the given ID
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, program} = get_by_id("550e8400-e29b-41d4-a716-446655440001")
-      {:error, :not_found} = get_by_id("550e8400-e29b-41d4-a716-446655440099")
-      {:error, :database_connection_error} = get_by_id("invalid-uuid")
   """
-  @callback get_by_id(String.t()) :: {:ok, Program.t()} | {:error, :not_found | list_error()}
+  @callback get_by_id(id :: binary()) :: {:ok, term()} | {:error, :not_found}
 
   @doc """
   Lists programs with cursor-based pagination.
@@ -73,31 +44,16 @@ defmodule PrimeYouth.ProgramCatalog.Domain.Ports.ForListingPrograms do
   of large result sets. The cursor encodes the position in the result set
   and should be treated as an opaque string.
 
-  Programs are returned in descending order by creation time (newest first),
-  with deterministic ordering using (inserted_at DESC, id DESC).
+  Programs are returned in descending order by creation time (newest first).
 
   Parameters:
-  - `limit` - Number of items per page (1-100, silently constrained if out of range)
+  - `limit` - Number of items per page (1-100)
   - `cursor` - Base64-encoded cursor for pagination, nil for first page
 
   Returns:
   - `{:ok, PageResult.t()}` - Page of programs with pagination metadata
   - `{:error, :invalid_cursor}` - Cursor decoding/validation failure
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      # First page
-      {:ok, page} = list_programs_paginated(20, nil)
-      page.items          # List of programs
-      page.next_cursor    # Cursor for next page (nil if last page)
-      page.has_more       # Boolean indicating more pages available
-
-      # Subsequent page
-      {:ok, page2} = list_programs_paginated(20, page.next_cursor)
   """
-  @callback list_programs_paginated(limit :: pos_integer(), cursor :: String.t() | nil) ::
-              {:ok, PageResult.t()} | {:error, list_error()}
+  @callback list_programs_paginated(limit :: pos_integer(), cursor :: binary() | nil) ::
+              {:ok, term()} | {:error, :invalid_cursor}
 end

--- a/lib/prime_youth/program_catalog/domain/ports/for_updating_programs.ex
+++ b/lib/prime_youth/program_catalog/domain/ports/for_updating_programs.ex
@@ -6,29 +6,18 @@ defmodule PrimeYouth.ProgramCatalog.Domain.Ports.ForUpdatingPrograms do
   It is implemented by adapters in the infrastructure layer (e.g., Ecto repositories).
 
   This port follows the Ports & Adapters architecture pattern, keeping the domain
-  layer independent of infrastructure concerns. It is separate from ForListingPrograms
-  to maintain single responsibility principle (SRP).
+  layer independent of infrastructure concerns.
+
+  ## Expected Return Values
+
+  - `update/1` - Returns `{:ok, Program.t()}` or domain errors:
+    - `{:error, :stale_data}` - Optimistic lock conflict
+    - `{:error, :not_found}` - Program doesn't exist
+    - `{:error, changeset}` - Validation failure
+
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
-
-  alias PrimeYouth.ProgramCatalog.Domain.Models.Program
-
-  @typedoc """
-  Specific error types for program update operations.
-
-  - `:stale_data` - Optimistic lock conflict (record modified by another process)
-  - `:not_found` - Program ID does not exist
-  - `:constraint_violation` - Database constraint violation (invalid data)
-  - `:database_connection_error` - Network/connection issues (potentially retryable)
-  - `:database_query_error` - SQL syntax, constraints, schema issues (non-retryable)
-  - `:database_unavailable` - Generic/unexpected errors (fallback)
-  """
-  @type update_error ::
-          :stale_data
-          | :not_found
-          | :constraint_violation
-          | :database_connection_error
-          | :database_query_error
-          | :database_unavailable
 
   @doc """
   Updates an existing program with optimistic locking.
@@ -38,44 +27,13 @@ defmodule PrimeYouth.ProgramCatalog.Domain.Ports.ForUpdatingPrograms do
   (optimistic lock conflict).
 
   The lock_version field is automatically incremented on successful update.
-  Callers should refetch the program after a stale_data error to get the latest
-  version before retrying.
-
-  Parameters:
-  - `program` - Domain Program entity with updated fields
 
   Returns:
-  - `{:ok, Program.t()}` - Successfully updated program with incremented lock_version
-  - `{:error, :stale_data}` - Program was modified by another process (optimistic lock)
-  - `{:error, :not_found}` - Program ID does not exist in the database
-  - `{:error, :constraint_violation}` - Data validation failed at database level
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or schema mismatch
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      # Successful update
-      program = %Program{id: "uuid", title: "Updated Title", ...}
-      {:ok, updated_program} = update(program)
-      updated_program.title  # "Updated Title"
-
-      # Optimistic lock conflict
-      {:error, :stale_data} = update(stale_program)
-
-      # Program not found
-      {:error, :not_found} = update(%Program{id: "non-existent-uuid", ...})
-
-      # Constraint violation
-      {:error, :constraint_violation} = update(%Program{price: -100, ...})
-
-  ## Concurrency Handling
-
-  When multiple processes attempt to update the same program concurrently:
-
-  1. First process succeeds, lock_version increments
-  2. Subsequent processes fail with :stale_data
-  3. Failed processes should refetch and retry if appropriate
+  - `{:ok, Program.t()}` - Successfully updated program
+  - `{:error, :stale_data}` - Program was modified by another process
+  - `{:error, :not_found}` - Program ID does not exist
+  - `{:error, changeset}` - Validation failure
   """
-  @callback update(Program.t()) :: {:ok, Program.t()} | {:error, update_error()}
+  @callback update(program :: term()) ::
+              {:ok, term()} | {:error, :stale_data | :not_found | term()}
 end

--- a/lib/prime_youth/providing/adapters/driven/persistence/repositories/provider_repository.ex
+++ b/lib/prime_youth/providing/adapters/driven/persistence/repositories/provider_repository.ex
@@ -4,23 +4,14 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
 
   Implements the ForStoringProviders port with:
   - Domain entity mapping via ProviderMapper
-  - Comprehensive logging for database operations
-  - Bidirectional conversion for create/read operations
+  - Idiomatic "let it crash" error handling
 
   Data integrity is enforced at the database level through:
   - NOT NULL constraint on identity_id and business_name
   - UNIQUE constraint on identity_id (prevents duplicate profiles)
 
-  ## Error Handling
-
-  Translates Ecto/database errors to domain error atoms:
-  - `Ecto.Changeset` (unique constraint on identity_id) → `:duplicate_identity`
-  - `DBConnection.ConnectionError` → `:database_connection_error`
-  - `Postgrex.Error` → `:database_query_error`
-  - `Ecto.Query.CastError` → `:database_query_error`
-  - Other errors → `:database_unavailable`
-
-  All errors logged with unique ErrorIds for production monitoring.
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
 
   @behaviour PrimeYouth.Providing.Domain.Ports.ForStoringProviders
@@ -29,7 +20,6 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
 
   alias PrimeYouth.Providing.Adapters.Driven.Persistence.Mappers.ProviderMapper
   alias PrimeYouth.Providing.Adapters.Driven.Persistence.Schemas.ProviderSchema
-  alias PrimeYouth.Providing.Domain.Models.Provider
   alias PrimeYouth.Repo
   alias PrimeYouth.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias PrimeYouthWeb.ErrorIds
@@ -40,102 +30,48 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
   @doc """
   Creates a new provider profile in the database.
 
-  Accepts a map with provider attributes. The identity_id and business_name are required.
-  All other fields are optional. Auto-generates UUID for id field if not provided.
-
   Returns:
-  - {:ok, Provider.t()} on success
-  - {:error, :duplicate_identity} - Provider profile already exists for this identity_id
-  - {:error, :database_connection_error} - Connection/network failure
-  - {:error, :database_query_error} - SQL error or constraint violation
-  - {:error, :database_unavailable} - Unexpected error
-
-  ## Examples
-
-      iex> ProviderRepository.create_provider_profile(%{identity_id: "550e8400-...", business_name: "My Business"})
-      {:ok, %Provider{...}}
-
-      iex> ProviderRepository.create_provider_profile(%{identity_id: "existing-id", business_name: "Another"})
-      {:error, :duplicate_identity}
+  - `{:ok, Provider.t()}` on success
+  - `{:error, :duplicate_identity}` - Provider profile already exists for this identity_id
+  - `{:error, changeset}` - Validation failure
   """
-  @spec create_provider_profile(map()) ::
-          {:ok, Provider.t()}
-          | {:error,
-             :duplicate_identity
-             | :database_connection_error
-             | :database_query_error
-             | :database_unavailable}
   def create_provider_profile(attrs) when is_map(attrs) do
     Logger.info("[ProviderRepository] Creating provider profile",
       identity_id: attrs[:identity_id],
       business_name: attrs[:business_name]
     )
 
-    try do
-      %ProviderSchema{}
-      |> ProviderSchema.changeset(attrs)
-      |> Repo.insert()
-      |> case do
-        {:ok, schema} ->
-          provider = ProviderMapper.to_domain(schema)
+    %ProviderSchema{}
+    |> ProviderSchema.changeset(attrs)
+    |> Repo.insert()
+    |> case do
+      {:ok, schema} ->
+        provider = ProviderMapper.to_domain(schema)
 
-          Logger.info(
-            "[ProviderRepository] Successfully created provider profile (ID: #{provider.id}) for identity_id: #{provider.identity_id}"
+        Logger.info(
+          "[ProviderRepository] Successfully created provider profile (ID: #{provider.id}) for identity_id: #{provider.identity_id}"
+        )
+
+        {:ok, provider}
+
+      {:error, %Ecto.Changeset{errors: errors} = changeset} ->
+        if EctoErrorHelpers.unique_constraint_violation?(errors, :identity_id) do
+          Logger.warning(
+            "[ProviderRepository] Duplicate provider profile",
+            error_id: ErrorIds.provider_duplicate_identity(),
+            identity_id: attrs[:identity_id]
           )
 
-          {:ok, provider}
+          {:error, :duplicate_identity}
+        else
+          Logger.warning(
+            "[ProviderRepository] Validation error creating provider profile",
+            identity_id: attrs[:identity_id],
+            errors: inspect(changeset.errors)
+          )
 
-        {:error, %Ecto.Changeset{errors: errors} = changeset} ->
-          if EctoErrorHelpers.unique_constraint_violation?(errors, :identity_id) do
-            Logger.warning(
-              "[ProviderRepository] Duplicate provider profile for identity_id: #{attrs[:identity_id]}"
-            )
-
-            {:error, :duplicate_identity}
-          else
-            Logger.error(
-              "[ProviderRepository] Validation error creating provider profile",
-              error_id: ErrorIds.provider_create_query_error(),
-              identity_id: attrs[:identity_id],
-              errors: inspect(changeset.errors)
-            )
-
-            {:error, :database_query_error}
-          end
-      end
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ProviderRepository] Database connection failed during provider profile creation",
-          error_id: ErrorIds.provider_create_connection_error(),
-          identity_id: attrs[:identity_id],
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_connection_error}
-
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ProviderRepository] Database query error during provider profile creation",
-          error_id: ErrorIds.provider_create_query_error(),
-          identity_id: attrs[:identity_id],
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ProviderRepository] Unexpected database error during provider profile creation",
-          error_id: ErrorIds.provider_create_generic_error(),
-          identity_id: attrs[:identity_id],
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
+          {:error, changeset}
+        end
     end
   end
 
@@ -143,86 +79,29 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
   @doc """
   Retrieves a provider profile by identity ID from the database.
 
-  Returns the provider profile associated with the given identity_id if found.
-
   Returns:
-  - {:ok, Provider.t()} when provider profile is found
-  - {:error, :not_found} when no provider profile exists with the given identity_id
-  - {:error, :database_connection_error} - Connection/network failure
-  - {:error, :database_query_error} - SQL error or constraint violation
-  - {:error, :database_unavailable} - Unexpected error
-
-  ## Examples
-
-      iex> ProviderRepository.get_by_identity_id("550e8400-e29b-41d4-a716-446655440001")
-      {:ok, %Provider{identity_id: "550e8400-e29b-41d4-a716-446655440001", ...}}
-
-      iex> ProviderRepository.get_by_identity_id("non-existent-id")
-      {:error, :not_found}
+  - `{:ok, Provider.t()}` when provider profile is found
+  - `{:error, :not_found}` when no provider profile exists with the given identity_id
   """
-  @spec get_by_identity_id(String.t()) ::
-          {:ok, Provider.t()}
-          | {:error,
-             :not_found
-             | :database_connection_error
-             | :database_query_error
-             | :database_unavailable}
   def get_by_identity_id(identity_id) when is_binary(identity_id) do
     Logger.info("[ProviderRepository] Retrieving provider profile by identity_id: #{identity_id}")
 
-    query = from p in ProviderSchema, where: p.identity_id == ^identity_id
-
-    try do
-      case Repo.one(query) do
-        nil ->
-          Logger.info(
-            "[ProviderRepository] Provider profile not found for identity_id: #{identity_id}"
-          )
-
-          {:error, :not_found}
-
-        schema ->
-          provider = ProviderMapper.to_domain(schema)
-
-          Logger.info(
-            "[ProviderRepository] Successfully retrieved provider profile (ID: #{provider.id}) for identity_id: #{identity_id}"
-          )
-
-          {:ok, provider}
-      end
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ProviderRepository] Database connection failed while fetching provider profile",
-          error_id: ErrorIds.provider_get_connection_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
+    case Repo.one(from p in ProviderSchema, where: p.identity_id == ^identity_id) do
+      nil ->
+        Logger.info(
+          "[ProviderRepository] Provider profile not found for identity_id: #{identity_id}"
         )
 
-        {:error, :database_connection_error}
+        {:error, :not_found}
 
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ProviderRepository] Database query error while fetching provider profile",
-          error_id: ErrorIds.provider_get_query_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
+      schema ->
+        provider = ProviderMapper.to_domain(schema)
+
+        Logger.info(
+          "[ProviderRepository] Successfully retrieved provider profile (ID: #{provider.id}) for identity_id: #{identity_id}"
         )
 
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ProviderRepository] Unexpected database error while fetching provider profile",
-          error_id: ErrorIds.provider_get_generic_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
+        {:ok, provider}
     end
   end
 
@@ -230,78 +109,22 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
   @doc """
   Checks if a provider profile exists for the given identity ID.
 
-  Returns boolean indicating whether a provider profile exists.
-
-  Returns:
-  - {:ok, true} when provider profile exists
-  - {:ok, false} when no provider profile exists
-  - {:error, :database_connection_error} - Connection/network failure
-  - {:error, :database_query_error} - SQL error
-  - {:error, :database_unavailable} - Unexpected error
-
-  ## Examples
-
-      iex> ProviderRepository.has_profile?("550e8400-e29b-41d4-a716-446655440001")
-      {:ok, true}
-
-      iex> ProviderRepository.has_profile?("non-existent-id")
-      {:ok, false}
+  Returns boolean directly.
   """
-  @spec has_profile?(String.t()) ::
-          {:ok, boolean()}
-          | {:error, :database_connection_error | :database_query_error | :database_unavailable}
   def has_profile?(identity_id) when is_binary(identity_id) do
     Logger.info(
       "[ProviderRepository] Checking if provider profile exists for identity_id: #{identity_id}"
     )
 
-    query =
-      from p in ProviderSchema,
-        where: p.identity_id == ^identity_id,
-        select: count(p.id)
+    exists =
+      ProviderSchema
+      |> where([p], p.identity_id == ^identity_id)
+      |> Repo.exists?()
 
-    try do
-      count = Repo.one!(query)
-      exists = count > 0
+    Logger.info(
+      "[ProviderRepository] Provider profile existence check for identity_id #{identity_id}: #{exists}"
+    )
 
-      Logger.info(
-        "[ProviderRepository] Provider profile existence check for identity_id #{identity_id}: #{exists}"
-      )
-
-      {:ok, exists}
-    rescue
-      error in [DBConnection.ConnectionError] ->
-        Logger.error(
-          "[ProviderRepository] Database connection failed during profile existence check",
-          error_id: ErrorIds.provider_exists_connection_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_connection_error}
-
-      error in [Postgrex.Error, Ecto.Query.CastError] ->
-        Logger.error(
-          "[ProviderRepository] Database query error during profile existence check",
-          error_id: ErrorIds.provider_exists_query_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          error_message: Exception.message(error)
-        )
-
-        {:error, :database_query_error}
-
-      error ->
-        Logger.error(
-          "[ProviderRepository] Unexpected database error during profile existence check",
-          error_id: ErrorIds.provider_exists_generic_error(),
-          identity_id: identity_id,
-          error_type: error.__struct__,
-          stacktrace: Exception.format(:error, error, __STACKTRACE__)
-        )
-
-        {:error, :database_unavailable}
-    end
+    exists
   end
 end

--- a/lib/prime_youth/providing/domain/ports/for_storing_providers.ex
+++ b/lib/prime_youth/providing/domain/ports/for_storing_providers.ex
@@ -5,87 +5,43 @@ defmodule PrimeYouth.Providing.Domain.Ports.ForStoringProviders do
   This is a behaviour (interface) that defines the contract for provider persistence.
   It is implemented by adapters in the infrastructure layer (e.g., Ecto repositories).
 
-  This port follows the Ports & Adapters architecture pattern, keeping the domain
-  layer independent of infrastructure concerns.
+  ## Expected Return Values
+
+  - `create_provider_profile/1` - Returns `{:ok, Provider.t()}` or domain errors
+  - `get_by_identity_id/1` - Returns `{:ok, Provider.t()}` or `{:error, :not_found}`
+  - `has_profile?/1` - Returns boolean directly
+
+  Infrastructure errors (connection, query) are not caught - they crash and
+  are handled by the supervision tree.
   """
-
-  alias PrimeYouth.Providing.Domain.Models.Provider
-
-  @typedoc """
-  Specific error types for provider storage operations.
-
-  - `:database_connection_error` - Network/connection issues (potentially retryable)
-  - `:database_query_error` - SQL syntax, constraints, schema issues (non-retryable)
-  - `:database_unavailable` - Generic/unexpected errors (fallback)
-  - `:duplicate_identity` - Provider profile already exists for this identity_id
-  - `:invalid_identity` - Identity ID does not exist in Accounts context
-  - `{:validation_error, [String.t()]}` - Domain validation errors (list of error messages)
-  """
-  @type storage_error ::
-          :database_connection_error
-          | :database_query_error
-          | :database_unavailable
-          | :duplicate_identity
-          | :invalid_identity
-          | {:validation_error, [String.t()]}
 
   @doc """
   Creates a new provider profile in the repository.
 
   Accepts a map with provider attributes including identity_id and business_name (required).
-  Auto-generates UUID for id field if not provided.
 
   Returns:
   - `{:ok, Provider.t()}` - Provider profile created successfully
   - `{:error, :duplicate_identity}` - Provider profile already exists for this identity_id
-  - `{:error, :invalid_identity}` - Identity ID does not exist
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, provider} = create_provider_profile(%{identity_id: "550e8400-...", business_name: "My Business"})
-      {:error, :duplicate_identity} = create_provider_profile(%{identity_id: "existing-id", business_name: "Another"})
+  - `{:error, changeset}` - Validation failure
   """
-  @callback create_provider_profile(map()) :: {:ok, Provider.t()} | {:error, storage_error()}
+  @callback create_provider_profile(attrs :: map()) ::
+              {:ok, term()} | {:error, :duplicate_identity | term()}
 
   @doc """
   Retrieves a provider profile by identity ID.
 
-  Returns the provider profile associated with the given identity_id if found.
-
   Returns:
   - `{:ok, Provider.t()}` - Provider found with matching identity_id
   - `{:error, :not_found}` - No provider profile exists for this identity_id
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error or constraint violation
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, provider} = get_by_identity_id("550e8400-e29b-41d4-a716-446655440001")
-      {:error, :not_found} = get_by_identity_id("non-existent-id")
   """
-  @callback get_by_identity_id(String.t()) ::
-              {:ok, Provider.t()} | {:error, :not_found | storage_error()}
+  @callback get_by_identity_id(identity_id :: binary()) ::
+              {:ok, term()} | {:error, :not_found}
 
   @doc """
   Checks if a provider profile exists for the given identity ID.
 
-  Returns boolean indicating whether a provider profile exists.
-
-  Returns:
-  - `{:ok, true}` - Provider profile exists for this identity_id
-  - `{:ok, false}` - No provider profile exists for this identity_id
-  - `{:error, :database_connection_error}` - Connection/network failure
-  - `{:error, :database_query_error}` - SQL error
-  - `{:error, :database_unavailable}` - Unexpected error
-
-  ## Examples
-
-      {:ok, true} = has_profile?("550e8400-e29b-41d4-a716-446655440001")
-      {:ok, false} = has_profile?("non-existent-id")
+  Returns boolean directly (no error tuple for simple existence check).
   """
-  @callback has_profile?(String.t()) :: {:ok, boolean()} | {:error, storage_error()}
+  @callback has_profile?(identity_id :: binary()) :: boolean()
 end

--- a/lib/prime_youth/support/adapters/driven/persistence/repositories/contact_request_repository.ex
+++ b/lib/prime_youth/support/adapters/driven/persistence/repositories/contact_request_repository.ex
@@ -6,59 +6,8 @@ defmodule PrimeYouth.Support.Adapters.Driven.Persistence.Repositories.ContactReq
   to a database. The repository fulfills the ForContactRequests port contract
   by accepting contact requests and logging them to the application logger.
 
-  ## Use Cases
-
-  - Early development and prototyping
-  - Testing without database dependencies
-  - Verifying business logic flow
-  - Debugging contact form submissions
-
-  ## Architecture
-
-  The repository follows the Adapter pattern in Ports & Adapters architecture:
-  - Implements the ForContactRequests behavior
-  - Uses Elixir Logger for structured logging
-  - Provides proper error handling with rescue clauses
-  - Returns contact request on success for verification
-
-  ## Logging Format
-
-  Contact submissions are logged with INFO level in a structured format:
-
-      Contact Form Submission:
-      ID: contact_abc123
-      Name: John Doe
-      Email: john@example.com
-      Subject: general
-      Message: I have a question...
-      Submitted At: 2024-03-15T10:30:00Z
-
-  ## Error Handling
-
-  Errors during logging are caught and logged at ERROR level, returning
-  `{:error, :repository_error}` to maintain the port contract.
-
-  ## Future Enhancements
-
-  This repository can be replaced or supplemented with:
-  - Database repository using Ecto
-  - Email notification repository
-  - Multi-channel repository (logs + database + email)
-  - Message queue integration for async processing
-
-  ## Example
-
-      contact = %ContactRequest{
-        id: "contact_123",
-        name: "John Doe",
-        email: "john@example.com",
-        subject: "general",
-        message: "Question about programs",
-        submitted_at: DateTime.utc_now()
-      }
-
-      {:ok, ^contact} = ContactRequestRepository.submit(contact)
-      # => Contact logged to application logger
+  Infrastructure errors are not caught - they crash and are handled by
+  the supervision tree.
   """
 
   @behaviour PrimeYouth.Support.Domain.Ports.ForContactRequests
@@ -68,31 +17,6 @@ defmodule PrimeYouth.Support.Adapters.Driven.Persistence.Repositories.ContactReq
   require Logger
 
   @impl true
-  @doc """
-  Submits a contact request by logging it to the application logger.
-
-  The function logs the contact request details in a structured format
-  at INFO level. This allows tracking of all contact form submissions
-  through the application logs.
-
-  ## Parameters
-
-  - `contact_request` - The contact request domain entity to submit
-
-  ## Returns
-
-  - `{:ok, ContactRequest.t()}` - Successfully logged contact request
-  - `{:error, :repository_error}` - Logging failed (rare, typically system issues)
-
-  ## Examples
-
-      # Successful submission
-      contact = %ContactRequest{id: "contact_123", ...}
-      {:ok, ^contact} = submit(contact)
-
-      # Error handling
-      {:error, :repository_error} = submit(malformed_contact)
-  """
   def submit(%ContactRequest{} = contact_request) do
     Logger.info("""
     Contact Form Submission:
@@ -105,9 +29,5 @@ defmodule PrimeYouth.Support.Adapters.Driven.Persistence.Repositories.ContactReq
     """)
 
     {:ok, contact_request}
-  rescue
-    error ->
-      Logger.error("Failed to log contact request: #{inspect(error)}")
-      {:error, :repository_error}
   end
 end

--- a/lib/prime_youth/support/domain/ports/for_contact_requests.ex
+++ b/lib/prime_youth/support/domain/ports/for_contact_requests.ex
@@ -11,10 +11,12 @@ defmodule PrimeYouth.Support.Domain.Ports.ForContactRequests do
 
   - `submit/1` - Submit a contact request to the repository
 
-  ## Error Handling
+  ## Expected Return Values
 
-  All operations return `{:ok, result}` tuples on success or `{:error, reason}`
-  tuples on failure. Error reasons are defined as types for compile-time checking.
+  - `submit/1` - Returns `{:ok, ContactRequest.t()}` on success
+
+  Infrastructure errors are not caught - they crash and are handled by
+  the supervision tree.
 
   ## Architecture
 
@@ -23,27 +25,7 @@ defmodule PrimeYouth.Support.Domain.Ports.ForContactRequests do
   - Database repository (future enhancement)
   - Email-sending repository (future enhancement)
   - Multi-channel repository (logs + database + email)
-
-  ## Example Implementation
-
-      defmodule MyApp.Support.Adapters.LoggingRepository do
-        @behaviour PrimeYouth.Support.Domain.Ports.ForContactRequests
-
-        def submit(contact_request) do
-          Logger.info("Contact: \#{contact_request.email}")
-          {:ok, contact_request}
-        end
-      end
-
-  ## Example Usage
-
-      repository = Application.get_env(:prime_youth, :support)[:repository]
-      {:ok, submitted} = repository.submit(contact_request)
   """
-
-  alias PrimeYouth.Support.Domain.Models.ContactRequest
-
-  @type submit_error :: :repository_unavailable | :repository_error
 
   @doc """
   Submits a contact request to the repository.
@@ -52,25 +34,8 @@ defmodule PrimeYouth.Support.Domain.Ports.ForContactRequests do
   request - it may be logged, stored in a database, sent via email, or
   any combination of these actions.
 
-  Parameters:
-  - `contact_request` - The contact request domain entity to submit
-
   Returns:
   - `{:ok, ContactRequest.t()}` - Successfully submitted
-  - `{:error, :repository_unavailable}` - Repository not accessible
-  - `{:error, :repository_error}` - General repository error
-
-  ## Examples
-
-      # Successful submission
-      contact = %ContactRequest{id: "contact_123", ...}
-      {:ok, ^contact} = repository.submit(contact)
-
-      # Repository unavailable
-      {:error, :repository_unavailable} = repository.submit(contact)
-
-      # General repository error
-      {:error, :repository_error} = repository.submit(contact)
   """
-  @callback submit(ContactRequest.t()) :: {:ok, ContactRequest.t()} | {:error, submit_error()}
+  @callback submit(term()) :: {:ok, term()}
 end

--- a/lib/prime_youth_web/error_ids.ex
+++ b/lib/prime_youth_web/error_ids.ex
@@ -7,14 +7,7 @@ defmodule PrimeYouthWeb.ErrorIds do
   ## Error ID Ranges by Bounded Context
 
   - `program.*` - Program Catalog context errors
-  - `parenting.*` - Parenting context errors
-  - `providing.*` - Providing context errors
   - `attendance.*` - Attendance context errors (sessions and records)
-  - `auth.*` - Authentication context errors (future)
-  - `enrollment.*` - Enrollment context errors (future)
-  - `family.*` - Family Management context errors (future)
-  - `progress.*` - Progress Tracking context errors (future)
-  - `review.*` - Review & Rating context errors (future)
 
   ## Usage
 
@@ -23,519 +16,75 @@ defmodule PrimeYouthWeb.ErrorIds do
 
   ### Logging Example
 
-      Logger.error("Database connection failed",
-        error_id: ErrorIds.program_list_connection_error(),
-        user_id: user.id,
-        context: "mount"
+      Logger.warning("Program update conflict",
+        error_id: ErrorIds.program_update_stale_entry_error(),
+        program_id: program.id
       )
 
-  ### User Message Example (NO error ID)
+  ## Philosophy
 
-      put_flash(socket, :error, "Connection lost. Please try again.")
-
+  Only domain-level errors that represent expected business scenarios are tracked.
+  Infrastructure errors (connection failures, query errors) should crash and be
+  handled by the supervision tree - they don't need explicit error IDs.
   """
 
-  # Program Catalog Context Errors
+  # Program Catalog Context - Domain Errors
 
-  @doc """
-  Database connection error when listing programs.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def program_list_connection_error, do: "program.catalog.list.connection_error"
-
-  @doc """
-  Database query error when listing programs.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def program_list_query_error, do: "program.catalog.list.query_error"
-
-  @doc """
-  Generic/unexpected error when listing programs.
-  Fallback for errors that don't fit other categories.
-  """
-  def program_list_generic_error, do: "program.catalog.list.generic_error"
-
-  @doc """
-  Program not found when attempting to retrieve by ID.
-  """
+  @doc "Program not found when attempting to retrieve by ID."
   def program_not_found, do: "program.catalog.detail.not_found"
 
-  @doc """
-  Error converting program price from Decimal to float for UI display.
-  """
-  def program_price_conversion_error, do: "program.catalog.display.price_conversion_error"
-
-  @doc """
-  Error parsing age range format when filtering programs.
-  """
-  def program_age_filter_error, do: "program.catalog.filter.age_parse_error"
-
-  @doc """
-  Database connection error when retrieving a program by ID.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def program_get_connection_error, do: "program.catalog.get.connection_error"
-
-  @doc """
-  Database query error when retrieving a program by ID.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def program_get_query_error, do: "program.catalog.get.query_error"
-
-  @doc """
-  Generic/unexpected error when retrieving a program by ID.
-  Fallback for errors that don't fit other categories.
-  """
-  def program_get_generic_error, do: "program.catalog.get.generic_error"
-
-  @doc """
-  Invalid cursor format when paginating programs.
-  Indicates cursor decoding/validation failure.
-  """
+  @doc "Invalid cursor format when paginating programs."
   def program_pagination_invalid_cursor, do: "program.catalog.paginate.invalid_cursor"
 
-  @doc """
-  Database connection error when paginating programs.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def program_pagination_connection_error, do: "program.catalog.paginate.connection_error"
-
-  @doc """
-  Database query error when paginating programs.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def program_pagination_query_error, do: "program.catalog.paginate.query_error"
-
-  @doc """
-  Generic/unexpected error when paginating programs.
-  Fallback for errors that don't fit other categories.
-  """
-  def program_pagination_generic_error, do: "program.catalog.paginate.generic_error"
-
-  @doc """
-  Generic error during pagination operation.
-  Used when specific error type cannot be determined.
-  """
-  def program_pagination_error, do: "program.catalog.paginate.error"
-
-  @doc """
-  Program update failed due to concurrent modification (optimistic lock conflict).
-  Indicates the record was modified by another process since it was loaded.
-  """
+  @doc "Program update failed due to concurrent modification (optimistic lock conflict)."
   def program_update_stale_entry_error, do: "program.catalog.update.stale_entry_error"
 
-  @doc """
-  Program update failed due to constraint violation.
-  Indicates data validation failure at the database level.
-  """
+  @doc "Program update failed due to constraint violation."
   def program_update_constraint_violation, do: "program.catalog.update.constraint_violation"
 
-  @doc """
-  Database connection error when updating a program.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def program_update_connection_error, do: "program.catalog.update.connection_error"
-
-  @doc """
-  Database query error when updating a program.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def program_update_query_error, do: "program.catalog.update.query_error"
-
-  @doc """
-  Generic/unexpected error when updating a program.
-  Fallback for errors that don't fit other categories.
-  """
-  def program_update_generic_error, do: "program.catalog.update.generic_error"
-
-  @doc """
-  Program not found when attempting to update.
-  The program ID does not exist in the database.
-  """
+  @doc "Program update failed - program not found."
   def program_update_not_found, do: "program.catalog.update.not_found"
 
-  # Parenting Context Errors
+  # Attendance Context - Session Domain Errors
 
-  @doc """
-  Database connection error when creating a parent profile.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def parent_create_connection_error, do: "parenting.profile.create.connection_error"
-
-  @doc """
-  Database query error when creating a parent profile.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def parent_create_query_error, do: "parenting.profile.create.query_error"
-
-  @doc """
-  Generic/unexpected error when creating a parent profile.
-  Fallback for errors that don't fit other categories.
-  """
-  def parent_create_generic_error, do: "parenting.profile.create.generic_error"
-
-  @doc """
-  Database connection error when retrieving a parent profile by identity ID.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def parent_get_connection_error, do: "parenting.profile.get.connection_error"
-
-  @doc """
-  Database query error when retrieving a parent profile by identity ID.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def parent_get_query_error, do: "parenting.profile.get.query_error"
-
-  @doc """
-  Generic/unexpected error when retrieving a parent profile by identity ID.
-  Fallback for errors that don't fit other categories.
-  """
-  def parent_get_generic_error, do: "parenting.profile.get.generic_error"
-
-  @doc """
-  Database connection error when checking if parent profile exists.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def parent_exists_connection_error, do: "parenting.profile.exists.connection_error"
-
-  @doc """
-  Database query error when checking if parent profile exists.
-  Indicates SQL syntax error or schema mismatch.
-  """
-  def parent_exists_query_error, do: "parenting.profile.exists.query_error"
-
-  @doc """
-  Generic/unexpected error when checking if parent profile exists.
-  Fallback for errors that don't fit other categories.
-  """
-  def parent_exists_generic_error, do: "parenting.profile.exists.generic_error"
-
-  # Providing Context Errors
-
-  @doc """
-  Database connection error when creating a provider profile.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def provider_create_connection_error, do: "providing.profile.create.connection_error"
-
-  @doc """
-  Database query error when creating a provider profile.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def provider_create_query_error, do: "providing.profile.create.query_error"
-
-  @doc """
-  Generic/unexpected error when creating a provider profile.
-  Fallback for errors that don't fit other categories.
-  """
-  def provider_create_generic_error, do: "providing.profile.create.generic_error"
-
-  @doc """
-  Database connection error when retrieving a provider profile by identity ID.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def provider_get_connection_error, do: "providing.profile.get.connection_error"
-
-  @doc """
-  Database query error when retrieving a provider profile by identity ID.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def provider_get_query_error, do: "providing.profile.get.query_error"
-
-  @doc """
-  Generic/unexpected error when retrieving a provider profile by identity ID.
-  Fallback for errors that don't fit other categories.
-  """
-  def provider_get_generic_error, do: "providing.profile.get.generic_error"
-
-  @doc """
-  Database connection error when checking if provider profile exists.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def provider_exists_connection_error, do: "providing.profile.exists.connection_error"
-
-  @doc """
-  Database query error when checking if provider profile exists.
-  Indicates SQL syntax error or schema mismatch.
-  """
-  def provider_exists_query_error, do: "providing.profile.exists.query_error"
-
-  @doc """
-  Generic/unexpected error when checking if provider profile exists.
-  Fallback for errors that don't fit other categories.
-  """
-  def provider_exists_generic_error, do: "providing.profile.exists.generic_error"
-
-  # Attendance Context Errors - Session
-
-  @doc """
-  Database connection error when creating a session.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def session_create_connection_error, do: "attendance.session.create.connection_error"
-
-  @doc """
-  Database query error when creating a session.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def session_create_query_error, do: "attendance.session.create.query_error"
-
-  @doc """
-  Generic/unexpected error when creating a session.
-  Fallback for errors that don't fit other categories.
-  """
-  def session_create_generic_error, do: "attendance.session.create.generic_error"
-
-  @doc """
-  Database connection error when retrieving a session by ID.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def session_get_connection_error, do: "attendance.session.get.connection_error"
-
-  @doc """
-  Database query error when retrieving a session by ID.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def session_get_query_error, do: "attendance.session.get.query_error"
-
-  @doc """
-  Generic/unexpected error when retrieving a session by ID.
-  Fallback for errors that don't fit other categories.
-  """
-  def session_get_generic_error, do: "attendance.session.get.generic_error"
-
-  @doc """
-  Database connection error when listing sessions.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def session_list_connection_error, do: "attendance.session.list.connection_error"
-
-  @doc """
-  Database query error when listing sessions.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def session_list_query_error, do: "attendance.session.list.query_error"
-
-  @doc """
-  Generic/unexpected error when listing sessions.
-  Fallback for errors that don't fit other categories.
-  """
-  def session_list_generic_error, do: "attendance.session.list.generic_error"
-
-  @doc """
-  Session update failed due to constraint violation.
-  Indicates data validation failure at the database level.
-  """
-  def session_update_constraint_violation, do: "attendance.session.update.constraint_violation"
-
-  @doc """
-  Database connection error when updating a session.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def session_update_connection_error, do: "attendance.session.update.connection_error"
-
-  @doc """
-  Database query error when updating a session.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def session_update_query_error, do: "attendance.session.update.query_error"
-
-  @doc """
-  Generic/unexpected error when updating a session.
-  Fallback for errors that don't fit other categories.
-  """
-  def session_update_generic_error, do: "attendance.session.update.generic_error"
-
-  @doc """
-  Optimistic lock conflict when updating a session.
-  Record was modified by another process since it was loaded.
-  """
+  @doc "Session update failed due to concurrent modification (optimistic lock conflict)."
   def session_update_stale_error, do: "attendance.session.update.stale"
 
-  @doc """
-  Duplicate session error - session already exists for the same program/date/time.
-  """
+  @doc "Session update failed due to constraint violation."
+  def session_update_constraint_violation, do: "attendance.session.update.constraint_violation"
+
+  @doc "Duplicate session error - session already exists for the same program/date/time."
   def session_duplicate_error, do: "attendance.session.create.duplicate"
 
-  @doc """
-  Session validation error - changeset validation failed.
-  """
+  @doc "Session validation error - changeset validation failed."
   def session_validation_error, do: "attendance.session.validation.error"
 
-  # Attendance Context Errors - Attendance Record
+  # Attendance Context - Attendance Record Domain Errors
 
-  @doc """
-  Database connection error when creating an attendance record.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def attendance_create_connection_error, do: "attendance.record.create.connection_error"
-
-  @doc """
-  Database query error when creating an attendance record.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def attendance_create_query_error, do: "attendance.record.create.query_error"
-
-  @doc """
-  Generic/unexpected error when creating an attendance record.
-  Fallback for errors that don't fit other categories.
-  """
-  def attendance_create_generic_error, do: "attendance.record.create.generic_error"
-
-  @doc """
-  Database connection error when retrieving an attendance record.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def attendance_get_connection_error, do: "attendance.record.get.connection_error"
-
-  @doc """
-  Database query error when retrieving an attendance record.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def attendance_get_query_error, do: "attendance.record.get.query_error"
-
-  @doc """
-  Generic/unexpected error when retrieving an attendance record.
-  Fallback for errors that don't fit other categories.
-  """
-  def attendance_get_generic_error, do: "attendance.record.get.generic_error"
-
-  @doc """
-  Attendance update failed due to concurrent modification (optimistic lock conflict).
-  Indicates the record was modified by another process since it was loaded.
-  """
+  @doc "Attendance update failed due to concurrent modification (optimistic lock conflict)."
   def attendance_update_stale_error, do: "attendance.record.update.stale_entry"
 
-  @doc """
-  Attendance update failed due to constraint violation.
-  Indicates data validation failure at the database level.
-  """
+  @doc "Attendance update failed due to constraint violation."
   def attendance_update_constraint_violation, do: "attendance.record.update.constraint_violation"
 
-  @doc """
-  Database connection error when updating an attendance record.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def attendance_update_connection_error, do: "attendance.record.update.connection_error"
-
-  @doc """
-  Database query error when updating an attendance record.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def attendance_update_query_error, do: "attendance.record.update.query_error"
-
-  @doc """
-  Generic/unexpected error when updating an attendance record.
-  Fallback for errors that don't fit other categories.
-  """
-  def attendance_update_generic_error, do: "attendance.record.update.generic_error"
-
-  @doc """
-  Database connection error when listing attendance records.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def attendance_list_connection_error, do: "attendance.record.list.connection_error"
-
-  @doc """
-  Database query error when listing attendance records.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def attendance_list_query_error, do: "attendance.record.list.query_error"
-
-  @doc """
-  Generic/unexpected error when listing attendance records.
-  Fallback for errors that don't fit other categories.
-  """
-  def attendance_list_generic_error, do: "attendance.record.list.generic_error"
-
-  @doc """
-  Batch attendance submission failed.
-  """
-  def attendance_batch_error, do: "attendance.record.batch.error"
-
-  @doc """
-  Batch attendance failed due to concurrent modification (optimistic lock conflict).
-  """
-  def attendance_batch_stale_error, do: "attendance.record.batch.stale_entry"
-
-  @doc """
-  Database connection error during batch attendance submission.
-  """
-  def attendance_batch_connection_error, do: "attendance.record.batch.connection_error"
-
-  @doc """
-  Database query error during batch attendance submission.
-  """
-  def attendance_batch_query_error, do: "attendance.record.batch.query_error"
-
-  @doc """
-  Generic/unexpected error during batch attendance submission.
-  """
-  def attendance_batch_generic_error, do: "attendance.record.batch.generic_error"
-
-  @doc """
-  Duplicate attendance record error - record already exists for session/child combination.
-  """
+  @doc "Duplicate attendance record error - record already exists for session/child combination."
   def attendance_duplicate_error, do: "attendance.record.create.duplicate"
 
-  @doc """
-  Attendance validation error - changeset validation failed.
-  """
+  @doc "Attendance validation error - changeset validation failed."
   def attendance_validation_error, do: "attendance.record.validation.error"
 
-  # Family Management Context Errors - Child
+  # Parenting Context - Domain Errors
 
-  @doc """
-  Database connection error when retrieving a child by ID.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def child_get_connection_error, do: "family.child.get.connection_error"
+  @doc "Duplicate parent profile - identity already has a parent profile."
+  def parent_duplicate_identity, do: "parenting.profile.create.duplicate_identity"
 
-  @doc """
-  Database query error when retrieving a child by ID.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def child_get_query_error, do: "family.child.get.query_error"
+  # Providing Context - Domain Errors
 
-  @doc """
-  Generic/unexpected error when retrieving a child by ID.
-  Fallback for errors that don't fit other categories.
-  """
-  def child_get_generic_error, do: "family.child.get.generic_error"
+  @doc "Duplicate provider profile - identity already has a provider profile."
+  def provider_duplicate_identity, do: "providing.profile.create.duplicate_identity"
 
-  @doc """
-  Database connection error when creating a child.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def child_create_connection_error, do: "family.child.create.connection_error"
+  # Family Context - Domain Errors
 
-  @doc """
-  Database query error when creating a child.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def child_create_query_error, do: "family.child.create.query_error"
-
-  @doc """
-  Generic/unexpected error when creating a child.
-  Fallback for errors that don't fit other categories.
-  """
-  def child_create_generic_error, do: "family.child.create.generic_error"
-
-  @doc """
-  Database connection error when listing children by parent.
-  Indicates transient network/connection issue that may resolve on retry.
-  """
-  def child_list_connection_error, do: "family.child.list.connection_error"
-
-  @doc """
-  Database query error when listing children by parent.
-  Indicates SQL syntax error, constraint violation, or schema mismatch.
-  """
-  def child_list_query_error, do: "family.child.list.query_error"
-
-  @doc """
-  Generic/unexpected error when listing children by parent.
-  Fallback for errors that don't fit other categories.
-  """
-  def child_list_generic_error, do: "family.child.list.generic_error"
+  @doc "Child validation error - changeset validation failed."
+  def child_validation_error, do: "family.child.validation.error"
 end

--- a/lib/prime_youth_web/live/home_live.ex
+++ b/lib/prime_youth_web/live/home_live.ex
@@ -8,7 +8,7 @@ defmodule PrimeYouthWeb.HomeLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, featured} = ListFeaturedPrograms.execute()
+    featured = ListFeaturedPrograms.execute()
 
     socket =
       socket

--- a/lib/prime_youth_web/live/parent/attendance_history_live.ex
+++ b/lib/prime_youth_web/live/parent/attendance_history_live.ex
@@ -123,17 +123,18 @@ defmodule PrimeYouthWeb.Parent.AttendanceHistoryLive do
   defp load_attendance_history(socket) do
     parent_id = socket.assigns.parent_id
 
-    with {:ok, children} <- GetChildren.execute(:simple),
-         {:ok, attendance_records} <- GetAttendanceHistory.execute(:by_parent, parent_id) do
-      child_names = Map.new(children, fn child -> {child.id, Child.full_name(child)} end)
-      children_ids = MapSet.new(children, fn child -> child.id end)
+    case GetChildren.execute(:simple) do
+      {:ok, children} ->
+        attendance_records = GetAttendanceHistory.execute(:by_parent, parent_id)
+        child_names = Map.new(children, fn child -> {child.id, Child.full_name(child)} end)
+        children_ids = MapSet.new(children, fn child -> child.id end)
 
-      socket
-      |> assign(:child_names, child_names)
-      |> assign(:children_ids, children_ids)
-      |> stream(:attendance_records, attendance_records, reset: true)
-      |> assign(:attendance_error, nil)
-    else
+        socket
+        |> assign(:child_names, child_names)
+        |> assign(:children_ids, children_ids)
+        |> stream(:attendance_records, attendance_records, reset: true)
+        |> assign(:attendance_error, nil)
+
       {:error, reason} ->
         Logger.error(
           "[AttendanceHistoryLive.load_attendance_history] Failed to load attendance",

--- a/test/prime_youth/attendance/adapters/driven/persistence/repositories/attendance_repository_test.exs
+++ b/test/prime_youth/attendance/adapters/driven/persistence/repositories/attendance_repository_test.exs
@@ -205,7 +205,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Attenda
       insert(:attendance_record_schema, session_id: session.id, child_id: child1.id)
       insert(:attendance_record_schema, session_id: session.id, child_id: child2.id)
 
-      assert {:ok, records} = AttendanceRepository.list_by_session(session.id)
+      records = AttendanceRepository.list_by_session(session.id)
       assert length(records) == 2
       assert Enum.all?(records, &(&1.session_id == session.id))
     end
@@ -213,8 +213,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Attenda
     test "returns empty list when session has no records" do
       session = insert(:program_session_schema)
 
-      assert {:ok, records} = AttendanceRepository.list_by_session(session.id)
-      assert records == []
+      assert [] = AttendanceRepository.list_by_session(session.id)
     end
 
     test "does not return records from other sessions" do
@@ -225,7 +224,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Attenda
       insert(:attendance_record_schema, session_id: session1.id, child_id: child.id)
       insert(:attendance_record_schema, session_id: session2.id, child_id: child.id)
 
-      assert {:ok, records} = AttendanceRepository.list_by_session(session1.id)
+      records = AttendanceRepository.list_by_session(session1.id)
       assert length(records) == 1
       assert hd(records).session_id == session1.id
     end
@@ -253,7 +252,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Attenda
       insert(:attendance_record_schema, session_id: session1.id, child_id: child.id)
       insert(:attendance_record_schema, session_id: session2.id, child_id: child.id)
 
-      assert {:ok, records} = AttendanceRepository.list_by_child(child.id)
+      records = AttendanceRepository.list_by_child(child.id)
       assert length(records) == 2
       assert Enum.all?(records, &(&1.child_id == child.id))
     end
@@ -261,8 +260,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Attenda
     test "returns empty list when child has no records" do
       child = insert(:child_schema)
 
-      assert {:ok, records} = AttendanceRepository.list_by_child(child.id)
-      assert records == []
+      assert [] = AttendanceRepository.list_by_child(child.id)
     end
   end
 
@@ -418,7 +416,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Attenda
         parent_id: parent.id
       )
 
-      assert {:ok, records} = AttendanceRepository.list_by_parent(parent.id)
+      records = AttendanceRepository.list_by_parent(parent.id)
       assert length(records) == 2
       assert Enum.all?(records, &(&1.parent_id == parent.id))
     end
@@ -426,8 +424,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Attenda
     test "returns empty list when parent has no records" do
       parent = insert(:parent_schema)
 
-      assert {:ok, records} = AttendanceRepository.list_by_parent(parent.id)
-      assert records == []
+      assert [] = AttendanceRepository.list_by_parent(parent.id)
     end
   end
 end

--- a/test/prime_youth/attendance/adapters/driven/persistence/repositories/session_repository_test.exs
+++ b/test/prime_youth/attendance/adapters/driven/persistence/repositories/session_repository_test.exs
@@ -190,7 +190,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
         start_time: ~T[09:00:00]
       )
 
-      assert {:ok, sessions} = SessionRepository.list_by_program(program.id)
+      sessions = SessionRepository.list_by_program(program.id)
       assert length(sessions) == 4
 
       dates = Enum.map(sessions, & &1.session_date)
@@ -205,8 +205,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
     test "returns empty list when program has no sessions" do
       program = insert(:program_schema)
 
-      assert {:ok, sessions} = SessionRepository.list_by_program(program.id)
-      assert sessions == []
+      assert [] = SessionRepository.list_by_program(program.id)
     end
 
     test "does not return sessions from other programs" do
@@ -216,7 +215,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
       insert(:program_session_schema, program_id: program1.id)
       insert(:program_session_schema, program_id: program2.id)
 
-      assert {:ok, sessions} = SessionRepository.list_by_program(program1.id)
+      sessions = SessionRepository.list_by_program(program1.id)
       assert length(sessions) == 1
       assert Enum.all?(sessions, &(&1.program_id == program1.id))
     end
@@ -241,7 +240,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
 
       insert(:program_session_schema, program_id: program.id, session_date: ~D[2025-02-16])
 
-      assert {:ok, sessions} = SessionRepository.list_today_sessions(target_date)
+      sessions = SessionRepository.list_today_sessions(target_date)
       assert length(sessions) == 2
       assert Enum.all?(sessions, &(&1.session_date == target_date))
     end
@@ -263,7 +262,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
         start_time: ~T[09:00:00]
       )
 
-      assert {:ok, sessions} = SessionRepository.list_today_sessions(target_date)
+      sessions = SessionRepository.list_today_sessions(target_date)
       times = Enum.map(sessions, & &1.start_time)
       assert times == [~T[09:00:00], ~T[14:00:00]]
     end
@@ -271,8 +270,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
     test "returns empty list when no sessions for date" do
       target_date = ~D[2025-02-15]
 
-      assert {:ok, sessions} = SessionRepository.list_today_sessions(target_date)
-      assert sessions == []
+      assert [] = SessionRepository.list_today_sessions(target_date)
     end
   end
 
@@ -285,8 +283,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
       insert(:program_session_schema, program_id: program.id, session_date: target_date)
       insert(:program_session_schema, program_id: program.id, session_date: ~D[2025-02-16])
 
-      assert {:ok, sessions} =
-               SessionRepository.list_by_provider_and_date(provider_id, target_date)
+      sessions = SessionRepository.list_by_provider_and_date(provider_id, target_date)
 
       assert length(sessions) == 1
       assert Enum.all?(sessions, &(&1.session_date == target_date))
@@ -310,8 +307,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
         start_time: ~T[10:00:00]
       )
 
-      assert {:ok, sessions} =
-               SessionRepository.list_by_provider_and_date(provider_id, target_date)
+      sessions = SessionRepository.list_by_provider_and_date(provider_id, target_date)
 
       times = Enum.map(sessions, & &1.start_time)
       assert times == [~T[10:00:00], ~T[16:00:00]]
@@ -321,10 +317,7 @@ defmodule PrimeYouth.Attendance.Adapters.Driven.Persistence.Repositories.Session
       provider_id = Ecto.UUID.generate()
       target_date = ~D[2025-02-15]
 
-      assert {:ok, sessions} =
-               SessionRepository.list_by_provider_and_date(provider_id, target_date)
-
-      assert sessions == []
+      assert [] = SessionRepository.list_by_provider_and_date(provider_id, target_date)
     end
   end
 end

--- a/test/prime_youth/attendance/application/use_cases/get_attendance_history_test.exs
+++ b/test/prime_youth/attendance/application/use_cases/get_attendance_history_test.exs
@@ -32,7 +32,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
       insert(:attendance_record_schema, session_id: session1.id, child_id: child.id)
       insert(:attendance_record_schema, session_id: session2.id, child_id: child.id)
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_child, child.id)
+      records = GetAttendanceHistory.execute(:by_child, child.id)
       assert length(records) == 2
       assert Enum.all?(records, &match?(%AttendanceRecord{}, &1))
       assert Enum.all?(records, &(&1.child_id == child.id))
@@ -41,7 +41,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
     test "returns empty list when child has no records" do
       child = insert(:child_schema)
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_child, child.id)
+      records = GetAttendanceHistory.execute(:by_child, child.id)
       assert records == []
     end
 
@@ -53,7 +53,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
       insert(:attendance_record_schema, session_id: session.id, child_id: child1.id)
       insert(:attendance_record_schema, session_id: session.id, child_id: child2.id)
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_child, child1.id)
+      records = GetAttendanceHistory.execute(:by_child, child1.id)
       assert length(records) == 1
       assert hd(records).child_id == child1.id
     end
@@ -68,7 +68,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
       insert(:attendance_record_schema, session_id: session.id, child_id: child1.id)
       insert(:attendance_record_schema, session_id: session.id, child_id: child2.id)
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_session, session.id)
+      records = GetAttendanceHistory.execute(:by_session, session.id)
       assert length(records) == 2
       assert Enum.all?(records, &(&1.session_id == session.id))
     end
@@ -76,7 +76,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
     test "returns empty list when session has no records" do
       session = insert(:program_session_schema)
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_session, session.id)
+      records = GetAttendanceHistory.execute(:by_session, session.id)
       assert records == []
     end
 
@@ -88,7 +88,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
       insert(:attendance_record_schema, session_id: session1.id, child_id: child.id)
       insert(:attendance_record_schema, session_id: session2.id, child_id: child.id)
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_session, session1.id)
+      records = GetAttendanceHistory.execute(:by_session, session1.id)
       assert length(records) == 1
       assert hd(records).session_id == session1.id
     end
@@ -113,7 +113,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
         parent_id: parent.id
       )
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_parent, parent.id)
+      records = GetAttendanceHistory.execute(:by_parent, parent.id)
       assert length(records) == 2
       assert Enum.all?(records, &(&1.parent_id == parent.id))
     end
@@ -121,7 +121,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
     test "returns empty list when parent has no records" do
       parent = insert(:parent_schema)
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_parent, parent.id)
+      records = GetAttendanceHistory.execute(:by_parent, parent.id)
       assert records == []
     end
 
@@ -144,7 +144,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.GetAttendanceHistoryTest do
         parent_id: parent2.id
       )
 
-      assert {:ok, records} = GetAttendanceHistory.execute(:by_parent, parent1.id)
+      records = GetAttendanceHistory.execute(:by_parent, parent1.id)
       assert length(records) == 1
       assert hd(records).parent_id == parent1.id
     end

--- a/test/prime_youth/attendance/application/use_cases/list_provider_sessions_test.exs
+++ b/test/prime_youth/attendance/application/use_cases/list_provider_sessions_test.exs
@@ -37,7 +37,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListProviderSessionsTest do
         start_time: ~T[09:00:00]
       )
 
-      assert {:ok, sessions} = ListProviderSessions.execute(provider_id, target_date)
+      sessions = ListProviderSessions.execute(provider_id, target_date)
       assert length(sessions) == 2
       assert Enum.all?(sessions, &match?(%ProgramSession{}, &1))
       assert Enum.all?(sessions, &(&1.session_date == target_date))
@@ -50,7 +50,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListProviderSessionsTest do
       provider_id = Ecto.UUID.generate()
       target_date = ~D[2025-02-15]
 
-      assert {:ok, sessions} = ListProviderSessions.execute(provider_id, target_date)
+      sessions = ListProviderSessions.execute(provider_id, target_date)
       assert sessions == []
     end
 
@@ -73,7 +73,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListProviderSessionsTest do
         end_time: ~T[17:00:00]
       )
 
-      assert {:ok, sessions} = ListProviderSessions.execute(provider_id, target_date)
+      sessions = ListProviderSessions.execute(provider_id, target_date)
       assert length(sessions) == 2
     end
   end

--- a/test/prime_youth/attendance/application/use_cases/list_sessions_test.exs
+++ b/test/prime_youth/attendance/application/use_cases/list_sessions_test.exs
@@ -41,7 +41,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListSessionsTest do
         start_time: ~T[09:00:00]
       )
 
-      assert {:ok, sessions} = ListSessions.execute(:by_program, program.id)
+      sessions = ListSessions.execute(:by_program, program.id)
       assert length(sessions) == 4
       assert Enum.all?(sessions, &match?(%ProgramSession{}, &1))
 
@@ -56,7 +56,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListSessionsTest do
     test "returns empty list when program has no sessions" do
       program = insert(:program_schema)
 
-      assert {:ok, sessions} = ListSessions.execute(:by_program, program.id)
+      sessions = ListSessions.execute(:by_program, program.id)
       assert sessions == []
     end
 
@@ -67,7 +67,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListSessionsTest do
       insert(:program_session_schema, program_id: program1.id)
       insert(:program_session_schema, program_id: program2.id)
 
-      assert {:ok, sessions} = ListSessions.execute(:by_program, program1.id)
+      sessions = ListSessions.execute(:by_program, program1.id)
       assert length(sessions) == 1
       assert Enum.all?(sessions, &(&1.program_id == program1.id))
     end
@@ -97,7 +97,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListSessionsTest do
         start_time: ~T[09:00:00]
       )
 
-      assert {:ok, sessions} = ListSessions.execute(:today, target_date)
+      sessions = ListSessions.execute(:today, target_date)
       assert length(sessions) == 2
       assert Enum.all?(sessions, &(&1.session_date == target_date))
 
@@ -108,7 +108,7 @@ defmodule PrimeYouth.Attendance.Application.UseCases.ListSessionsTest do
     test "returns empty list when no sessions for date" do
       target_date = ~D[2025-02-15]
 
-      assert {:ok, sessions} = ListSessions.execute(:today, target_date)
+      sessions = ListSessions.execute(:today, target_date)
       assert sessions == []
     end
   end

--- a/test/prime_youth/family/adapters/driven/persistence/repositories/child_repository_test.exs
+++ b/test/prime_youth/family/adapters/driven/persistence/repositories/child_repository_test.exs
@@ -147,16 +147,16 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
       refute is_nil(child.updated_at)
     end
 
-    test "returns :database_query_error for missing required fields" do
+    test "returns changeset error for missing required fields" do
       attrs = %{
         first_name: "Alice",
         last_name: "Smith"
       }
 
-      assert {:error, :database_query_error} = ChildRepository.create(attrs)
+      assert {:error, %Ecto.Changeset{valid?: false}} = ChildRepository.create(attrs)
     end
 
-    test "returns :database_query_error for invalid date_of_birth (future)" do
+    test "returns changeset error for invalid date_of_birth (future)" do
       parent_schema = insert(:parent_schema)
       future_date = Date.add(Date.utc_today(), 1)
 
@@ -167,7 +167,7 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
         date_of_birth: future_date
       }
 
-      assert {:error, :database_query_error} = ChildRepository.create(attrs)
+      assert {:error, %Ecto.Changeset{valid?: false}} = ChildRepository.create(attrs)
     end
   end
 
@@ -183,7 +183,7 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
       child2 = insert(:child_schema, parent_id: parent_schema.id, first_name: "Bob")
       child3 = insert(:child_schema, parent_id: parent_schema.id, first_name: "Charlie")
 
-      assert {:ok, children} = ChildRepository.list_by_parent(parent_schema.id)
+      children = ChildRepository.list_by_parent(parent_schema.id)
 
       assert length(children) == 3
       assert Enum.all?(children, &match?(%Child{}, &1))
@@ -197,7 +197,7 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
     test "returns empty list when parent has no children" do
       parent_id = Ecto.UUID.generate()
 
-      assert {:ok, []} = ChildRepository.list_by_parent(parent_id)
+      assert [] = ChildRepository.list_by_parent(parent_id)
     end
 
     test "orders children by first_name ASC, then last_name ASC" do
@@ -227,7 +227,7 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
       _bob =
         insert(:child_schema, parent_id: parent_schema.id, first_name: "Bob", last_name: "Davis")
 
-      assert {:ok, children} = ChildRepository.list_by_parent(parent_schema.id)
+      children = ChildRepository.list_by_parent(parent_schema.id)
 
       assert length(children) == 4
       assert Enum.at(children, 0).first_name == "Alice"
@@ -264,7 +264,7 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
           last_name: "Jones"
         )
 
-      assert {:ok, children} = ChildRepository.list_by_parent(parent_schema.id)
+      children = ChildRepository.list_by_parent(parent_schema.id)
 
       assert length(children) == 3
       assert Enum.all?(children, &(&1.first_name == "Alice"))
@@ -282,7 +282,7 @@ defmodule PrimeYouth.Family.Adapters.Driven.Persistence.Repositories.ChildReposi
       _child3 = insert(:child_schema, parent_id: parent2_schema.id, first_name: "Charlie")
       _child4 = insert(:child_schema, parent_id: parent2_schema.id, first_name: "Diana")
 
-      assert {:ok, children} = ChildRepository.list_by_parent(parent1_schema.id)
+      children = ChildRepository.list_by_parent(parent1_schema.id)
 
       assert length(children) == 2
       assert Enum.all?(children, &(&1.parent_id == parent1_schema.id))

--- a/test/prime_youth/parenting/adapters/driven/persistence/repositories/parent_repository_test.exs
+++ b/test/prime_youth/parenting/adapters/driven/persistence/repositories/parent_repository_test.exs
@@ -139,17 +139,17 @@ defmodule PrimeYouth.Parenting.Adapters.Driven.Persistence.Repositories.ParentRe
   # =============================================================================
 
   describe "has_profile?/1" do
-    test "returns {:ok, true} when parent profile exists" do
+    test "returns true when parent profile exists" do
       identity_id = Ecto.UUID.generate()
       {:ok, _parent} = ParentRepository.create_parent_profile(%{identity_id: identity_id})
 
-      assert {:ok, true} = ParentRepository.has_profile?(identity_id)
+      assert ParentRepository.has_profile?(identity_id) == true
     end
 
-    test "returns {:ok, false} when parent profile does not exist" do
+    test "returns false when parent profile does not exist" do
       non_existent_id = Ecto.UUID.generate()
 
-      assert {:ok, false} = ParentRepository.has_profile?(non_existent_id)
+      assert ParentRepository.has_profile?(non_existent_id) == false
     end
 
     test "returns correct result after creating multiple profiles" do
@@ -158,8 +158,8 @@ defmodule PrimeYouth.Parenting.Adapters.Driven.Persistence.Repositories.ParentRe
 
       {:ok, _} = ParentRepository.create_parent_profile(%{identity_id: existing_identity})
 
-      assert {:ok, true} = ParentRepository.has_profile?(existing_identity)
-      assert {:ok, false} = ParentRepository.has_profile?(non_existing_identity)
+      assert ParentRepository.has_profile?(existing_identity) == true
+      assert ParentRepository.has_profile?(non_existing_identity) == false
     end
   end
 end

--- a/test/prime_youth/program_catalog/adapters/driven/persistence/repositories/program_repository_test.exs
+++ b/test/prime_youth/program_catalog/adapters/driven/persistence/repositories/program_repository_test.exs
@@ -45,7 +45,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
           spots_available: 12
         })
 
-      {:ok, programs} = ProgramRepository.list_all_programs()
+      programs = ProgramRepository.list_all_programs()
 
       assert length(programs) == 3
       assert Enum.all?(programs, &match?(%Program{}, &1))
@@ -88,14 +88,14 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
         spots_available: 10
       })
 
-      {:ok, programs} = ProgramRepository.list_all_programs()
+      programs = ProgramRepository.list_all_programs()
 
       titles = Enum.map(programs, & &1.title)
       assert titles == ["Art Class", "Music Lessons", "Zebra Camp"]
     end
 
     test "returns empty list when database is empty" do
-      {:ok, programs} = ProgramRepository.list_all_programs()
+      programs = ProgramRepository.list_all_programs()
 
       assert programs == []
     end
@@ -123,7 +123,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
           spots_available: 15
         })
 
-      {:ok, programs} = ProgramRepository.list_all_programs()
+      programs = ProgramRepository.list_all_programs()
 
       assert length(programs) == 2
 
@@ -159,7 +159,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
           spots_available: 20
         })
 
-      {:ok, programs} = ProgramRepository.list_all_programs()
+      programs = ProgramRepository.list_all_programs()
 
       assert length(programs) == 2
 
@@ -204,7 +204,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
         spots_available: 10
       })
 
-      {:ok, programs} = ProgramRepository.list_all_programs()
+      programs = ProgramRepository.list_all_programs()
 
       assert length(programs) == 1
       # The successful query indicates the repository is working.
@@ -596,7 +596,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
       assert {:error, :not_found} = ProgramRepository.update(non_existent_program)
     end
 
-    test "returns database_query_error for constraint violation" do
+    test "returns changeset error for constraint violation" do
       # Create a program
       program_schema =
         insert_program(%{
@@ -615,7 +615,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
 
       # Update should fail with changeset validation error
       # (validate_number ensures price >= 0)
-      assert {:error, :database_query_error} = ProgramRepository.update(invalid_program)
+      assert {:error, %Ecto.Changeset{valid?: false}} = ProgramRepository.update(invalid_program)
 
       # Verify original data unchanged
       unchanged_schema = Repo.get(ProgramSchema, program_schema.id)
@@ -623,7 +623,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
       assert unchanged_schema.lock_version == 1
     end
 
-    test "returns database_query_error for empty required field" do
+    test "returns changeset error for empty required field" do
       # Create a program
       program_schema =
         insert_program(%{
@@ -641,7 +641,7 @@ defmodule PrimeYouth.ProgramCatalog.Adapters.Driven.Persistence.Repositories.Pro
       invalid_program = %{domain_program | title: ""}
 
       # Update should fail with changeset validation error
-      assert {:error, :database_query_error} = ProgramRepository.update(invalid_program)
+      assert {:error, %Ecto.Changeset{valid?: false}} = ProgramRepository.update(invalid_program)
 
       # Verify original data unchanged
       unchanged_schema = Repo.get(ProgramSchema, program_schema.id)

--- a/test/prime_youth/program_catalog/application/use_cases/list_all_programs_integration_test.exs
+++ b/test/prime_youth/program_catalog/application/use_cases/list_all_programs_integration_test.exs
@@ -87,7 +87,7 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllProgramsIntegrat
         spots_available: 15
       })
 
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
 
       assert length(programs) == 2
       assert Enum.all?(programs, &match?(%Program{}, &1))
@@ -123,7 +123,7 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllProgramsIntegrat
       Repo.delete_all(ProgramSessionSchema)
       Repo.delete_all(ProgramSchema)
 
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
 
       assert programs == []
       assert is_list(programs)
@@ -161,7 +161,7 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllProgramsIntegrat
         spots_available: 10
       })
 
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
 
       titles = Enum.map(programs, & &1.title)
       assert titles == ["Art Class", "Music Lessons", "Zebra Camp"]
@@ -185,7 +185,7 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllProgramsIntegrat
         spots_available: 10
       })
 
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
 
       assert length(programs) == 1
       assert List.first(programs).title == "Test Program"
@@ -213,7 +213,7 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllProgramsIntegrat
         spots_available: 0
       })
 
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
 
       assert length(programs) == 2
 
@@ -254,7 +254,7 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllProgramsIntegrat
         spots_available: 0
       })
 
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
 
       assert length(programs) == 2
 
@@ -299,7 +299,7 @@ defmodule PrimeYouth.ProgramCatalog.Application.UseCases.ListAllProgramsIntegrat
         spots_available: 10
       })
 
-      {:ok, programs} = ListAllPrograms.execute()
+      programs = ListAllPrograms.execute()
 
       assert length(programs) == 2
 

--- a/test/prime_youth/providing/adapters/driven/persistence/repositories/provider_repository_test.exs
+++ b/test/prime_youth/providing/adapters/driven/persistence/repositories/provider_repository_test.exs
@@ -230,7 +230,7 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
   # =============================================================================
 
   describe "has_profile?/1" do
-    test "returns {:ok, true} when provider profile exists" do
+    test "returns true when provider profile exists" do
       identity_id = Ecto.UUID.generate()
 
       {:ok, _provider} =
@@ -239,13 +239,13 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
           business_name: "Test Business"
         })
 
-      assert {:ok, true} = ProviderRepository.has_profile?(identity_id)
+      assert ProviderRepository.has_profile?(identity_id) == true
     end
 
-    test "returns {:ok, false} when provider profile does not exist" do
+    test "returns false when provider profile does not exist" do
       non_existent_id = Ecto.UUID.generate()
 
-      assert {:ok, false} = ProviderRepository.has_profile?(non_existent_id)
+      assert ProviderRepository.has_profile?(non_existent_id) == false
     end
 
     test "returns correct result after creating multiple profiles" do
@@ -258,8 +258,8 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
           business_name: "Existing Provider"
         })
 
-      assert {:ok, true} = ProviderRepository.has_profile?(existing_identity)
-      assert {:ok, false} = ProviderRepository.has_profile?(non_existing_identity)
+      assert ProviderRepository.has_profile?(existing_identity) == true
+      assert ProviderRepository.has_profile?(non_existing_identity) == false
     end
 
     test "returns true for provider with minimal fields" do
@@ -271,7 +271,7 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
           business_name: "Minimal"
         })
 
-      assert {:ok, true} = ProviderRepository.has_profile?(identity_id)
+      assert ProviderRepository.has_profile?(identity_id) == true
     end
 
     test "returns true for provider with all fields populated" do
@@ -291,7 +291,7 @@ defmodule PrimeYouth.Providing.Adapters.Driven.Persistence.Repositories.Provider
           categories: ["sports", "outdoor"]
         })
 
-      assert {:ok, true} = ProviderRepository.has_profile?(identity_id)
+      assert ProviderRepository.has_profile?(identity_id) == true
     end
   end
 end

--- a/test/prime_youth_web/live/booking_live_test.exs
+++ b/test/prime_youth_web/live/booking_live_test.exs
@@ -32,7 +32,8 @@ defmodule PrimeYouthWeb.BookingLiveTest do
                live(conn, ~p"/programs/invalid/booking")
 
       assert path == ~p"/programs"
-      assert flash["error"] == "Unable to load program. Please try again later."
+      # Invalid UUIDs return :not_found, which shows the "not found" message
+      assert flash["error"] == "Program not found"
     end
 
     test "redirects with error flash for non-existent program ID", %{conn: conn} do

--- a/test/prime_youth_web/live/program_detail_live_test.exs
+++ b/test/prime_youth_web/live/program_detail_live_test.exs
@@ -16,7 +16,10 @@ defmodule PrimeYouthWeb.ProgramDetailLiveTest do
       assert {:error, {:redirect, %{to: path, flash: flash}}} = live(conn, ~p"/programs/invalid")
 
       assert path == ~p"/programs"
-      assert flash["error"] == "Unable to load program. Please try again later."
+
+      # Invalid UUIDs return :not_found, which shows the "not found" message
+      assert flash["error"] ==
+               "Program not found. It may have been removed or is no longer available."
     end
 
     test "redirects with error flash for non-existent program ID", %{conn: conn} do
@@ -36,14 +39,20 @@ defmodule PrimeYouthWeb.ProgramDetailLiveTest do
       assert {:error, {:redirect, %{to: path, flash: flash}}} = live(conn, ~p"/programs/0")
 
       assert path == ~p"/programs"
-      assert flash["error"] == "Unable to load program. Please try again later."
+
+      # Invalid UUIDs return :not_found, which shows the "not found" message
+      assert flash["error"] ==
+               "Program not found. It may have been removed or is no longer available."
     end
 
     test "redirects with error flash for negative program ID", %{conn: conn} do
       assert {:error, {:redirect, %{to: path, flash: flash}}} = live(conn, ~p"/programs/-1")
 
       assert path == ~p"/programs"
-      assert flash["error"] == "Unable to load program. Please try again later."
+
+      # Invalid UUIDs return :not_found, which shows the "not found" message
+      assert flash["error"] ==
+               "Program not found. It may have been removed or is no longer available."
     end
 
     test "enroll_now button navigates to booking page", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Simplified error handling across all repository adapters
- Changed list operations to return raw `[struct()]` instead of `{:ok, [struct()]}` tuples
- Updated boolean operations like `has_profile?/1` to return `boolean()` instead of `{:ok, boolean()}`
- Fixed UUID validation using `Ecto.UUID.dump/1` (cast/1 incorrectly accepts 16-byte strings)
- Reduced ~2,400 lines of boilerplate code

## Test plan
- [x] All 1410 tests pass
- [x] `mix precommit` passes (compile with warnings-as-errors, format, test)