### PR TITLE
fix: show starter message at 0% weekly activity goal

### DIFF
--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -57,12 +57,13 @@ defmodule KlassHeroWeb.DashboardLive do
 
   defp calculate_activity_goal(children) do
     goal = Family.calculate_activity_goal(children)
-    Map.put(goal, :message, goal_message(goal.status))
+    Map.put(goal, :message, goal_message(goal.status, goal.percentage))
   end
 
-  defp goal_message(:achieved), do: gettext("Congratulations! Goal achieved!")
-  defp goal_message(:almost_there), do: gettext("Almost there! One more to go!")
-  defp goal_message(:in_progress), do: gettext("You're doing great! Keep it up!")
+  defp goal_message(:achieved, _percentage), do: gettext("Congratulations! Goal achieved!")
+  defp goal_message(:almost_there, _percentage), do: gettext("Almost there! One more to go!")
+  defp goal_message(:in_progress, 0), do: gettext("You're just getting started!")
+  defp goal_message(:in_progress, _percentage), do: gettext("You're doing great! Keep it up!")
 
   defp assign_booking_usage_info(socket) do
     identity_id = socket.assigns.user.id

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1831,6 +1831,11 @@ msgstr "Wöchentliches Aktivitätsziel"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:65
 #, elixir-autogen, elixir-format
+msgid "You're just getting started!"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:66
+#, elixir-autogen, elixir-format
 msgid "You're doing great! Keep it up!"
 msgstr "Du machst das großartig! Weiter so!"
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1831,6 +1831,11 @@ msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:65
 #, elixir-autogen, elixir-format
+msgid "You're just getting started!"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:66
+#, elixir-autogen, elixir-format
 msgid "You're doing great! Keep it up!"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1831,6 +1831,11 @@ msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:65
 #, elixir-autogen, elixir-format
+msgid "You're just getting started!"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:66
+#, elixir-autogen, elixir-format
 msgid "You're doing great! Keep it up!"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- Split `goal_message/1` into `goal_message/2` with percentage parameter in `DashboardLive`
- At 0% progress: displays "You're just getting started!" instead of "You're doing great! Keep it up!"
- All other percentage thresholds (1-79%, 80-99%, 100%) unchanged

## Test plan
- [x] `mix precommit` passes (3006 tests, 0 failures)
- [x] Verify on `/dashboard` with a user who has 0 sessions this week

Closes #226