### PR TITLE
refactor: extract shared normalize_subscription_tier from repositories

### DIFF
--- a/lib/klass_hero/family/adapters/driven/persistence/repositories/parent_profile_repository.ex
+++ b/lib/klass_hero/family/adapters/driven/persistence/repositories/parent_profile_repository.ex
@@ -22,6 +22,7 @@ defmodule KlassHero.Family.Adapters.Driven.Persistence.Repositories.ParentProfil
   alias KlassHero.Family.Adapters.Driven.Persistence.Schemas.ParentProfileSchema
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
+  alias KlassHero.Shared.Adapters.Driven.Persistence.MapperHelpers
   alias KlassHero.Shared.ErrorIds
 
   require Logger
@@ -36,7 +37,7 @@ defmodule KlassHero.Family.Adapters.Driven.Persistence.Repositories.ParentProfil
   - `{:error, changeset}` - Validation failure
   """
   def create_parent_profile(attrs) when is_map(attrs) do
-    schema_attrs = prepare_attrs_for_schema(attrs)
+    schema_attrs = MapperHelpers.normalize_subscription_tier(attrs)
 
     %ParentProfileSchema{}
     |> ParentProfileSchema.changeset(schema_attrs)
@@ -91,20 +92,5 @@ defmodule KlassHero.Family.Adapters.Driven.Persistence.Repositories.ParentProfil
     ParentProfileSchema
     |> where([p], p.identity_id == ^identity_id)
     |> Repo.exists?()
-  end
-
-  defp prepare_attrs_for_schema(attrs) do
-    attrs
-    |> maybe_convert_tier_to_string()
-  end
-
-  defp maybe_convert_tier_to_string(attrs) do
-    case Map.get(attrs, :subscription_tier) do
-      tier when is_atom(tier) and not is_nil(tier) ->
-        Map.put(attrs, :subscription_tier, Atom.to_string(tier))
-
-      _ ->
-        attrs
-    end
   end
 end

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/provider_profile_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/provider_profile_repository.ex
@@ -22,6 +22,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProviderPr
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProfileSchema
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
+  alias KlassHero.Shared.Adapters.Driven.Persistence.MapperHelpers
   alias KlassHero.Shared.ErrorIds
 
   require Logger
@@ -36,7 +37,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProviderPr
   - `{:error, changeset}` - Validation failure
   """
   def create_provider_profile(attrs) when is_map(attrs) do
-    schema_attrs = prepare_attrs_for_schema(attrs)
+    schema_attrs = MapperHelpers.normalize_subscription_tier(attrs)
 
     %ProviderProfileSchema{}
     |> ProviderProfileSchema.changeset(schema_attrs)
@@ -151,20 +152,5 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProviderPr
       |> Repo.all()
 
     {:ok, ids}
-  end
-
-  defp prepare_attrs_for_schema(attrs) do
-    attrs
-    |> maybe_convert_tier_to_string()
-  end
-
-  defp maybe_convert_tier_to_string(attrs) do
-    case Map.get(attrs, :subscription_tier) do
-      tier when is_atom(tier) and not is_nil(tier) ->
-        Map.put(attrs, :subscription_tier, Atom.to_string(tier))
-
-      _ ->
-        attrs
-    end
   end
 end

--- a/lib/klass_hero/shared/adapters/driven/persistence/mapper_helpers.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/mapper_helpers.ex
@@ -41,6 +41,22 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.MapperHelpers do
   def tier_to_string(tier, _default) when is_atom(tier), do: Atom.to_string(tier)
 
   @doc """
+  Converts :subscription_tier in an attrs map from atom to string.
+
+  No-op if the key is absent, nil, or already a string.
+  """
+  @spec normalize_subscription_tier(map()) :: map()
+  def normalize_subscription_tier(attrs) do
+    case Map.get(attrs, :subscription_tier) do
+      tier when is_atom(tier) and not is_nil(tier) ->
+        Map.put(attrs, :subscription_tier, Atom.to_string(tier))
+
+      _ ->
+        attrs
+    end
+  end
+
+  @doc """
   Conditionally adds an id to attrs map if the id is not nil.
   """
   @spec maybe_add_id(map(), String.t() | nil) :: map()


### PR DESCRIPTION
## Summary

- Added `normalize_subscription_tier/1` to `MapperHelpers` — converts `:subscription_tier` atom to string in an attrs map, no-op when absent/nil/already a string
- Replaced identical private `prepare_attrs_for_schema/1` and `maybe_convert_tier_to_string/1` in `ParentProfileRepository` and `ProviderProfileRepository` with the shared helper
- Removed 28 lines of duplicated code across two bounded contexts, net -12 lines

## Review Focus

- **Shared helper placement** — `normalize_subscription_tier/1` sits alongside existing `tier_to_string/2` and `string_to_tier/2` in `mapper_helpers.ex:48-57`, which is the established location for tier conversion utilities
- **Behavioral equivalence** — the extracted function is byte-for-byte identical to the removed private helpers; `parent_profile_repository.ex:40` and `provider_profile_repository.ex:40` now call the shared version
- **No new cross-context coupling** — both repositories already depend on `Shared.Adapters.Driven.Persistence.EctoErrorHelpers`; adding `MapperHelpers` follows the same pattern

Closes #220