### PR TITLE
feat: add empty state message to admin sessions list

### DIFF
--- a/docs/reports/test-drive-2026-03-14.md
+++ b/docs/reports/test-drive-2026-03-14.md
@@ -1,0 +1,79 @@
+# Test Drive Report - 2026-03-14
+
+## Scope
+- **Mode:** existing feature on `main` (no branch diff)
+- **Routes:** `/admin/sessions` (index), `/admin/sessions/:id` (show)
+- **Key files:** `sessions_live.ex`, `sessions_live.html.heex`, `searchable_select.ex`, `participation.ex`, `admin/queries.ex`
+
+## Backend Checks
+
+### Passed
+- `Admin.Queries.list_providers_for_select/0` returns 8 providers with `%{id, label}` shape
+- `Admin.Queries.list_programs_for_select/0` returns 20 programs with `%{id, label, provider_id}` shape
+- `Participation.session_statuses/0` returns `[:scheduled, :in_progress, :completed, :cancelled]`
+- `Participation.record_statuses/0` returns `[:registered, :checked_in, :checked_out, :absent]`
+- `Participation.list_admin_sessions(%{})` defaults to today, returns correct shape with `checked_in_count`/`total_count`
+- `Participation.list_admin_sessions(%{date_from, date_to})` date range returns 22 sessions across 2 weeks
+- `Participation.get_session_with_roster_enriched/1` returns full session with `participation_records`, child names, behavioral notes
+- `Participation.get_session_with_roster_enriched/1` returns `{:error, :not_found}` for non-existent UUID
+- `Participation.correct_attendance/1` — `:reason_required` validation works (empty reason)
+- `Participation.correct_attendance/1` — `:no_changes` validation works (reason only, no field changes)
+- `Participation.correct_attendance/1` — `:check_out_requires_check_in` validation works
+- No N+1 queries: roster uses batch child name resolution from Family context
+
+### Issues Found
+- None
+
+## UI Checks
+
+### Pages Tested
+
+#### Index (`/admin/sessions`) — PASS
+- Page loads with correct heading, filter bar, admin layout
+- **Provider filter:** searchable dropdown with autocomplete, case-insensitive substring match, clear button (x)
+- **Provider → Program cascade:** selecting Wolf Musik Akademie filters programs to 4 (Art & Music Fusion, Children's Choir, Music Theory Essentials, Piano for Beginners) and sessions to 3
+- **Clearing provider:** restores all programs and sessions
+- **Date filter:** changing From/To dates updates session list live (debounced 300ms)
+- **Reset dates button (↻):** resets both dates to today
+- **Status filter:** selecting "Completed" shows empty list (correct — all 2026-03-12 sessions are "Scheduled")
+- **Session cards:** display program name, provider name, date, time range, status badge, check-in count / total count
+- **Session card click:** navigates to show view via `navigate` (full page transition)
+
+#### Show (`/admin/sessions/:id`) — PASS
+- Header: program name, date, time range, status badge ("In Progress")
+- Back link: "← Back to sessions" navigates to index
+- Roster table: 6 columns (Child, Status, Check-in, Check-out, Notes, Correct button)
+- Status badges: correct color coding (Checked In = green, Registered = ghost)
+- Time formatting: HH:MM format, "—" for nil values
+- Notes column: shows "Approved" for children with approved behavioral notes
+
+#### Correction Flow — PASS
+- "Correct" button opens inline form below the target child's row
+- Form has: Status dropdown (No change + 4 statuses), Check-in time, Check-out time, Reason textarea (required)
+- **No changes validation:** submitting with reason but no field changes shows "No changes detected" flash
+- **Successful correction:** changing status to "Checked In" + check-in time + reason → "Attendance corrected successfully" flash, roster updates immediately, form closes
+- **Cancel button:** hides form, no changes applied
+- Re-opening form pre-fills current values (check-in time)
+
+#### Error Handling — PASS
+- Invalid UUID (`/admin/sessions/invalid-uuid`): 302 redirect to index with "Session not found" error flash
+- Non-existent valid UUID: same redirect behavior
+
+#### Mobile Responsive (375x667) — PASS
+- Index: filters stack vertically, session cards adapt, sidebar hidden with hamburger toggle
+- Show: table scrolls horizontally (`overflow-x-auto`), Notes/Correct columns accessible via scroll
+- No layout breaks on either view
+
+### Issues Found
+- **[info]** No empty state message when session list is empty
+  - Location: `sessions_live.html.heex:89`
+  - Expected: "No sessions found" or similar message when filters yield no results
+  - Actual: Blank area between filter bar and footer
+  - Note: LiveView streams support empty states via `hidden only:block` pattern
+
+## Auto-Fixes Applied
+- None needed
+
+## Recommendations
+1. **Add empty state for sessions list** — Use the LiveView streams `hidden only:block` pattern to show a "No sessions found for this date/filter" message when the stream is empty. This improves UX clarity.
+2. **Consider adding a "No change" indicator** — When the roster has 0/0 counts and the session date is in the past, a visual indicator could help admins identify sessions needing attention.

--- a/lib/klass_hero_web/live/admin/sessions_live.html.heex
+++ b/lib/klass_hero_web/live/admin/sessions_live.html.heex
@@ -87,6 +87,9 @@
 
   <%!-- Session list --%>
   <div id="sessions-list" phx-update="stream" class="space-y-1">
+    <div id="sessions-empty" class="hidden only:block p-8 text-center text-sm opacity-50">
+      {gettext("No sessions found for the selected filters.")}
+    </div>
     <.link
       :for={{dom_id, session} <- @streams.sessions}
       id={dom_id}


### PR DESCRIPTION
## Summary
- Added an empty state message to the admin sessions list when no sessions match the current filters
- Uses the LiveView streams `hidden only:block` CSS pattern inside the `phx-update="stream"` container
- Included a test-drive report covering the full admin sessions view (index, show, correction flow, mobile)

## Review Focus
- **Stream child ID requirement** — every child inside a `phx-update="stream"` container must have an `id`. The empty state div uses `id="sessions-empty"` at `sessions_live.html.heex:89`
- **CSS only:block pattern** — the `hidden only:block` classes ensure the div is only visible when it is the sole child in the container (i.e., the stream is empty). When sessions are streamed in, the div auto-hides via CSS

## Test Plan
- [x] `mix precommit` — 3221 tests pass, 0 failures
- [x] Navigate to `/admin/sessions` on a date with no sessions — empty state message appears
- [x] Change date to one with sessions — message disappears, sessions render normally
- [x] All 16 `SessionsLiveTest` tests pass