### PR TITLE
fix: route provider messages icon to /provider/messages

### DIFF
--- a/lib/klass_hero_web/components/layouts/app.html.heex
+++ b/lib/klass_hero_web/components/layouts/app.html.heex
@@ -74,7 +74,15 @@
 
           <%= if assigns[:current_scope] && @current_scope.user do %>
             <!-- Messages Indicator -->
-            <.messages_indicator unread_count={assigns[:total_unread_count] || 0} />
+            <.messages_indicator
+              unread_count={assigns[:total_unread_count] || 0}
+              href={
+                if(:provider in (@current_scope.user.intended_roles || []),
+                  do: ~p"/provider/messages",
+                  else: ~p"/messages"
+                )
+              }
+            />
             
 <!-- Authenticated User Dropdown -->
             <div class="dropdown dropdown-end">
@@ -226,7 +234,15 @@
           <%= if assigns[:current_scope] && @current_scope.user do %>
             <li class="mt-4"><.link navigate={~p"/dashboard"}>{gettext("Dashboard")}</.link></li>
             <li>
-              <.link navigate={~p"/messages"} class="flex items-center justify-between">
+              <.link
+                navigate={
+                  if(:provider in (@current_scope.user.intended_roles || []),
+                    do: ~p"/provider/messages",
+                    else: ~p"/messages"
+                  )
+                }
+                class="flex items-center justify-between"
+              >
                 {gettext("Messages")}
                 <span
                   :if={assigns[:total_unread_count] && @total_unread_count > 0}

--- a/lib/klass_hero_web/components/ui_components.ex
+++ b/lib/klass_hero_web/components/ui_components.ex
@@ -1571,14 +1571,18 @@ defmodule KlassHeroWeb.UIComponents do
 
       <.messages_indicator unread_count={5} />
       <.messages_indicator unread_count={0} />
+      <.messages_indicator unread_count={3} href={~p"/provider/messages"} />
 
   """
   attr :unread_count, :integer, default: 0
+  attr :href, :string, default: nil
   attr :class, :string, default: ""
 
   def messages_indicator(assigns) do
+    assigns = assign(assigns, :href, assigns[:href] || ~p"/messages")
+
     ~H"""
-    <.link navigate={~p"/messages"} class={["relative btn btn-ghost btn-circle", @class]}>
+    <.link navigate={@href} class={["relative btn btn-ghost btn-circle", @class]}>
       <.icon name="hero-chat-bubble-left-right" class="w-6 h-6 text-hero-grey-600" />
       <span
         :if={@unread_count > 0}

--- a/test/klass_hero_web/components/ui_components_test.exs
+++ b/test/klass_hero_web/components/ui_components_test.exs
@@ -1,0 +1,55 @@
+defmodule KlassHeroWeb.UIComponentsTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHeroWeb.UIComponents
+
+  describe "messages_indicator/1" do
+    test "renders with default href to /messages" do
+      html =
+        render_component(&UIComponents.messages_indicator/1, %{
+          unread_count: 0
+        })
+
+      assert html =~ ~s|href="/messages"|
+    end
+
+    test "renders with custom href" do
+      html =
+        render_component(&UIComponents.messages_indicator/1, %{
+          unread_count: 0,
+          href: ~p"/provider/messages"
+        })
+
+      assert html =~ ~s|href="/provider/messages"|
+    end
+
+    test "renders unread badge when count > 0" do
+      html =
+        render_component(&UIComponents.messages_indicator/1, %{
+          unread_count: 5
+        })
+
+      assert html =~ "5"
+    end
+
+    test "caps unread badge at 99" do
+      html =
+        render_component(&UIComponents.messages_indicator/1, %{
+          unread_count: 150
+        })
+
+      assert html =~ "99"
+    end
+
+    test "hides badge when unread count is 0" do
+      html =
+        render_component(&UIComponents.messages_indicator/1, %{
+          unread_count: 0
+        })
+
+      refute html =~ "badge" or html =~ "bg-prime-magenta"
+    end
+  end
+end


### PR DESCRIPTION
Closes #155

## Summary
- Added `href` attr to `messages_indicator` component (defaults to `/messages`)
- Layout now checks `intended_roles` to route providers to `/provider/messages` in both navbar and mobile sidebar
- Added component tests for `messages_indicator`

## Test plan
- [x] `mix precommit` passes (1993 tests, 0 failures)
- [x] Playwright: logged in as provider, messages icon navigates to `/provider/messages`