### PR TITLE
refactor: extract publish-and-log boilerplate from PromoteIntegrationEvents

### DIFF
--- a/lib/klass_hero/enrollment/adapters/driven/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/events/event_handlers/promote_integration_events.ex
@@ -9,52 +9,26 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Events.EventHandlers.PromoteInteg
   alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.IntegrationEventPublishing
 
-  require Logger
-
   @spec handle(DomainEvent.t()) :: :ok | {:error, term()}
   def handle(%DomainEvent{event_type: :participant_policy_set} = event) do
     # Trigger: participant_policy_set domain event dispatched from SetParticipantPolicy use case
     # Why: other contexts may need to react to policy changes (e.g., search filtering)
     # Outcome: publish integration event on topic integration:enrollment:participant_policy_set
-    result =
-      event.aggregate_id
-      |> EnrollmentIntegrationEvents.participant_policy_set(event.payload)
-      |> IntegrationEventPublishing.publish()
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish participant_policy_set",
-          program_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        error
-    end
+    event.aggregate_id
+    |> EnrollmentIntegrationEvents.participant_policy_set(event.payload)
+    |> IntegrationEventPublishing.publish_critical("participant_policy_set",
+      program_id: event.aggregate_id
+    )
   end
 
   def handle(%DomainEvent{event_type: :invite_claimed} = event) do
     # Trigger: invite_claimed domain event dispatched when a guardian claims an invite link
     # Why: downstream contexts (Family, Accounts) need to react — create profiles, link users
     # Outcome: publish integration event on topic integration:enrollment:invite_claimed
-    result =
-      event.payload.invite_id
-      |> EnrollmentIntegrationEvents.invite_claimed(event.payload)
-      |> IntegrationEventPublishing.publish()
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish invite_claimed",
-          invite_id: event.payload.invite_id,
-          reason: inspect(reason)
-        )
-
-        error
-    end
+    event.payload.invite_id
+    |> EnrollmentIntegrationEvents.invite_claimed(event.payload)
+    |> IntegrationEventPublishing.publish_critical("invite_claimed",
+      invite_id: event.payload.invite_id
+    )
   end
 end

--- a/lib/klass_hero/messaging/adapters/driven/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/messaging/adapters/driven/events/event_handlers/promote_integration_events.ex
@@ -21,140 +21,71 @@ defmodule KlassHero.Messaging.Adapters.Driven.Events.EventHandlers.PromoteIntegr
   alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.IntegrationEventPublishing
 
-  require Logger
-
   @doc """
   Handles a domain event by promoting it to the corresponding integration event.
   """
   @spec handle(DomainEvent.t()) :: :ok | {:error, term()}
   def handle(%DomainEvent{event_type: :user_data_anonymized} = event) do
+    # Trigger: user_data_anonymized domain event received
+    # Why: downstream contexts need notification; but event is non-critical (state already durable)
+    # Outcome: best-effort publish; swallow failures and return :ok
     user_id = event.payload.user_id
 
-    integration_event = MessagingIntegrationEvents.message_data_anonymized(user_id)
-
-    case IntegrationEventPublishing.publish(integration_event) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        # Trigger: PubSub publish failed after transaction committed
-        # Why: data change is durable, integration event is best-effort notification
-        # Outcome: log warning, return :ok so bus reports success to use case
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish message_data_anonymized",
-          user_id: user_id,
-          reason: inspect(reason)
-        )
-
-        :ok
-    end
+    MessagingIntegrationEvents.message_data_anonymized(user_id)
+    |> IntegrationEventPublishing.publish_best_effort("message_data_anonymized",
+      user_id: user_id
+    )
   end
 
   def handle(%DomainEvent{event_type: :conversation_created} = event) do
     # Trigger: conversation_created domain event dispatched from CreateDirectConversation use case
     # Why: CQRS projections need this to build denormalized conversation summaries
     # Outcome: publish integration event; propagate failure so use case is aware
-    result =
-      event.aggregate_id
-      |> MessagingIntegrationEvents.conversation_created(event.payload)
-      |> IntegrationEventPublishing.publish()
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish conversation_created",
-          conversation_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        error
-    end
+    event.aggregate_id
+    |> MessagingIntegrationEvents.conversation_created(event.payload)
+    |> IntegrationEventPublishing.publish_critical("conversation_created",
+      conversation_id: event.aggregate_id
+    )
   end
 
   def handle(%DomainEvent{event_type: :message_sent} = event) do
     # Trigger: message_sent domain event dispatched from SendMessage use case
     # Why: CQRS projections need this to update last-message summaries and unread counts
     # Outcome: publish integration event; propagate failure so use case is aware
-    result =
-      event.aggregate_id
-      |> MessagingIntegrationEvents.message_sent(event.payload)
-      |> IntegrationEventPublishing.publish()
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish message_sent",
-          conversation_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        error
-    end
+    event.aggregate_id
+    |> MessagingIntegrationEvents.message_sent(event.payload)
+    |> IntegrationEventPublishing.publish_critical("message_sent",
+      conversation_id: event.aggregate_id
+    )
   end
 
   def handle(%DomainEvent{event_type: :messages_read} = event) do
     # Trigger: messages_read domain event dispatched from MarkAsRead use case
     # Why: CQRS projections use this to update unread counts
     # Outcome: best-effort publish; swallow failure since read-receipt is non-critical
-    integration_event =
-      MessagingIntegrationEvents.messages_read(event.aggregate_id, event.payload)
-
-    case IntegrationEventPublishing.publish(integration_event) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish messages_read",
-          conversation_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        :ok
-    end
+    MessagingIntegrationEvents.messages_read(event.aggregate_id, event.payload)
+    |> IntegrationEventPublishing.publish_best_effort("messages_read",
+      conversation_id: event.aggregate_id
+    )
   end
 
   def handle(%DomainEvent{event_type: :conversation_archived} = event) do
     # Trigger: conversation_archived domain event dispatched from archive use case
     # Why: CQRS projections use this to mark conversations as archived
     # Outcome: best-effort publish; swallow failure since archive status is non-critical
-    integration_event =
-      MessagingIntegrationEvents.conversation_archived(event.aggregate_id, event.payload)
-
-    case IntegrationEventPublishing.publish(integration_event) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish conversation_archived",
-          conversation_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        :ok
-    end
+    MessagingIntegrationEvents.conversation_archived(event.aggregate_id, event.payload)
+    |> IntegrationEventPublishing.publish_best_effort("conversation_archived",
+      conversation_id: event.aggregate_id
+    )
   end
 
   def handle(%DomainEvent{event_type: :conversations_archived} = event) do
     # Trigger: conversations_archived domain event dispatched from bulk archive use case
     # Why: CQRS projections use this to mark multiple conversations as archived
     # Outcome: best-effort publish; swallow failure since bulk archive status is non-critical
-    integration_event =
-      MessagingIntegrationEvents.conversations_archived(event.aggregate_id, event.payload)
-
-    case IntegrationEventPublishing.publish(integration_event) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish conversations_archived",
-          aggregate_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        :ok
-    end
+    MessagingIntegrationEvents.conversations_archived(event.aggregate_id, event.payload)
+    |> IntegrationEventPublishing.publish_best_effort("conversations_archived",
+      aggregate_id: event.aggregate_id
+    )
   end
 end

--- a/lib/klass_hero/program_catalog/adapters/driven/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/program_catalog/adapters/driven/events/event_handlers/promote_integration_events.ex
@@ -9,52 +9,26 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Events.EventHandlers.PromoteI
   alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.IntegrationEventPublishing
 
-  require Logger
-
   @spec handle(DomainEvent.t()) :: :ok | {:error, term()}
   def handle(%DomainEvent{event_type: :program_created} = event) do
     # Trigger: program_created domain event dispatched from CreateProgram use case
     # Why: other contexts may need to react to new programs
     # Outcome: publish integration event on PubSub topic integration:program_catalog:program_created
-    result =
-      event.aggregate_id
-      |> ProgramCatalogIntegrationEvents.program_created(event.payload)
-      |> IntegrationEventPublishing.publish()
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish program_created",
-          program_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        error
-    end
+    event.aggregate_id
+    |> ProgramCatalogIntegrationEvents.program_created(event.payload)
+    |> IntegrationEventPublishing.publish_critical("program_created",
+      program_id: event.aggregate_id
+    )
   end
 
   def handle(%DomainEvent{event_type: :program_updated} = event) do
     # Trigger: program_updated domain event dispatched from UpdateProgram use case
     # Why: other contexts may need to react to program changes (e.g., refresh read models)
     # Outcome: publish integration event on PubSub topic integration:program_catalog:program_updated
-    result =
-      event.aggregate_id
-      |> ProgramCatalogIntegrationEvents.program_updated(event.payload)
-      |> IntegrationEventPublishing.publish()
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Logger.warning("[PromoteIntegrationEvents] Failed to publish program_updated",
-          program_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        error
-    end
+    event.aggregate_id
+    |> ProgramCatalogIntegrationEvents.program_updated(event.payload)
+    |> IntegrationEventPublishing.publish_critical("program_updated",
+      program_id: event.aggregate_id
+    )
   end
 end

--- a/lib/klass_hero/provider/adapters/driven/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/provider/adapters/driven/events/event_handlers/promote_integration_events.ex
@@ -9,30 +9,15 @@ defmodule KlassHero.Provider.Adapters.Driven.Events.EventHandlers.PromoteIntegra
   alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.IntegrationEventPublishing
 
-  require Logger
-
   @spec handle(DomainEvent.t()) :: :ok | {:error, term()}
   def handle(%DomainEvent{event_type: :subscription_tier_changed} = event) do
     # Trigger: subscription_tier_changed domain event dispatched from ChangeSubscriptionTier use case
     # Why: other contexts (e.g., Entitlements) need to react to tier changes
     # Outcome: publish integration event on topic integration:provider:subscription_tier_changed
-    result =
-      event.aggregate_id
-      |> ProviderIntegrationEvents.subscription_tier_changed(event.payload)
-      |> IntegrationEventPublishing.publish()
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Logger.warning(
-          "[PromoteIntegrationEvents] Failed to publish subscription_tier_changed",
-          provider_id: event.aggregate_id,
-          reason: inspect(reason)
-        )
-
-        error
-    end
+    event.aggregate_id
+    |> ProviderIntegrationEvents.subscription_tier_changed(event.payload)
+    |> IntegrationEventPublishing.publish_critical("subscription_tier_changed",
+      provider_id: event.aggregate_id
+    )
   end
 end

--- a/lib/klass_hero/shared/integration_event_publishing.ex
+++ b/lib/klass_hero/shared/integration_event_publishing.ex
@@ -32,6 +32,8 @@ defmodule KlassHero.Shared.IntegrationEventPublishing do
 
   alias KlassHero.Shared.Adapters.Driven.Events.PubSubIntegrationEventPublisher
 
+  require Logger
+
   @doc """
   Returns the configured integration event publisher module.
 
@@ -59,5 +61,62 @@ defmodule KlassHero.Shared.IntegrationEventPublishing do
   @spec publish(struct()) :: :ok | {:error, term()}
   def publish(event) do
     publisher_module().publish(event)
+  end
+
+  @doc """
+  Publishes an integration event and propagates failures.
+
+  Logs a warning on failure with the given label and metadata fields,
+  then returns the `{:error, reason}` tuple so the caller can react.
+
+  ## Parameters
+
+  - `event` - The integration event struct to publish
+  - `label` - Event name for the log message (e.g. `"program_created"`)
+  - `log_fields` - Extra keyword metadata for the log entry (default: `[]`)
+  """
+  @spec publish_critical(struct(), String.t(), keyword()) :: :ok | {:error, term()}
+  def publish_critical(event, label, log_fields \\ []) do
+    case publish(event) do
+      :ok ->
+        :ok
+
+      {:error, reason} = error ->
+        Logger.warning(
+          "[PromoteIntegrationEvents] Failed to publish #{label}",
+          Keyword.put(log_fields, :reason, inspect(reason))
+        )
+
+        error
+    end
+  end
+
+  @doc """
+  Publishes an integration event, swallowing failures.
+
+  Logs a warning on failure with the given label and metadata fields,
+  but always returns `:ok`. Use for non-critical notifications where
+  the underlying state change is already durable.
+
+  ## Parameters
+
+  - `event` - The integration event struct to publish
+  - `label` - Event name for the log message (e.g. `"messages_read"`)
+  - `log_fields` - Extra keyword metadata for the log entry (default: `[]`)
+  """
+  @spec publish_best_effort(struct(), String.t(), keyword()) :: :ok
+  def publish_best_effort(event, label, log_fields \\ []) do
+    case publish(event) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[PromoteIntegrationEvents] Failed to publish #{label}",
+          Keyword.put(log_fields, :reason, inspect(reason))
+        )
+
+        :ok
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Added `publish_critical/3` and `publish_best_effort/3` helpers to `IntegrationEventPublishing` that centralize the case/Logger pattern for integration event publishing (`integration_event_publishing.ex:79-121`)
- Replaced 11 duplicated case/Logger blocks across 4 handler files with calls to the new helpers, removing `require Logger` from each
- Refactored Enrollment (2 critical), Provider (1 critical), ProgramCatalog (2 critical), and Messaging (2 critical + 4 best-effort) handlers
- Fixed misleading comment on `user_data_anonymized` handler that was copied from the error branch (`messaging/.../promote_integration_events.ex:30-32`)
- Net reduction: -190 lines added / +113 lines = 77 fewer lines across 5 files

## Review Focus

- **Two helper variants** -- `publish_critical/3` propagates `{:error, reason}` while `publish_best_effort/3` swallows errors and returns `:ok`. Verify the correct variant is used for each handler (`integration_event_publishing.ex:79-92` vs `108-121`)
- **Log metadata passthrough** -- `log_fields` keyword list is merged with `:reason` via `Keyword.put/3`. Confirm callers pass the right context keys (e.g. `program_id`, `conversation_id`, `user_id`) matching the previous inline Logger calls
- **Messaging handler error strategy** -- Critical vs best-effort classification matches the moduledoc (`messaging/.../promote_integration_events.ex:9-17`): `conversation_created` and `message_sent` are critical; `user_data_anonymized`, `messages_read`, `conversation_archived`, `conversations_archived` are best-effort

## Test Plan

- [x] `mix precommit` -- compile with `--warnings-as-errors`, format, full test suite (2947 tests, 0 failures)
- [x] Handler-specific tests across all 4 contexts (21 tests, 0 failures)
- [ ] Verify log output format matches previous behavior (structured metadata with `:reason` field)