### PR TITLE
chore: reinitialize beads with klass-hero prefix

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,37 +1,19 @@
-# SQLite databases
-*.db
-*.db?*
-*.db-journal
-*.db-wal
-*.db-shm
+# Dolt database (managed by Dolt, not git)
+dolt/
+dolt-access.lock
 
-# Daemon runtime files
-daemon.lock
-daemon.log
-daemon-*.log.gz
-daemon.pid
+# Runtime files
 bd.sock
+bd.sock.startlock
 sync-state.json
 last-touched
 
 # Local version tracking (prevents upgrade notification spam after git ops)
 .local_version
 
-# Legacy database files
-db.sqlite
-bd.db
-
 # Worktree redirect file (contains relative path to main repo's .beads/)
 # Must not be committed as paths would be wrong in other clones
 redirect
-
-# Merge artifacts (temporary files from 3-way merge)
-beads.base.jsonl
-beads.base.meta.json
-beads.left.jsonl
-beads.left.meta.json
-beads.right.jsonl
-beads.right.meta.json
 
 # Sync state (local-only, per-machine)
 # These files are machine-specific and should not be shared across clones
@@ -40,9 +22,30 @@ beads.right.meta.json
 sync_base.jsonl
 export-state/
 
-# Dolt database (managed by Dolt remotes, not git)
-dolt/
-dolt-access.lock
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+daemon.lock
+daemon.log
+daemon-*.log.gz
+daemon.pid
+beads.base.jsonl
+beads.base.meta.json
+beads.left.jsonl
+beads.left.meta.json
+beads.right.jsonl
+beads.right.meta.json
 
 # NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.
 # They would override fork protection in .git/info/exclude, allowing

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -19,20 +19,10 @@
 # Default actor for audit trails (overridden by BD_ACTOR or --actor)
 # actor: ""
 
-# Debounce interval for auto-flush (can also use BEADS_FLUSH_DEBOUNCE)
-# flush-debounce: "5s"
-
 # Export events (audit trail) to .beads/events.jsonl on each flush/sync
 # When enabled, new events are appended incrementally using a high-water mark.
 # Use 'bd export --events' to trigger manually regardless of this setting.
 # events-export: false
-
-# Git branch for beads commits (bd sync will commit to this branch)
-# IMPORTANT: Set this for team projects so all clones use the same sync branch.
-# This setting persists across clones (unlike database config which is gitignored).
-# Can also use BEADS_SYNC_BRANCH env var for local override.
-# If not set, bd sync will require you to run 'bd config set sync.branch <branch>'.
-sync-branch: "beads-sync"
 
 # Multi-repo configuration (experimental - bd-307)
 # Allows hydrating from multiple repositories and routing writes to the correct JSONL

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -2,5 +2,5 @@
   "database": "dolt",
   "jsonl_export": "issues.jsonl",
   "backend": "dolt",
-  "dolt_database": "beads_prime-youth"
+  "dolt_database": "beads_klass-hero"
 }


### PR DESCRIPTION
## Summary
- Cleaned up stale beads data and lock files from Dolt migration
- Reinitialized beads with `klass-hero` prefix on Dolt backend
- Issues will now be named `klass-hero-<hash>` instead of `prime-youth-<hash>`