### PR TITLE
fix: add security-events write permission to Security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,7 @@ env:
 
 permissions:
   security-events: write
+  contents: read
 
 jobs:
   sobelow:


### PR DESCRIPTION
## Summary
- Adds `permissions: security-events: write` to the Security workflow
- Fixes `Resource not accessible by integration` error on `upload-sarif` step for pushes to `main`

Closes #268

## Test plan
- [x] Merge to main and verify the Security workflow succeeds (specifically the "Upload SARIF results" step)