### PR TITLE
refactor: extract duplicate unique constraint check to shared EctoErrorHelpers

### DIFF
--- a/lib/klass_hero/family/adapters/driven/persistence/repositories/consent_repository.ex
+++ b/lib/klass_hero/family/adapters/driven/persistence/repositories/consent_repository.ex
@@ -17,6 +17,7 @@ defmodule KlassHero.Family.Adapters.Driven.Persistence.Repositories.ConsentRepos
   alias KlassHero.Family.Adapters.Driven.Persistence.Mappers.ConsentMapper
   alias KlassHero.Family.Adapters.Driven.Persistence.Schemas.ConsentSchema
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias KlassHero.Shared.Adapters.Driven.Persistence.MapperHelpers
 
   require Logger
@@ -33,7 +34,7 @@ defmodule KlassHero.Family.Adapters.Driven.Persistence.Repositories.ConsentRepos
         # Trigger: unique partial index on (child_id, consent_type) WHERE withdrawn_at IS NULL
         # Why: prevent duplicate active consents for the same child and type
         # Outcome: return domain-specific :already_active error
-        if has_unique_constraint_error?(changeset.errors) do
+        if EctoErrorHelpers.any_unique_constraint_violation?(changeset.errors) do
           {:error, :already_active}
         else
           Logger.warning(
@@ -125,13 +126,6 @@ defmodule KlassHero.Family.Adapters.Driven.Persistence.Repositories.ConsentRepos
       |> Repo.delete_all()
 
     {:ok, count}
-  end
-
-  defp has_unique_constraint_error?(errors) do
-    Enum.any?(errors, fn
-      {_field, {_msg, opts}} -> Keyword.get(opts, :constraint) == :unique
-      _ -> false
-    end)
   end
 
   defp get_schema(consent_id) do

--- a/lib/klass_hero/participation/adapters/driven/persistence/repositories/behavioral_note_repository.ex
+++ b/lib/klass_hero/participation/adapters/driven/persistence/repositories/behavioral_note_repository.ex
@@ -14,6 +14,7 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Behav
   alias KlassHero.Participation.Adapters.Driven.Persistence.Schemas.BehavioralNoteSchema
   alias KlassHero.Participation.Domain.Models.BehavioralNote
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
 
   require Logger
 
@@ -163,7 +164,7 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Behav
     # Trigger: unique constraint violation on [participation_record_id, provider_id]
     # Why: one note per provider per participation record
     # Outcome: return domain-specific error atom
-    if has_unique_constraint_error?(errors) do
+    if EctoErrorHelpers.any_unique_constraint_violation?(errors) do
       {:error, :duplicate_note}
     else
       Logger.warning("[BehavioralNoteRepository] Validation failed on insert",
@@ -184,13 +185,6 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Behav
     )
 
     {:error, :validation_failed}
-  end
-
-  defp has_unique_constraint_error?(errors) do
-    Enum.any?(errors, fn
-      {_field, {_msg, opts}} -> Keyword.get(opts, :constraint) == :unique
-      _ -> false
-    end)
   end
 
   defp convert_enum_fields(attrs) do

--- a/lib/klass_hero/participation/adapters/driven/persistence/repositories/session_repository.ex
+++ b/lib/klass_hero/participation/adapters/driven/persistence/repositories/session_repository.ex
@@ -14,6 +14,7 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Sessi
   alias KlassHero.Participation.Domain.Models.ProgramSession
   alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramSchema
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias KlassHero.Shared.ErrorIds
 
   @impl true
@@ -96,7 +97,7 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Sessi
   end
 
   defp handle_insert_result({:error, %Ecto.Changeset{errors: errors} = changeset}) do
-    if has_unique_constraint_error?(errors) do
+    if EctoErrorHelpers.any_unique_constraint_violation?(errors) do
       {:error, :duplicate_session}
     else
       {:error, ErrorIds.session_create_failed(changeset)}
@@ -113,11 +114,5 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Sessi
     else
       {:error, ErrorIds.session_update_failed(changeset)}
     end
-  end
-
-  defp has_unique_constraint_error?(errors) do
-    Enum.any?(errors, fn {_field, {_msg, opts}} ->
-      opts[:constraint] == :unique
-    end)
   end
 end

--- a/lib/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers.ex
@@ -68,6 +68,39 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers do
   end
 
   @doc """
+  Detects if any field has a unique constraint violation.
+
+  Unlike `unique_constraint_violation?/2`, this does not check a specific field —
+  it returns true if any error in the list is a unique constraint violation.
+
+  ## Parameters
+
+  - `errors` - List of Ecto changeset errors in format `[{field, {message, opts}}]`
+
+  ## Returns
+
+  - `true` if any field has a unique constraint violation
+  - `false` otherwise
+
+  ## Examples
+
+      errors = [{:email, {"has already been taken", [constraint: :unique]}}]
+      any_unique_constraint_violation?(errors)
+      # => true
+
+      errors = [{:email, {"is invalid", []}}]
+      any_unique_constraint_violation?(errors)
+      # => false
+  """
+  @spec any_unique_constraint_violation?(errors :: [{atom(), {String.t(), Keyword.t()}}]) ::
+          boolean()
+  def any_unique_constraint_violation?(errors) when is_list(errors) do
+    Enum.any?(errors, fn {_field, {_message, opts}} ->
+      Keyword.get(opts, :constraint) == :unique
+    end)
+  end
+
+  @doc """
   Detects if a specific field has a foreign key constraint violation.
 
   ## Parameters

--- a/test/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers_test.exs
+++ b/test/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers_test.exs
@@ -55,6 +55,40 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpersTest do
     end
   end
 
+  describe "any_unique_constraint_violation?/1" do
+    test "returns true when a unique constraint violation exists" do
+      errors = [{:email, {"has already been taken", [constraint: :unique]}}]
+
+      assert EctoErrorHelpers.any_unique_constraint_violation?(errors)
+    end
+
+    test "returns true when unique constraint exists among multiple errors" do
+      errors = [
+        {:name, {"can't be blank", []}},
+        {:email, {"has already been taken", [constraint: :unique]}},
+        {:age, {"must be a number", []}}
+      ]
+
+      assert EctoErrorHelpers.any_unique_constraint_violation?(errors)
+    end
+
+    test "returns false when no constraint violations exist" do
+      errors = [{:email, {"is invalid", []}}]
+
+      refute EctoErrorHelpers.any_unique_constraint_violation?(errors)
+    end
+
+    test "returns false when constraint type is different" do
+      errors = [{:user_id, {"does not exist", [constraint: :foreign]}}]
+
+      refute EctoErrorHelpers.any_unique_constraint_violation?(errors)
+    end
+
+    test "returns false for empty error list" do
+      refute EctoErrorHelpers.any_unique_constraint_violation?([])
+    end
+  end
+
   describe "foreign_key_violation?/2" do
     test "returns true when foreign key constraint violation exists for specified field" do
       errors = [{:user_id, {"does not exist", [constraint: :foreign]}}]


### PR DESCRIPTION
## Summary

- Added `any_unique_constraint_violation?/1` to `EctoErrorHelpers` — a field-agnostic variant of the existing `unique_constraint_violation?/2`
- Removed duplicate private `has_unique_constraint_error?/1` from `ConsentRepository`, `SessionRepository`, and `BehavioralNoteRepository`
- Each repository now aliases and calls the shared `EctoErrorHelpers` module (consistent with how `EnrollmentRepository`, `ProviderProfileRepository`, and `ParentProfileRepository` already use it)
- Added 5 unit tests for the new function covering positive, negative, and edge cases

## Review Focus

- **New shared function implementation** — `ecto_error_helpers.ex:99-101` uses `Keyword.get(opts, :constraint)` (consistent with existing `constraint_violation?/3` at line 138) and omits catch-all clause (Ecto errors always follow `{field, {msg, opts}}` format)
- **Behavioral equivalence** — the removed `session_repository.ex` variant used `opts[:constraint]` (Access syntax) while the other two used `Keyword.get`; both are semantically identical but the shared version standardizes on `Keyword.get`
- **No functional changes** — each call site returns the same domain-specific error atoms (`:already_active`, `:duplicate_session`, `:duplicate_note`) as before

## Test Plan

- [x] `mix precommit` passes (3154 tests, 0 failures)
- [ ] Verify consent grant with duplicate active consent returns `:already_active`
- [ ] Verify duplicate session insert returns `:duplicate_session`
- [ ] Verify duplicate behavioral note insert returns `:duplicate_note`

Closes #403