### PR TITLE
ci: version-control gh-aw actions lock file

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,0 +1,14 @@
+{
+  "entries": {
+    "actions/github-script@v8": {
+      "repo": "actions/github-script",
+      "version": "v8",
+      "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
+    },
+    "github/gh-aw-actions/setup@v0.64.0": {
+      "repo": "github/gh-aw-actions/setup",
+      "version": "v0.64.0",
+      "sha": "51c65948c64ab6752536ead71fba1fc2c20ed0bc"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.github/aw/actions-lock.json` to version control, pinning GitHub Actions used in agentic workflows to exact commit SHAs
- Ensures reproducible CI builds and mitigates supply-chain risk from mutable action tags

## Test plan
- [x] Verify lock file contains correct SHA pins for `actions/github-script@v8` and `github/gh-aw-actions/setup@v0.64.0`
- [x] Confirm agentic workflows still run correctly with the lock file committed