### PR TITLE
style: reduce About Us vetting to 3-step process

### DIFF
--- a/lib/klass_hero_web/live/about_live.ex
+++ b/lib/klass_hero_web/live/about_live.ex
@@ -27,22 +27,13 @@ defmodule KlassHeroWeb.AboutLive do
         number: 2,
         number_bg: "bg-hero-blue-100",
         number_color: "text-hero-blue-700",
-        icon: "hero-magnifying-glass-circle",
-        icon_gradient: "bg-hero-blue-400",
-        title: gettext("Background Check"),
-        description: gettext("Comprehensive criminal record screening")
-      },
-      %{
-        number: 3,
-        number_bg: "bg-hero-blue-100",
-        number_color: "text-hero-blue-700",
         icon: "hero-academic-cap",
         icon_gradient: "bg-hero-blue-400",
         title: gettext("Qualifications"),
         description: gettext("Certification and experience verification")
       },
       %{
-        number: 4,
+        number: 3,
         number_bg: "bg-hero-blue-100",
         number_color: "text-hero-blue-700",
         icon: "hero-video-camera",
@@ -201,12 +192,12 @@ defmodule KlassHeroWeb.AboutLive do
         </div>
       </div>
 
-      <%!-- 4-Step Vetting Process --%>
+      <%!-- 3-Step Vetting Process --%>
       <div class="bg-hero-pink-50 py-12 md:py-16 lg:py-24">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div class="text-center mb-12">
             <h2 class="font-display text-3xl md:text-4xl lg:text-5xl text-hero-black mb-4">
-              {gettext("Our 4-Step Vetting Process")}
+              {gettext("Our 3-Step Vetting Process")}
             </h2>
             <p class="text-lg text-hero-grey-700 max-w-3xl mx-auto">
               {gettext(
@@ -215,7 +206,7 @@ defmodule KlassHeroWeb.AboutLive do
             </p>
           </div>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
             <div :for={step <- vetting_steps()} class="bg-white rounded-xl p-6 text-center">
               <div class={[
                 "w-16 h-16 mx-auto mb-4 rounded-full flex items-center justify-center",

--- a/test/klass_hero_web/live/about_live_test.exs
+++ b/test/klass_hero_web/live/about_live_test.exs
@@ -52,26 +52,24 @@ defmodule KlassHeroWeb.AboutLiveTest do
       {:ok, _view, html} = live(conn, ~p"/about")
 
       # Verify section heading and background
-      assert html =~ "Our 4-Step Vetting Process"
+      assert html =~ "Our 3-Step Vetting Process"
       assert html =~ "bg-hero-pink-50"
       assert html =~ "rigorous screening to ensure the highest quality"
     end
 
-    test "displays all four vetting process steps", %{conn: conn} do
+    test "displays all three vetting process steps", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/about")
 
-      # Verify all four steps are present with numbered circles
       assert html =~ "Identity Verification"
       assert html =~ "Official ID and credentials check"
-
-      assert html =~ "Background Check"
-      assert html =~ "Comprehensive criminal record screening"
 
       assert html =~ "Qualifications"
       assert html =~ "Certification and experience verification"
 
       assert html =~ "Personal Interview"
       assert html =~ "In-depth conversation about values and approach"
+
+      refute html =~ "Background Check"
     end
 
     test "vetting steps have KH blue numbered circles", %{conn: conn} do
@@ -146,7 +144,7 @@ defmodule KlassHeroWeb.AboutLiveTest do
 
       # Verify responsive grid classes
       assert html =~ "md:grid-cols-2"
-      assert html =~ "lg:grid-cols-4"
+      assert html =~ "lg:grid-cols-3"
       assert html =~ "md:grid-cols-3"
     end
 


### PR DESCRIPTION
## Summary
- Remove Background Check step (step 2), keeping Identity Verification, Qualifications, Personal Interview
- Renumber steps as 1, 2, 3
- Update grid layout from lg:grid-cols-4 → lg:grid-cols-3
- Section heading: "4-Step" → "3-Step"

Closes #134

## Test plan
- [x] `mix precommit` passes (1988 tests, 0 failures)
- [x] Visual check of 3-step vetting section layout