### PR TITLE
refactor: extract verify_participant into Shared module

### DIFF
--- a/lib/klass_hero/messaging/application/use_cases/get_conversation.ex
+++ b/lib/klass_hero/messaging/application/use_cases/get_conversation.ex
@@ -11,6 +11,7 @@ defmodule KlassHero.Messaging.Application.UseCases.GetConversation do
   """
 
   alias KlassHero.Messaging.Application.UseCases.MarkAsRead
+  alias KlassHero.Messaging.Application.UseCases.Shared
   alias KlassHero.Messaging.Repositories
 
   require Logger
@@ -44,7 +45,7 @@ defmodule KlassHero.Messaging.Application.UseCases.GetConversation do
 
     with {:ok, conversation} <-
            repos.conversations.get_by_id(conversation_id, preload: [:participants]),
-         :ok <- verify_participant(conversation_id, user_id, repos.participants),
+         :ok <- Shared.verify_participant(conversation_id, user_id, repos.participants),
          {:ok, messages, sender_names, has_more} <-
            repos.messages.list_with_senders(conversation_id, opts) do
       maybe_mark_as_read(mark_as_read?, conversation_id, user_id)
@@ -62,14 +63,6 @@ defmodule KlassHero.Messaging.Application.UseCases.GetConversation do
          has_more: has_more,
          sender_names: sender_names
        }}
-    end
-  end
-
-  defp verify_participant(conversation_id, user_id, participant_repo) do
-    if participant_repo.is_participant?(conversation_id, user_id) do
-      :ok
-    else
-      {:error, :not_participant}
     end
   end
 

--- a/lib/klass_hero/messaging/application/use_cases/reply_privately_to_broadcast.ex
+++ b/lib/klass_hero/messaging/application/use_cases/reply_privately_to_broadcast.ex
@@ -11,6 +11,7 @@ defmodule KlassHero.Messaging.Application.UseCases.ReplyPrivatelyToBroadcast do
 
   alias KlassHero.Accounts.Scope
   alias KlassHero.Messaging
+  alias KlassHero.Messaging.Application.UseCases.Shared
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Repositories
   alias KlassHero.Repo
@@ -41,7 +42,7 @@ defmodule KlassHero.Messaging.Application.UseCases.ReplyPrivatelyToBroadcast do
     #      on :program_broadcast and check participation for defense in depth
     # Outcome: only broadcast participants can initiate private replies
     with {:ok, broadcast} <- fetch_broadcast(broadcast_conversation_id, repos),
-         :ok <- verify_participant(broadcast.id, scope.user.id, repos),
+         :ok <- Shared.verify_participant(broadcast.id, scope.user.id, repos.participants),
          {:ok, provider_user_id} <- repos.users.get_user_id_for_provider(broadcast.provider_id),
          {:ok, direct_conversation} <-
            find_or_create_direct_conversation(
@@ -72,14 +73,6 @@ defmodule KlassHero.Messaging.Application.UseCases.ReplyPrivatelyToBroadcast do
       {:ok, %{type: :program_broadcast} = broadcast} -> {:ok, broadcast}
       {:ok, _non_broadcast} -> {:error, :not_broadcast}
       {:error, :not_found} -> {:error, :not_found}
-    end
-  end
-
-  defp verify_participant(conversation_id, user_id, repos) do
-    if repos.participants.is_participant?(conversation_id, user_id) do
-      :ok
-    else
-      {:error, :not_participant}
     end
   end
 

--- a/lib/klass_hero/messaging/application/use_cases/send_message.ex
+++ b/lib/klass_hero/messaging/application/use_cases/send_message.ex
@@ -9,6 +9,7 @@ defmodule KlassHero.Messaging.Application.UseCases.SendMessage do
   4. Publishes a message_sent event for real-time updates
   """
 
+  alias KlassHero.Messaging.Application.UseCases.Shared
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Repositories
   alias KlassHero.Shared.DomainEventBus
@@ -39,7 +40,7 @@ defmodule KlassHero.Messaging.Application.UseCases.SendMessage do
     message_type = Keyword.get(opts, :message_type, :text)
     repos = Repositories.all()
 
-    with :ok <- verify_participant(conversation_id, sender_id, repos.participants),
+    with :ok <- Shared.verify_participant(conversation_id, sender_id, repos.participants),
          :ok <- verify_broadcast_send_permission(conversation_id, sender_id, repos),
          {:ok, message} <-
            create_message(conversation_id, sender_id, content, message_type, repos.messages) do
@@ -74,19 +75,6 @@ defmodule KlassHero.Messaging.Application.UseCases.SendMessage do
 
       {:error, :not_found} ->
         {:error, :not_found}
-    end
-  end
-
-  defp verify_participant(conversation_id, user_id, participant_repo) do
-    if participant_repo.is_participant?(conversation_id, user_id) do
-      :ok
-    else
-      Logger.debug("User not participant in conversation",
-        conversation_id: conversation_id,
-        user_id: user_id
-      )
-
-      {:error, :not_participant}
     end
   end
 

--- a/lib/klass_hero/messaging/application/use_cases/shared.ex
+++ b/lib/klass_hero/messaging/application/use_cases/shared.ex
@@ -1,0 +1,26 @@
+defmodule KlassHero.Messaging.Application.UseCases.Shared do
+  @moduledoc """
+  Shared utilities for Messaging use cases.
+  """
+
+  require Logger
+
+  @doc """
+  Verifies that a user is a participant in a conversation.
+
+  Returns `:ok` if the user is a participant, or `{:error, :not_participant}` otherwise.
+  """
+  @spec verify_participant(String.t(), String.t(), module()) :: :ok | {:error, :not_participant}
+  def verify_participant(conversation_id, user_id, participant_repo) do
+    if participant_repo.is_participant?(conversation_id, user_id) do
+      :ok
+    else
+      Logger.debug("User not participant in conversation",
+        conversation_id: conversation_id,
+        user_id: user_id
+      )
+
+      {:error, :not_participant}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extract duplicated `verify_participant/3` from 3 messaging use cases into `Messaging.Application.UseCases.Shared`
- Standardize on the most complete variant (with `Logger.debug` on failure)
- Align `ReplyPrivatelyToBroadcast` to pass `repos.participants` instead of full `repos` struct

Closes #436

## Test plan

- [x] All 302 messaging tests pass
- [x] Full precommit suite passes (3276 tests, 0 failures)
- [x] Verified `Shared.verify_participant/3` is exported via Tidewave