### PR TITLE
fix: cast binary UUIDs to string in remediation script output

### DIFF
--- a/priv/repo/scripts/remediate_duplicate_children.exs
+++ b/priv/repo/scripts/remediate_duplicate_children.exs
@@ -72,8 +72,10 @@ else
       # Outcome: first-inserted child kept; newer duplicates merged into it.
       #   Relies on order_by: [asc: c.inserted_at] above to guarantee head = oldest.
       [survivor | duplicates] = children_in_group
-      IO.puts("  Survivor:   #{survivor.id} (#{survivor.inserted_at})")
-      for dup <- duplicates, do: IO.puts("  Duplicate:  #{dup.id} (#{dup.inserted_at})")
+      IO.puts("  Survivor:   #{Ecto.UUID.cast!(survivor.id)} (#{survivor.inserted_at})")
+
+      for dup <- duplicates,
+          do: IO.puts("  Duplicate:  #{Ecto.UUID.cast!(dup.id)} (#{dup.inserted_at})")
 
       if dry_run do
         :skipped


### PR DESCRIPTION
## Summary
- Fix crash in `priv/repo/scripts/remediate_duplicate_children.exs` where `IO.puts` on raw binary UUIDs causes `:no_translation` Erlang error
- Wrap survivor/duplicate ID output with `Ecto.UUID.cast!/1`

## Test plan
- [x] Seeded 3 duplicate children (case-insensitive name variants) with overlapping enrollments and conflicting consents on local dev DB
- [x] Dry run correctly identified 1 group, 3 copies, correct survivor
- [x] Execute run: merged fields, re-pointed 2 enrollments, deduplicated consents, deleted 2 duplicates
- [x] Post-run verification: single child with all enrollments, merged fields, no orphans
- [x] Cleaned up test data

Closes #299