### PR TITLE
fix: switch daily perf improver engine from copilot to claude-sonnet-4-6

### DIFF
--- a/.github/workflows/daily-perf-improver.md
+++ b/.github/workflows/daily-perf-improver.md
@@ -62,7 +62,7 @@ tools:
   repo-memory: true
 
 source: githubnext/agentics/workflows/daily-perf-improver.md@613b585d37d53ee994d85ad27e8e62ad0022ae32
-engine: copilot
+engine: claude-sonnet-4-6
 ---
 
 # Daily Perf Improver


### PR DESCRIPTION
## Summary
- Switch the Daily Perf Improver agentic workflow engine from `copilot` to `claude-sonnet-4-6`
- Fixes the same engine termination failure pattern already resolved for daily-qa (#534) and duplicate-code-detector (#537)

Closes #518

## Test Plan
- [x] `mix precommit` passes (3691 tests, 0 failures)
- [ ] Next scheduled workflow run succeeds (or trigger manually via workflow_dispatch)