### PR TITLE
Replace teal with hero-blue (#0fc3ff)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -68,17 +68,17 @@
 
 /* Klass Hero Superhero Brand Colors */
 @theme {
-  /* Hero Blue #00D4FF */
-  --color-hero-blue-50: oklch(96% 0.03 195);
-  --color-hero-blue-100: oklch(92% 0.06 195);
-  --color-hero-blue-200: oklch(88% 0.09 195);
-  --color-hero-blue-300: oklch(84% 0.12 195);
-  --color-hero-blue-400: oklch(81% 0.14 195);
-  --color-hero-blue-500: oklch(78% 0.16 195); /* Primary #00D4FF */
-  --color-hero-blue-600: oklch(68% 0.14 195);
-  --color-hero-blue-700: oklch(58% 0.12 195);
-  --color-hero-blue-800: oklch(48% 0.10 195);
-  --color-hero-blue-900: oklch(38% 0.08 195);
+  /* Hero Blue #0fc3ff */
+  --color-hero-blue-50: oklch(96% 0.03 210);
+  --color-hero-blue-100: oklch(92% 0.06 210);
+  --color-hero-blue-200: oklch(88% 0.09 210);
+  --color-hero-blue-300: oklch(84% 0.12 210);
+  --color-hero-blue-400: oklch(81% 0.14 210);
+  --color-hero-blue-500: oklch(78% 0.155 210); /* Primary #0fc3ff */
+  --color-hero-blue-600: oklch(68% 0.14 210);
+  --color-hero-blue-700: oklch(58% 0.12 210);
+  --color-hero-blue-800: oklch(48% 0.10 210);
+  --color-hero-blue-900: oklch(38% 0.08 210);
 
   /* Hero Yellow #FFFF36 */
   --color-hero-yellow-50: oklch(99% 0.05 105);

--- a/lib/klass_hero_web/components/participation_components.ex
+++ b/lib/klass_hero_web/components/participation_components.ex
@@ -235,7 +235,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
           <button
             type="submit"
             class={[
-              "flex-1 px-4 py-3 bg-hero-blue-600 text-white font-medium hover:bg-hero-blue-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2",
+              "flex-1 px-4 py-3 bg-hero-blue-600 text-white font-medium hover:bg-hero-blue-700 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -608,8 +608,8 @@ defmodule KlassHeroWeb.ParticipationComponents do
             <button
               type="submit"
               class={[
-                "flex-1 px-3 py-1.5 bg-teal-600 text-white text-sm font-medium hover:bg-teal-700",
-                "focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2",
+                "flex-1 px-3 py-1.5 bg-hero-blue-600 text-white text-sm font-medium hover:bg-hero-blue-700",
+                "focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                 Theme.rounded(:md),
                 Theme.transition(:normal)
               ]}
@@ -622,7 +622,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
               phx-value-id={@entity_id}
               class={[
                 "px-3 py-1.5 bg-white text-hero-black-100 text-sm font-medium border border-hero-grey-300",
-                "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2",
+                "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                 Theme.rounded(:md),
                 Theme.transition(:normal)
               ]}

--- a/lib/klass_hero_web/components/theme.ex
+++ b/lib/klass_hero_web/components/theme.ex
@@ -7,7 +7,7 @@ defmodule KlassHeroWeb.Theme do
 
   ## Design Tokens
 
-  - **Colors**: Primary (teal), Secondary (pink), Accent (yellow)
+  - **Colors**: Primary (hero-blue), Secondary (pink), Accent (yellow)
   - **Gradients**: 15+ pre-defined gradients for various use cases
   - **Icon Styles**: Paired background + text colors for icons
   - **Status**: Color combinations for availability states
@@ -54,17 +54,17 @@ defmodule KlassHeroWeb.Theme do
 
   ## Available Gradients
 
-  - `:primary` - Teal horizontal gradient (teal-500 to teal-600)
-  - `:hero` - Teal diagonal gradient (teal-400 via teal-500 to teal-600)
+  - `:primary` - Hero blue horizontal gradient (hero-blue-500 to hero-blue-600)
+  - `:hero` - Hero blue/yellow diagonal gradient
   - `:safety` - Green horizontal gradient (green-500 to emerald-600)
 
   ## Examples
 
       iex> Theme.gradient(:primary)
-      "bg-gradient-to-r from-teal-500 to-teal-600"
+      "bg-gradient-to-r from-hero-blue-500 to-hero-blue-600"
 
       iex> Theme.gradient(:hero)
-      "bg-gradient-to-br from-teal-400 via-teal-500 to-teal-600"
+      "bg-gradient-to-br from-hero-blue-400 via-hero-yellow-400 to-hero-yellow-500"
 
       iex> Theme.gradient(:safety)
       "bg-gradient-to-r from-green-500 to-emerald-600"
@@ -150,9 +150,9 @@ defmodule KlassHeroWeb.Theme do
   ## Available Colors
 
   ### Primary Colors
-  - `:primary` - Main brand color (teal-600)
-  - `:primary_hover` - Hover state (teal-700)
-  - `:primary_light` - Light background (teal-50)
+  - `:primary` - Main brand color (hero-blue-600)
+  - `:primary_hover` - Hover state (hero-blue-700)
+  - `:primary_light` - Light background (hero-blue-50)
 
   ### Accent Colors
   - `:accent` - Accent highlights (pink-500)
@@ -178,7 +178,7 @@ defmodule KlassHeroWeb.Theme do
   ## Examples
 
       iex> Theme.brand_color(:primary)
-      "teal-600"
+      "hero-blue-600"
 
       iex> Theme.brand_color(:accent)
       "pink-500"

--- a/lib/klass_hero_web/components/ui_components.ex
+++ b/lib/klass_hero_web/components/ui_components.ex
@@ -1325,7 +1325,7 @@ defmodule KlassHeroWeb.UIComponents do
         name={@name}
         value={format_date_value(@value)}
         class={[
-          "px-4 py-2 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent",
+          "px-4 py-2 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:border-transparent",
           Theme.rounded(:lg),
           Theme.transition(:normal)
         ]}

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -3,7 +3,7 @@
   <div class="mb-6">
     <.link
       navigate={~p"/provider/sessions"}
-      class="inline-flex items-center gap-2 text-teal-600 hover:text-teal-700 font-medium"
+      class="inline-flex items-center gap-2 text-hero-blue-600 hover:text-hero-blue-700 font-medium"
     >
       <.icon name="hero-arrow-left" class="w-5 h-5" />
       <span>Back to Sessions</span>
@@ -58,8 +58,8 @@
                 phx-click="check_in"
                 phx-value-id={record.id}
                 class={[
-                  "px-3 py-1.5 text-sm bg-teal-600 text-white font-medium hover:bg-teal-700",
-                  "focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2",
+                  "px-3 py-1.5 text-sm bg-hero-blue-600 text-white font-medium hover:bg-hero-blue-700",
+                  "focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:md),
                   Theme.transition(:normal)
                 ]}

--- a/lib/klass_hero_web/live/provider/sessions_live.html.heex
+++ b/lib/klass_hero_web/live/provider/sessions_live.html.heex
@@ -32,7 +32,7 @@
                 phx-click="start_session"
                 phx-value-session_id={session.id}
                 class={[
-                  "px-4 py-2 bg-teal-600 text-white font-medium hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2",
+                  "px-4 py-2 bg-hero-blue-600 text-white font-medium hover:bg-hero-blue-700 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:lg),
                   Theme.transition(:normal)
                 ]}
@@ -43,7 +43,7 @@
               <.link
                 navigate={~p"/provider/participation/#{session.id}"}
                 class={[
-                  "px-4 py-2 bg-teal-600 text-white font-medium hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 text-center",
+                  "px-4 py-2 bg-hero-blue-600 text-white font-medium hover:bg-hero-blue-700 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2 text-center",
                   Theme.rounded(:lg),
                   Theme.transition(:normal)
                 ]}


### PR DESCRIPTION
## Summary
- Replace all `teal-*` Tailwind classes with `hero-blue-*` across templates and components
- Update hero-blue CSS palette hue from 195 to 210 to match #0fc3ff
- Fix stale teal references in theme.ex docs

Closes #118