### PR TITLE
refactor: extract shared document_page component from legal pages

### DIFF
--- a/lib/klass_hero_web/components/composite_components.ex
+++ b/lib/klass_hero_web/components/composite_components.ex
@@ -671,10 +671,15 @@ defmodule KlassHeroWeb.CompositeComponents do
 
   Used for pages that display structured document sections (Terms of Service, Privacy Policy, etc.).
 
+  ## Security
+
+  Section `content` values are rendered with `raw/1` and must be trusted, pre-sanitized HTML
+  defined in application code. Never pass user-controlled input as section content.
+
   ## Examples
 
       <.document_page
-        gradient={Theme.gradient(:primary)}
+        gradient_class={Theme.gradient(:primary)}
         title={gettext("Terms of Service")}
         subtitle={gettext("Understanding our agreement with you")}
         last_updated="December 12, 2025"
@@ -683,7 +688,7 @@ defmodule KlassHeroWeb.CompositeComponents do
         cta_body={gettext("We're here to clarify any questions you may have.")}
       />
   """
-  attr :gradient, :string, required: true, doc: "Hero section gradient class"
+  attr :gradient_class, :string, required: true, doc: "Hero section gradient class"
   attr :title, :string, required: true, doc: "Page title (already translated)"
   attr :subtitle, :string, required: true, doc: "Page subtitle (already translated)"
   attr :last_updated, :string, required: true, doc: "Last updated date string"
@@ -700,7 +705,7 @@ defmodule KlassHeroWeb.CompositeComponents do
     <div class={["min-h-screen pb-20 md:pb-6", Theme.bg(:muted)]}>
       <.hero_section
         variant="page"
-        gradient_class={@gradient}
+        gradient_class={@gradient_class}
         show_back_button
       >
         <:title>{@title}</:title>

--- a/lib/klass_hero_web/live/privacy_policy_live.ex
+++ b/lib/klass_hero_web/live/privacy_policy_live.ex
@@ -231,7 +231,7 @@ defmodule KlassHeroWeb.PrivacyPolicyLive do
   def render(assigns) do
     ~H"""
     <.document_page
-      gradient={Theme.gradient(:cool)}
+      gradient_class={Theme.gradient(:cool)}
       title={gettext("Privacy Policy")}
       subtitle={gettext("Your privacy matters to us")}
       last_updated={last_updated()}

--- a/lib/klass_hero_web/live/terms_of_service_live.ex
+++ b/lib/klass_hero_web/live/terms_of_service_live.ex
@@ -264,7 +264,7 @@ defmodule KlassHeroWeb.TermsOfServiceLive do
   def render(assigns) do
     ~H"""
     <.document_page
-      gradient={Theme.gradient(:primary)}
+      gradient_class={Theme.gradient(:primary)}
       title={gettext("Terms of Service")}
       subtitle={gettext("Understanding our agreement with you")}
       last_updated={last_updated()}


### PR DESCRIPTION
## Summary

- Extracted a shared `document_page/1` function component into `CompositeComponents` that renders the full legal document page layout (hero, last-updated banner, table of contents, content sections, contact CTA)
- Replaced ~96 lines of near-identical HEEx in `TermsOfServiceLive.render/1` and `PrivacyPolicyLive.render/1` with a single `<.document_page />` call each
- Removed unused `UIComponents` alias from both LiveViews
- Added `import Phoenix.HTML, only: [raw: 1]` to `CompositeComponents` since it doesn't inherit global imports

## Review Focus

- **Component interface** -- the new `document_page/1` accepts 7 attrs (gradient, title, subtitle, last_updated, sections, cta_title, cta_body) at `composite_components.ex:685-696`. Translated strings are passed in from callers; universal labels (Table of Contents, Contact Us, Last Updated) use gettext inside the component
- **CTA gradient hardcoded to :primary** -- `composite_components.ex:773` keeps the CTA button gradient as `Theme.gradient(:primary)` regardless of the hero gradient. This is intentional (brand consistency for CTAs) and matches the original behavior in both pages
- **raw/1 import** -- `composite_components.ex:17` adds a targeted import since `CompositeComponents` uses `use Phoenix.Component` directly rather than going through `KlassHeroWeb` html_helpers which provides the global `Phoenix.HTML` import

## Test Plan

- [x] `mix precommit` passes (2947 tests, 0 failures, compile with --warnings-as-errors)
- [ ] Visual check: navigate to `/terms-of-service` and `/privacy-policy` to confirm identical rendering

Closes #300