### PR TITLE
fix: add active-state feedback to provider dashboard buttons

### DIFF
--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -666,7 +666,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             id="save-staff-btn"
             class={[
               "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow hover:bg-hero-yellow-dark",
-              "text-hero-charcoal font-semibold",
+              "text-hero-charcoal font-semibold active:scale-[0.98]",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -1140,7 +1140,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       class={[
         "w-full h-full min-h-[200px] border-2 border-dashed border-hero-grey-300",
         "flex flex-col items-center justify-center gap-2",
-        "text-hero-grey-400 hover:border-hero-cyan hover:text-hero-cyan",
+        "text-hero-grey-400 hover:border-hero-cyan hover:text-hero-cyan active:scale-[0.98]",
         Theme.rounded(:xl),
         Theme.transition(:normal),
         @class

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -1224,7 +1224,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
           phx-click="add_member"
           class={[
             "flex items-center gap-2 px-4 py-2 bg-hero-yellow hover:bg-hero-yellow-dark",
-            "text-hero-charcoal font-semibold",
+            "text-hero-charcoal font-semibold active:scale-[0.98]",
             Theme.rounded(:lg),
             Theme.transition(:normal)
           ]}


### PR DESCRIPTION
## Summary
- Adds `active:scale-[0.98]` to the 3 yellow buttons on the provider Team tab that lacked click/press visual feedback
- The "+ Add Team Member" header button, "Save Changes"/"Add Member" form submit button, and the dashed add-card button now depress on click

## Test plan
- [x] `mix precommit` passes (2742 tests, 0 failures)
- [x] Manually verify press feedback on provider dashboard Team tab buttons

Closes #143