### PR TITLE
feat: rebrand instructor section to Hero terminology

### DIFF
--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -395,11 +395,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
             <div class={["p-4 border-b", Theme.border_color(:light)]}>
               <h3 class={["font-semibold flex items-center gap-2", Theme.text_color(:heading)]}>
                 <.icon name="hero-user" class="w-5 h-5 text-hero-blue-500" />
-                <%= if length(@team_members) > 1 do %>
-                  {gettext("Meet the Heroes")}
-                <% else %>
-                  {gettext("Meet the Hero")}
-                <% end %>
+                {ngettext("Meet the Hero", "Meet the Heroes", length(@team_members))}
               </h3>
             </div>
             <div class="p-6">

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -291,10 +291,12 @@ msgstr "Mehr Programme laden"
 msgid "Loading..."
 msgstr "Laden..."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:401
+#: lib/klass_hero_web/live/program_detail_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
-msgstr "Triff den Helden"
+msgid_plural "Meet the Heroes"
+msgstr[0] "Triff den Helden"
+msgstr[1] "Triff die Helden"
 
 #: lib/klass_hero_web/live/programs_live.ex:343
 #, elixir-autogen, elixir-format
@@ -3088,10 +3090,6 @@ msgstr ""
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:399
-#, elixir-autogen, elixir-format
-msgid "Meet the Heroes"
-msgstr "Triff die Helden"
 
 #: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -291,10 +291,12 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:401
+#: lib/klass_hero_web/live/program_detail_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
-msgstr ""
+msgid_plural "Meet the Heroes"
+msgstr[0] ""
+msgstr[1] ""
 
 #: lib/klass_hero_web/live/programs_live.ex:343
 #, elixir-autogen, elixir-format
@@ -3084,10 +3086,6 @@ msgstr ""
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:399
-#, elixir-autogen, elixir-format
-msgid "Meet the Heroes"
-msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -291,10 +291,12 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:401
+#: lib/klass_hero_web/live/program_detail_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
-msgstr ""
+msgid_plural "Meet the Heroes"
+msgstr[0] ""
+msgstr[1] ""
 
 #: lib/klass_hero_web/live/programs_live.ex:343
 #, elixir-autogen, elixir-format
@@ -3088,10 +3090,6 @@ msgstr ""
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:399
-#, elixir-autogen, elixir-format
-msgid "Meet the Heroes"
-msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -197,6 +197,31 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       assert has_element?(view, "h3", "Meet the Hero")
     end
 
+    test "program with multiple staff shows plural heading", %{conn: conn} do
+      provider = provider_profile_fixture()
+
+      program =
+        insert(:program_schema, provider_id: provider.id, title: "STEM Camp")
+
+      staff_member_fixture(
+        provider_id: provider.id,
+        first_name: "Alice",
+        last_name: "Johnson",
+        role: "Instructor"
+      )
+
+      staff_member_fixture(
+        provider_id: provider.id,
+        first_name: "Bob",
+        last_name: "Williams",
+        role: "Assistant Instructor"
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "h3", "Meet the Heroes")
+    end
+
     test "program without staff hides instructor section", %{conn: conn} do
       program = insert(:program_schema, title: "Art Class")
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")


### PR DESCRIPTION
## Summary

- Renamed "Meet the Team" heading to "Meet the Heroes" (plural, multiple staff) in `program_detail_live.ex:399`
- Renamed "Meet Your Instructor" heading to "Meet the Hero" (singular, one staff) in `program_detail_live.ex:401`
- Updated Gettext msgids in POT and PO files (en, de) to match new strings
- Added German translations: "Triff den Helden" (singular) and "Triff die Helden" (plural)
- Updated test assertions in `program_detail_live_test.exs` for both singular and plural cases

## Review Focus

- **Gettext msgid consistency** -- verify the same msgid strings appear across all three Gettext files (`default.pot:296`, `en/default.po:296`, `de/default.po:296` for singular; `:3089`/`:3093` for plural)
- **German translations** -- "Triff den Helden" / "Triff die Helden" at `de/default.po:297` and `de/default.po:3093`
- **Singular/plural logic preserved** -- the `length(@team_members) > 1` conditional at `program_detail_live.ex:398` is unchanged

## Test Plan

- [x] `mix precommit` -- compile (warnings-as-errors), format, full test suite (2962 tests, 0 failures)
- [x] Verify program detail page with 0 staff members (section hidden)
- [x] Verify program detail page with 1 staff member (shows "Meet the Hero")
- [x] Verify program detail page with 2+ staff members (shows "Meet the Heroes")

Closes #297