### PR TITLE
fix: normalize qualifications string before changeset in validate_staff

### DIFF
--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -232,6 +232,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
   @impl true
   def handle_event("validate_staff", %{"staff_member_schema" => params}, socket) do
+    params = normalize_staff_form_params(params)
+
     changeset =
       case socket.assigns.editing_staff_id do
         nil ->
@@ -1039,6 +1041,13 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   end
 
   defp parse_qualifications(quals) when is_list(quals), do: quals
+
+  # Trigger: validate_staff sends raw form params with qualifications as a comma-separated string
+  # Why: Ecto's cast rejects a plain string for {:array, :string} — must pre-parse before changeset
+  # Outcome: changeset receives a list, matching what atomize_staff_params does on the save path
+  defp normalize_staff_form_params(params) do
+    Map.put(params, "qualifications", parse_qualifications(params["qualifications"]))
+  end
 
   defp maybe_add_headshot(attrs, {:ok, url}), do: {:ok, Map.put(attrs, :headshot_url, url)}
   defp maybe_add_headshot(attrs, :no_upload), do: {:ok, attrs}

--- a/test/klass_hero_web/live/provider/dashboard_team_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_team_test.exs
@@ -307,5 +307,26 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
       assert html =~ "Team member added."
       refute html =~ "Please fix the errors below."
     end
+
+    test "validates qualifications as comma-separated string without cast error", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view |> element("#add-member-btn") |> render_click()
+
+      html =
+        view
+        |> form("#staff-form", %{
+          "staff_member_schema" => %{
+            "first_name" => "Alice",
+            "last_name" => "Smith",
+            "qualifications" => "First Aid, CPR"
+          }
+        })
+        |> render_change()
+
+      # No cast error on qualifications — the comma string was parsed to a list
+      refute html =~ "is invalid"
+      assert has_element?(view, "#staff-member-form")
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fix `validate_staff` event receiving qualifications as a comma-separated string, which Ecto's cast rejects for `{:array, :string}`
- Add `normalize_staff_form_params/1` to pre-parse the string into a list before changeset validation
- Add test covering the qualifications parsing path during form validation

## Test plan
- [x] `mix test test/klass_hero_web/live/provider/dashboard_team_test.exs` — 17 tests, 0 failures

Closes #142