### PR TITLE
refactor: deduplicate check-in/check-out attendance pipeline

### DIFF
--- a/lib/klass_hero/participation/application/use_cases/record_check_in.ex
+++ b/lib/klass_hero/participation/application/use_cases/record_check_in.ex
@@ -16,14 +16,6 @@ defmodule KlassHero.Participation.Application.UseCases.RecordCheckIn do
   alias KlassHero.Participation.Application.UseCases.Shared
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Participation.Domain.Models.ParticipationRecord
-  alias KlassHero.Shared.DomainEventBus
-
-  @context KlassHero.Participation
-
-  @participation_repository Application.compile_env!(:klass_hero, [
-                              :participation,
-                              :participation_repository
-                            ])
 
   @type params :: %{
           required(:record_id) => String.t(),
@@ -51,18 +43,12 @@ defmodule KlassHero.Participation.Application.UseCases.RecordCheckIn do
   """
   @spec execute(params()) :: result()
   def execute(%{record_id: record_id, checked_in_by: checked_in_by} = params) do
-    notes = params |> Map.get(:notes) |> Shared.normalize_notes()
-
-    with {:ok, record} <- @participation_repository.get_by_id(record_id),
-         {:ok, checked_in} <- ParticipationRecord.check_in(record, checked_in_by, notes),
-         {:ok, persisted} <- @participation_repository.update(checked_in) do
-      publish_event(persisted)
-      {:ok, persisted}
-    end
-  end
-
-  defp publish_event(record) do
-    event = ParticipationEvents.child_checked_in(record)
-    DomainEventBus.dispatch(@context, event)
+    Shared.run_attendance_action(
+      record_id,
+      checked_in_by,
+      Map.get(params, :notes),
+      &ParticipationRecord.check_in/3,
+      &ParticipationEvents.child_checked_in/1
+    )
   end
 end

--- a/lib/klass_hero/participation/application/use_cases/record_check_out.ex
+++ b/lib/klass_hero/participation/application/use_cases/record_check_out.ex
@@ -16,14 +16,6 @@ defmodule KlassHero.Participation.Application.UseCases.RecordCheckOut do
   alias KlassHero.Participation.Application.UseCases.Shared
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Participation.Domain.Models.ParticipationRecord
-  alias KlassHero.Shared.DomainEventBus
-
-  @context KlassHero.Participation
-
-  @participation_repository Application.compile_env!(:klass_hero, [
-                              :participation,
-                              :participation_repository
-                            ])
 
   @type params :: %{
           required(:record_id) => String.t(),
@@ -51,18 +43,12 @@ defmodule KlassHero.Participation.Application.UseCases.RecordCheckOut do
   """
   @spec execute(params()) :: result()
   def execute(%{record_id: record_id, checked_out_by: checked_out_by} = params) do
-    notes = params |> Map.get(:notes) |> Shared.normalize_notes()
-
-    with {:ok, record} <- @participation_repository.get_by_id(record_id),
-         {:ok, checked_out} <- ParticipationRecord.check_out(record, checked_out_by, notes),
-         {:ok, persisted} <- @participation_repository.update(checked_out) do
-      publish_event(persisted)
-      {:ok, persisted}
-    end
-  end
-
-  defp publish_event(record) do
-    event = ParticipationEvents.child_checked_out(record)
-    DomainEventBus.dispatch(@context, event)
+    Shared.run_attendance_action(
+      record_id,
+      checked_out_by,
+      Map.get(params, :notes),
+      &ParticipationRecord.check_out/3,
+      &ParticipationEvents.child_checked_out/1
+    )
   end
 end

--- a/lib/klass_hero/participation/application/use_cases/shared.ex
+++ b/lib/klass_hero/participation/application/use_cases/shared.ex
@@ -3,7 +3,18 @@ defmodule KlassHero.Participation.Application.UseCases.Shared do
   Shared utilities for Participation use cases.
   """
 
+  alias KlassHero.Participation.Domain.Models.ParticipationRecord
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+  alias KlassHero.Shared.DomainEventBus
+
   require Logger
+
+  @context KlassHero.Participation
+
+  @participation_repository Application.compile_env!(:klass_hero, [
+                              :participation,
+                              :participation_repository
+                            ])
 
   @doc """
   Normalizes notes by trimming whitespace and converting empty strings to nil.
@@ -26,6 +37,32 @@ defmodule KlassHero.Participation.Application.UseCases.Shared do
     case String.trim(notes) do
       "" -> nil
       trimmed -> trimmed
+    end
+  end
+
+  @doc """
+  Runs the shared attendance action pipeline: fetch → domain call → persist → publish event.
+
+  Accepts the domain function (e.g. `&ParticipationRecord.check_in/3`) and event function
+  (e.g. `&ParticipationEvents.child_checked_in/1`) to keep the pipeline generic while each
+  use case controls the specific action and event.
+  """
+  @type domain_fn ::
+          (ParticipationRecord.t(), String.t(), String.t() | nil ->
+             {:ok, ParticipationRecord.t()} | {:error, term()})
+  @type event_fn :: (ParticipationRecord.t() -> DomainEvent.t())
+
+  @spec run_attendance_action(String.t(), String.t(), String.t() | nil, domain_fn(), event_fn()) ::
+          {:ok, ParticipationRecord.t()} | {:error, term()}
+  def run_attendance_action(record_id, actor_id, notes, domain_fn, event_fn) do
+    notes = normalize_notes(notes)
+
+    with {:ok, record} <- @participation_repository.get_by_id(record_id),
+         {:ok, updated} <- domain_fn.(record, actor_id, notes),
+         {:ok, persisted} <- @participation_repository.update(updated) do
+      event = event_fn.(persisted)
+      DomainEventBus.dispatch(@context, event)
+      {:ok, persisted}
     end
   end
 


### PR DESCRIPTION
## Summary

- Extracted duplicate fetch-domain-persist-publish pipeline from `RecordCheckIn` and `RecordCheckOut` into `Shared.run_attendance_action/5`
- Removed duplicated `@participation_repository`, `@context`, and `DomainEventBus` alias from both use case modules
- Each use case now delegates to `Shared` passing its specific domain function (`check_in/3` or `check_out/3`) and event constructor
- Added precise `@type domain_fn` and `@type event_fn` typespecs instead of broad `function()` types
- Added `DomainEvent` alias to `Shared` for accurate typespec references

## Review Focus

- **Typespec precision** -- `shared.ex:43-46` defines `domain_fn` and `event_fn` types with exact signatures rather than `function()`, verify the arrow syntax is correct for Elixir typespecs
- **Function reference passing** -- `record_check_in.ex:46-50` and `record_check_out.ex:46-50` pass captured functions; confirm the arity and module references match the domain model API
- **Notes normalization moved** -- `normalize_notes/1` is now called inside `run_attendance_action/5` (`shared.ex:55`) instead of at the call site, meaning raw `Map.get(params, :notes)` (possibly nil) flows into `Shared` -- verify this is safe
- **No behavioral change** -- the pipeline order (get -> domain call -> update -> dispatch) is preserved identically; existing tests pass unchanged

## Test Plan

- [x] `mix precommit` (compile --warnings-as-errors, format, 2947 tests pass, 0 failures)
- [ ] Verify check-in flow works end-to-end via UI or LiveView test
- [ ] Verify check-out flow works end-to-end via UI or LiveView test

Closes #310