### PR TITLE
refactor: remove orphaned Task.async in DashboardLive mount

### DIFF
--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -34,7 +34,7 @@ defmodule KlassHeroWeb.DashboardLive do
             {nil, [], [], []}
         end
       rescue
-        # Trigger: database or linked-task failure during dashboard data loading
+        # Trigger: database failure during dashboard data loading
         # Why: a failing section should not crash the entire dashboard
         # Outcome: gracefully degrade to empty state if any load fails
         e ->


### PR DESCRIPTION
## Summary

- Removed `Task.async`/`Task.await` pattern from `DashboardLive.mount/3`, replaced with sequential `Family.get_children/1` call
- If `load_family_programs/1` raised, the spawned children task was never awaited, leaving orphaned `{ref, result}` and `:DOWN` messages in the LiveView mailbox
- Sequential loading is sufficient here — two simple DB queries in mount do not benefit meaningfully from parallelism
- Ref: Daily QA discussion #449

## Review Focus

- **Orphaned task elimination** — `dashboard_live.ex:30-32` previously spawned `Task.async` then awaited at L32; if L31 raised, the rescue block (L37-44) returned without awaiting, leaking messages into the process mailbox
- **No behavioral change on happy path** — the same two queries run in the same order, just sequentially instead of concurrently; the rescue block still catches failures identically
- **No handle_info needed** — removing the Task means no stray `{ref, result}` or `:DOWN` messages can arrive, so no cleanup clause is required

## Test Plan

- [x] `mix precommit` — compile (warnings-as-errors), format, 3392 tests pass
- [x] Verify dashboard loads correctly for a user with parent profile, children, and enrollments
- [x] Verify dashboard degrades gracefully for a user without a parent profile (empty state)