### PR TITLE
refactor: deduplicate EventPublishing and IntegrationEventPublishing

### DIFF
--- a/lib/klass_hero/shared/adapters/driven/events/event_handlers/notify_live_views.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/event_handlers/notify_live_views.ex
@@ -43,7 +43,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventHandlers.NotifyLiveViews 
   """
   @spec safe_publish(DomainEvent.t(), String.t()) :: :ok
   def safe_publish(event, topic) do
-    case EventPublishing.publisher_module().publish(event, topic) do
+    case EventPublishing.publish(event, topic) do
       :ok ->
         :ok
 

--- a/lib/klass_hero/shared/event_publishing.ex
+++ b/lib/klass_hero/shared/event_publishing.ex
@@ -1,63 +1,34 @@
 defmodule KlassHero.Shared.EventPublishing do
   @moduledoc """
-  Shared utilities for event publishing across bounded contexts.
+  Shared utilities for domain event publishing across bounded contexts.
 
-  This module provides a centralized way to access the configured event publisher,
-  eliminating duplicate `publisher_module/0` implementations across contexts.
-
-  ## Configuration
-
-  The publisher module is configured in application config:
+  The publisher module is resolved at compile time from application config:
 
       config :klass_hero, :event_publisher,
         module: KlassHero.Shared.Adapters.Driven.Events.PubSubEventPublisher,
         pubsub: KlassHero.PubSub
 
-  For tests, configure a test publisher:
-
-      config :klass_hero, :event_publisher,
-        module: KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher,
-        pubsub: KlassHero.PubSub
-
   ## Usage
 
-      alias KlassHero.Shared.EventPublishing
-
-      # Get the configured publisher module
-      EventPublishing.publisher_module()
-
-      # Publish an event directly
       EventPublishing.publish(event)
+      EventPublishing.publish(event, topic)
   """
 
-  alias KlassHero.Shared.Adapters.Driven.Events.PubSubEventPublisher
-
-  @doc """
-  Returns the configured event publisher module.
-
-  Falls back to `PubSubEventPublisher` if not configured.
-  """
-  @spec publisher_module() :: module()
-  def publisher_module do
-    :klass_hero
-    |> Application.get_env(:event_publisher, [])
-    |> Keyword.get(:module, PubSubEventPublisher)
-  end
+  @publisher Application.compile_env!(:klass_hero, [:event_publisher, :module])
 
   @doc """
   Publishes an event using the configured publisher.
 
-  ## Parameters
-
-  - `event` - The domain event struct to publish
-
-  ## Returns
-
-  - `:ok` on successful publish
-  - `{:error, reason}` on failure
+  Returns `:ok` on success, `{:error, reason}` on failure.
   """
   @spec publish(struct()) :: :ok | {:error, term()}
-  def publish(event) do
-    publisher_module().publish(event)
-  end
+  def publish(event), do: @publisher.publish(event)
+
+  @doc """
+  Publishes an event to a specific topic using the configured publisher.
+
+  Returns `:ok` on success, `{:error, reason}` on failure.
+  """
+  @spec publish(struct(), String.t()) :: :ok | {:error, term()}
+  def publish(event, topic), do: @publisher.publish(event, topic)
 end

--- a/lib/klass_hero/shared/integration_event_publishing.ex
+++ b/lib/klass_hero/shared/integration_event_publishing.ex
@@ -2,65 +2,32 @@ defmodule KlassHero.Shared.IntegrationEventPublishing do
   @moduledoc """
   Shared utilities for integration event publishing across bounded contexts.
 
-  This module provides a centralized way to access the configured integration
-  event publisher, mirroring `EventPublishing` but for cross-context events.
-
-  ## Configuration
-
-  The publisher module is configured in application config:
+  The publisher module is resolved at runtime from application config to allow
+  the invite-claim saga test to swap to the real PubSub publisher.
 
       config :klass_hero, :integration_event_publisher,
         module: KlassHero.Shared.Adapters.Driven.Events.PubSubIntegrationEventPublisher,
         pubsub: KlassHero.PubSub
 
-  For tests, configure a test publisher:
-
-      config :klass_hero, :integration_event_publisher,
-        module: KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher,
-        pubsub: KlassHero.PubSub
-
   ## Usage
 
-      alias KlassHero.Shared.IntegrationEventPublishing
-
-      # Get the configured publisher module
-      IntegrationEventPublishing.publisher_module()
-
-      # Publish an integration event directly
       IntegrationEventPublishing.publish(event)
+      IntegrationEventPublishing.publish_critical(event, "label")
+      IntegrationEventPublishing.publish_best_effort(event, "label")
   """
-
-  alias KlassHero.Shared.Adapters.Driven.Events.PubSubIntegrationEventPublisher
 
   require Logger
 
   @doc """
-  Returns the configured integration event publisher module.
-
-  Falls back to `PubSubIntegrationEventPublisher` if not configured.
-  """
-  @spec publisher_module() :: module()
-  def publisher_module do
-    :klass_hero
-    |> Application.get_env(:integration_event_publisher, [])
-    |> Keyword.get(:module, PubSubIntegrationEventPublisher)
-  end
-
-  @doc """
   Publishes an integration event using the configured publisher.
 
-  ## Parameters
-
-  - `event` - The integration event struct to publish
-
-  ## Returns
-
-  - `:ok` on successful publish
-  - `{:error, reason}` on failure
+  Returns `:ok` on success, `{:error, reason}` on failure.
   """
   @spec publish(struct()) :: :ok | {:error, term()}
-  def publish(event) do
-    publisher_module().publish(event)
+  def publish(event), do: publisher_module().publish(event)
+
+  defp publisher_module do
+    Application.get_env(:klass_hero, :integration_event_publisher)[:module]
   end
 
   @doc """

--- a/test/klass_hero/participation/application/use_cases/record_check_in_integration_test.exs
+++ b/test/klass_hero/participation/application/use_cases/record_check_in_integration_test.exs
@@ -10,79 +10,17 @@ defmodule KlassHero.Participation.Application.UseCases.RecordCheckInIntegrationT
   - Events are published with correct payload structure
   """
 
-  # async: false is REQUIRED because this test modifies global Application config
-  use KlassHero.DataCase, async: false
+  use KlassHero.DataCase, async: true
 
   import KlassHero.Factory
 
   alias KlassHero.AccountsFixtures
   alias KlassHero.Participation.Application.UseCases.RecordCheckIn
   alias KlassHero.Participation.Application.UseCases.RecordCheckOut
-
-  # Test event publisher that captures published events using Agent
-  defmodule TestEventPublisher do
-    use Agent
-
-    def start_link(_opts) do
-      Agent.start_link(fn -> [] end, name: __MODULE__)
-    end
-
-    def publish(event) do
-      Agent.update(__MODULE__, &[event | &1])
-      :ok
-    end
-
-    def publish(event, _topic) do
-      publish(event)
-    end
-
-    def get_events do
-      Agent.get(__MODULE__, & &1) |> Enum.reverse()
-    end
-
-    def clear do
-      Agent.update(__MODULE__, fn _ -> [] end)
-    end
-  end
+  alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
 
   setup do
-    # Store original configs
-    original_participation_config = Application.get_env(:klass_hero, :participation)
-    original_publisher_config = Application.get_env(:klass_hero, :event_publisher)
-
-    # Start test event publisher
-    start_supervised!(TestEventPublisher)
-
-    # Configure real repositories + test publisher
-    Application.put_env(:klass_hero, :participation,
-      session_repository:
-        KlassHero.Participation.Adapters.Driven.Persistence.Repositories.SessionRepository,
-      participation_repository:
-        KlassHero.Participation.Adapters.Driven.Persistence.Repositories.ParticipationRepository,
-      child_info_resolver:
-        KlassHero.Participation.Adapters.Driven.IdentityContext.ChildInfoResolver
-    )
-
-    Application.put_env(:klass_hero, :event_publisher,
-      module: TestEventPublisher,
-      pubsub: KlassHero.PubSub
-    )
-
-    on_exit(fn ->
-      # Restore original configs
-      if original_participation_config do
-        Application.put_env(:klass_hero, :participation, original_participation_config)
-      else
-        Application.delete_env(:klass_hero, :participation)
-      end
-
-      if original_publisher_config do
-        Application.put_env(:klass_hero, :event_publisher, original_publisher_config)
-      else
-        Application.delete_env(:klass_hero, :event_publisher)
-      end
-    end)
-
+    TestEventPublisher.setup()
     :ok
   end
 

--- a/test/klass_hero/shared/integration_event_publishing_test.exs
+++ b/test/klass_hero/shared/integration_event_publishing_test.exs
@@ -12,12 +12,6 @@ defmodule KlassHero.Shared.IntegrationEventPublishingTest do
     :ok
   end
 
-  describe "publisher_module/0" do
-    test "returns the configured publisher (TestIntegrationEventPublisher in test env)" do
-      assert IntegrationEventPublishing.publisher_module() == TestIntegrationEventPublisher
-    end
-  end
-
   describe "publish/1" do
     test "returns :ok and stores the event" do
       event = build_event(:some_event)


### PR DESCRIPTION
## Summary

- Removed public `publisher_module/0` from both `EventPublishing` and `IntegrationEventPublishing` — callers now use `publish/1` or `publish/2` directly
- `EventPublishing` uses compile-time resolution (`Application.compile_env!`), matching the pattern used by 51+ other port modules in the codebase
- `IntegrationEventPublishing` keeps runtime resolution (`Application.get_env`) because the invite-claim saga test needs to swap to the real PubSub publisher at runtime
- Added `publish/2` (with topic) to `EventPublishing` so `NotifyLiveViews` no longer reaches through to the underlying publisher module
- Simplified `record_check_in_integration_test` by replacing its inline Agent-based `TestEventPublisher` with the global process-dictionary-based one, enabling `async: true`

Net result: **-130 lines** (5 files changed, 25 insertions, 155 deletions)

Closes #385

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 3311 tests, 0 failures
- [x] `mix precommit` — full suite green