### PR TITLE
feat: add create-issue skill

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -70,3 +70,9 @@ Reads a Daily QA GitHub Discussion by number, triages Carried-Forward and New Co
 Enhanced version of the global skill with auto-triggering on `.ex`/`.exs` files and modern Elixir 1.17–1.20 patterns (type system, Duration, built-in JSON, parameterized tests).
 
 **Triggers automatically** when working on any Elixir file.
+
+### create-issue
+
+Creates well-formed GitHub issues from findings or hypotheses. Validates against current code, gathers references, drafts using project issue templates.
+
+**Use when:** `/create-issue "description"` or when asked to file/open/create an issue

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: create-issue
+description: >-
+  Create well-formed GitHub issues from findings, hypotheses, or gaps discovered during
+  codebase exploration. Explores code to validate the finding, gathers references, classifies
+  issue type (FEATURE/BUG/TASK), selects labels, drafts the body following project templates,
+  and creates via gh CLI. Invoke with: `/create-issue "description of finding"`. Also triggers
+  on "file an issue", "open an issue", "create a ticket", "turn this into an issue".
+---
+
+# Create Issue
+
+Turn a finding or hypothesis into a well-formed GitHub issue with validated code references.
+
+**Type:** Rigid workflow. Follow steps exactly.
+
+---
+
+## Step 1: Parse Input
+
+Extract the hypothesis/finding from:
+1. The skill argument (e.g., `/create-issue "session creation not in UI"`)
+2. The current conversation context (recent exploration results)
+
+If neither provides a clear finding, ask the user to describe it.
+
+Formulate a one-sentence hypothesis: what exists, what's missing, or what's broken.
+
+## Step 2: Check for Duplicates
+
+Search for existing issues that already cover this finding:
+
+```bash
+gh issue list --search "keyword1 keyword2" --state open --json number,title,labels --limit 10
+```
+
+Use 2-3 key terms from the hypothesis. If a matching open issue exists, show it to the user and stop unless they want a new issue anyway.
+
+## Step 3: Validate Hypothesis
+
+Explore the codebase to confirm or disprove the finding. Use Grep, Glob, and Read to gather evidence.
+
+Classify the finding:
+
+| Classification | Meaning | Action |
+|---|---|---|
+| `confirmed-gap` | Finding validated — functionality missing or broken | Continue to Step 4 |
+| `partially-exists` | Some pieces exist, others missing | Continue — scope issue to the gap |
+| `already-exists` | Functionality exists, finding invalid | Show evidence, stop |
+| `not-applicable` | Finding doesn't apply to this codebase | Explain why, stop |
+
+Present classification with evidence (file paths, code snippets) to the user before continuing.
+
+## Step 4: Gather Code References
+
+Collect everything useful for the issue:
+
+- **Relevant files** — paths and line numbers for existing related code
+- **Bounded context** — which DDD context this belongs to (see `docs/contexts/`)
+- **Existing patterns** — similar implementations to follow as reference
+- **Dependencies** — prerequisites or related issues
+
+## Step 5: Determine Type, Labels, and Draft
+
+### Issue Type
+
+| Finding nature | Type prefix | Default label |
+|---|---|---|
+| Missing functionality, new capability | `[FEATURE]` | `enhancement` |
+| Broken behavior, regression, incorrect output | `[BUG]` | `bug` |
+| Refactor, cleanup, infra, chore | `[TASK]` | (context-dependent) |
+
+**Important:** The repo uses `enhancement` for features — there is no `feature` label.
+
+### Labels
+
+Select labels from the repo taxonomy. See `references/labels.md` for the full list and selection guidance. Always pick:
+1. One **type** label (`enhancement`, `bug`, `refactor`, etc.)
+2. One **area** label if applicable (`backend`, `mobile`, `admin-dashboard`, `api`, `docs`)
+3. One **priority** label if severity is clear (`priority:high`, `priority:medium`, `priority:low`)
+4. One **epic** label if it maps to a strategic initiative
+
+### Draft Issue Body
+
+Use the matching template from `references/templates.md`. Fill in all sections with the validated findings and code references from Steps 3-4.
+
+### Present for Review
+
+Show the user the complete draft:
+- Title (with type prefix)
+- Labels
+- Full body
+
+**Do NOT create the issue before user confirmation.** Let the user adjust title, labels, body, or cancel.
+
+## Step 6: Create Issue
+
+On user approval:
+
+```bash
+gh issue create \
+  --title "[TYPE] Title here" \
+  --body "$(cat <<'EOF'
+Body content here...
+EOF
+)" \
+  --label "label1,label2" \
+  --assignee "MaxPayne89"
+```
+
+Capture the issue URL from stdout.
+
+## Step 7: Link to Project
+
+Attempt to add the issue to the klass-hero GitHub project:
+
+```bash
+# Find the project number
+gh project list --owner MaxPayne89 --format json
+
+# Add issue to project (requires read:project scope)
+gh project item-add <PROJECT_NUMBER> --owner MaxPayne89 --url <ISSUE_URL>
+```
+
+If this fails due to missing `read:project` token scope, inform the user:
+
+```
+Project linking failed (token missing read:project scope).
+Manual step: go to the issue on GitHub and add it to the project board.
+```
+
+Output the created issue URL.
+
+---
+
+## Rules
+
+- **Never create without confirmation.** Present the full draft for user review first.
+- **Validate before drafting.** Always check the codebase — never file issues based on assumptions.
+- **Check for duplicates.** Search existing open issues before drafting.
+- **Use `enhancement`, not `feature`.** The repo's feature label is `enhancement`.
+- **Always assign to MaxPayne89.**
+- **Include code references.** Every issue body must have file paths and relevant context.
+- **Keep titles under 80 characters** (excluding the type prefix).
+- **Use HEREDOC for body.** Pass multi-line body via `cat <<'EOF'` to preserve formatting.

--- a/.claude/skills/create-issue/references/labels.md
+++ b/.claude/skills/create-issue/references/labels.md
@@ -1,0 +1,55 @@
+# Label Taxonomy
+
+Select labels from these categories. Always pick at least a type label.
+
+## Type Labels
+
+| Label | Use when |
+|---|---|
+| `bug` | Broken behavior, regression, incorrect output |
+| `enhancement` | New functionality, missing feature, capability gap |
+| `refactor` / `refactoring` | Code restructuring without behavior change |
+| `design` | UI/UX design work |
+| `documentation` | Docs-only changes |
+
+**Note:** There is no `feature` label. Use `enhancement` for features.
+
+## Area Labels
+
+| Label | Use when |
+|---|---|
+| `backend` | Server-side Elixir/Phoenix code, domain logic, persistence |
+| `mobile` | Mobile-specific UI or functionality |
+| `admin-dashboard` | Admin panel features |
+| `api` | API endpoints or external integrations |
+| `docs` | Documentation files |
+
+## Priority Labels
+
+| Label | Use when |
+|---|---|
+| `priority:high` | Blocks other work, affects users, or is urgent |
+| `priority:medium` | Important but not blocking |
+| `priority:low` | Nice to have, no urgency |
+
+Only apply if severity is clear from the finding. When in doubt, omit.
+
+## Epic Labels (Strategic Initiatives)
+
+| Label | Covers |
+|---|---|
+| `Provider Management` | Provider onboarding, verification, staff, incident reporting |
+| `Marketplace Platform` | External providers, scalable marketplace model |
+| `Job Board` | Parent-posted opportunities, custom requests |
+| `Booking & Payments` | Invoices, waitlist, cross-sell, payment flows |
+| `Program Operations` | Program filtering, attendance tracking, session management |
+| `Platform Foundation` | i18n, GDPR, UI polish, infrastructure |
+
+## Quality Labels
+
+| Label | Use when |
+|---|---|
+| `code-quality` | Code quality improvements |
+| `testing` | Test coverage gaps or test infrastructure |
+| `automation` | CI/CD or automation improvements |
+| `qa` | Quality assurance findings |

--- a/.claude/skills/create-issue/references/templates.md
+++ b/.claude/skills/create-issue/references/templates.md
@@ -1,0 +1,86 @@
+# Issue Body Templates
+
+Use the matching template based on issue type. Fill in all sections. Always append the Code References section.
+
+## Feature Template (`[FEATURE]`)
+
+```markdown
+## Feature Description
+
+{Clear description of the missing functionality and why it matters.}
+
+## User Story
+
+As a {parent/provider/instructor/admin}, I want {goal} so that {benefit}.
+
+## Acceptance Criteria
+
+- [ ] {Criterion 1}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+## Code References
+
+- {File path 1}: {what exists or is relevant}
+- {File path 2}: {pattern to follow}
+
+## Additional Context
+
+{Architecture notes, bounded context, existing patterns to follow, or related issues.}
+```
+
+## Bug Template (`[BUG]`)
+
+```markdown
+## Describe the Bug
+
+{Clear description of the incorrect behavior.}
+
+## To Reproduce
+
+1. {Step 1}
+2. {Step 2}
+3. {Step 3}
+
+## Expected Behavior
+
+{What should happen instead.}
+
+## Environment
+
+- Component: {backend/mobile/admin}
+- Area: {which bounded context or module}
+
+## Code References
+
+- {File path 1}: {where the bug likely originates}
+- {File path 2}: {related code}
+
+## Additional Context
+
+{Stack traces, logs, or related issues.}
+```
+
+## Task Template (`[TASK]`)
+
+```markdown
+## Task Description
+
+{What needs to be done and why.}
+
+## Definition of Done
+
+- [ ] {Completion criterion 1}
+- [ ] {Completion criterion 2}
+- [ ] Tests written (if applicable)
+- [ ] Documentation updated (if applicable)
+
+## Code References
+
+- {File path 1}: {relevant code}
+- {File path 2}: {related context}
+
+## Additional Notes
+
+{Technical details, architectural considerations, or implementation hints.}
+```


### PR DESCRIPTION
## Summary

- Adds `create-issue` skill (`.claude/skills/create-issue/`) — a rigid 7-step workflow that turns codebase findings into well-formed GitHub issues
- Includes reference files for issue templates and label taxonomy
- Registers the skill in `.claude/rules/skills.md`

## What the skill does

1. Parses a hypothesis/finding from conversation context or argument
2. Checks for duplicate open issues
3. Validates the hypothesis against current code (confirm/disprove)
4. Gathers code references (file paths, line numbers, patterns)
5. Drafts a structured issue body using project templates ([FEATURE]/[BUG]/[TASK])
6. Creates via `gh issue create` with labels and assignment to MaxPayne89
7. Attempts project board linking (currently blocked — token missing `read:project` scope)

## Known Limitation

Project board linking (Step 7) fails because the GitHub token lacks the `read:project` scope. The skill documents this and prints a manual fallback instruction. Fix: `gh auth refresh -s read:project`.

## Test Plan

- [x] Skill passes `quick_validate.py` validation
- [x] Guinea pig test: filed [#461](https://github.com/MaxPayne89/klass-hero/issues/461) using the skill workflow