### PR TITLE
fix: allow minor version bumps for feat commits in pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "elixir",
   "separate-pull-requests": false,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "include-component-in-tag": false,
   "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [


### PR DESCRIPTION
## Summary

- Set `bump-patch-for-minor-pre-major` to `false` in `release-please-config.json`
- Previously, `feat:` commits were treated as patch bumps while on 0.x.x due to this flag being `true`
- With this change, `feat:` commits now correctly bump the minor version (e.g. 0.1.14 -> 0.2.0)
- `bump-minor-pre-major` remains `true` to prevent accidental 1.0.0 bumps from breaking changes

## Review Focus

- **Versioning behavior change** — `release-please-config.json:6` flips `bump-patch-for-minor-pre-major` from `true` to `false`. This means the next `feat:` merge will produce a minor bump instead of a patch bump. Verify this is the desired semver behavior for the project's current stage.

## Test Plan

- [x] `mix precommit`
- [ ] After merging, merge a `feat:` PR to main and verify release-please opens a release PR with a minor version bump (e.g. 0.2.0, not 0.1.15)