### PR TITLE
Fix: Provider users seeing parent dashboard

### DIFF
--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -50,6 +50,7 @@ defmodule KlassHeroWeb.Router do
       layout: {KlassHeroWeb.Layouts, :app},
       on_mount: [
         {KlassHeroWeb.UserAuth, :require_authenticated},
+        {KlassHeroWeb.UserAuth, :redirect_provider_from_parent_routes},
         {KlassHeroWeb.Hooks.RestoreLocale, :restore_locale}
       ] do
       live "/dashboard", DashboardLive, :index


### PR DESCRIPTION
## Summary
- Provider users navigating to `/dashboard` are now redirected to `/provider/dashboard`
- Adds `redirect_provider_from_parent_routes` on_mount hook to UserAuth
- Hook checks user roles and redirects providers to their appropriate dashboard