### PR TITLE
fix: normalize qualifications params in save error paths

### DIFF
--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -892,7 +892,9 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
       {:error, {:validation_error, _errors}} ->
         changeset =
-          Provider.new_staff_member_changeset(params)
+          params
+          |> normalize_staff_form_params()
+          |> Provider.new_staff_member_changeset()
           |> Map.put(:action, :validate)
 
         {:noreply,
@@ -939,7 +941,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     case Provider.get_staff_member(staff_id) do
       {:ok, staff} ->
         changeset =
-          Provider.change_staff_member(staff, params)
+          Provider.change_staff_member(staff, normalize_staff_form_params(params))
           |> Map.put(:action, :validate)
 
         {:noreply,

--- a/test/klass_hero_web/live/provider/dashboard_team_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_team_test.exs
@@ -308,6 +308,29 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
       refute html =~ "Please fix the errors below."
     end
 
+    test "no qualifications cast error when save fails with validation error", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view |> element("#add-member-btn") |> render_click()
+
+      # Submit with qualifications string but missing required first/last name
+      html =
+        view
+        |> form("#staff-form", %{
+          "staff_member_schema" => %{
+            "first_name" => "",
+            "last_name" => "",
+            "qualifications" => "First Aid, CPR"
+          }
+        })
+        |> render_submit()
+
+      # Qualifications should not show cast error — the string was normalized to a list
+      refute html =~ "is invalid"
+      # Actual validation errors should appear
+      assert html =~ "Please fix the errors below."
+    end
+
     test "validates qualifications as comma-separated string without cast error", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
 


### PR DESCRIPTION
## Summary

- Normalizes qualifications string→list in `save_new_staff` and `handle_staff_validation_error` error paths, fixing spurious "is invalid" cast error on the qualifications field when a save fails for other reasons (e.g. missing required fields)
- Reuses existing `normalize_staff_form_params/1` — same fix already applied to `validate_staff`
- Adds regression test that submits with qualifications string + missing required fields and asserts no cast error

Closes #141