### PR TITLE
test: silence log noise with global capture_log

### DIFF
--- a/test/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository_test.exs
@@ -441,7 +441,6 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.Enrollme
     # same child in the same program. One must succeed and the other must return
     # {:error, :duplicate_resource} rather than crashing or leaking a raw
     # constraint error to callers.
-    @tag :capture_log
     test "one request succeeds and the other returns duplicate_resource" do
       program = insert(:program_schema)
       {child, parent} = insert_child_with_guardian()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,2 @@
-ExUnit.start(exclude: [:integration])
+ExUnit.start(exclude: [:integration], capture_log: true)
 Ecto.Adapters.SQL.Sandbox.mode(KlassHero.Repo, :manual)


### PR DESCRIPTION
## Summary
- Enable `capture_log: true` in `ExUnit.start` to suppress warning/error logs during passing tests
- Removes 111 distracting log lines from test output (90 warnings, 21 errors from error-path tests)
- Remove redundant `@tag :capture_log` from enrollment repository test (now covered globally)

## Test plan
- [x] `mix test` — 3312 tests pass, 0 failures, 0 log lines in output
- [x] Existing `capture_log/1` assertion tests unaffected (ExUnit handles nesting)
- [x] Logs still shown on test failure for debugging