### PR TITLE
fix: keep program slots counter in sync after program changes

### DIFF
--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -380,7 +380,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           <p class="text-xs text-hero-grey-500 uppercase tracking-wide">
             {gettext("Program Slots")}
           </p>
-          <p class="text-lg font-semibold text-hero-charcoal">
+          <p id="program-slots-counter" class="text-lg font-semibold text-hero-charcoal">
             {@business.program_slots_used}/{if @business.program_slots_total == :unlimited,
               do: "∞",
               else: @business.program_slots_total}

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -61,8 +61,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
         staff_members = Task.await(staff_task)
         staff_views = StaffMemberPresenter.to_card_view_list(staff_members)
-
-        business = %{business | program_slots_used: length(programs)}
+        programs_count = length(programs)
 
         # Build staff filter options from real data
         staff_options =
@@ -80,7 +79,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
           |> stream(:team_members, staff_views)
           |> update_staff_count(length(staff_views))
           |> stream(:programs, programs)
-          |> assign(programs_count: length(programs))
+          |> assign(programs_count: programs_count)
+          |> update_program_slots(programs_count)
           |> assign(staff_options: staff_options)
           |> assign(search_query: "")
           |> assign(selected_staff: "all")
@@ -812,7 +812,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
          programs_count: socket.assigns.programs_count + 1,
          enrollment_form: to_form(Enrollment.new_policy_changeset(), as: "enrollment_policy"),
          participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
-       )}
+       )
+       |> update_program_slots(socket.assigns.business.program_slots_used + 1)}
     else
       {:error, :instructor_not_found} ->
         {:noreply,
@@ -1500,6 +1501,11 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     assign(socket, staff_count: count, business: business)
   end
 
+  defp update_program_slots(socket, count) do
+    business = %{socket.assigns.business | program_slots_used: count}
+    assign(socket, business: business)
+  end
+
   defp fetch_staff_members(provider_id) do
     case Provider.list_staff_members(provider_id) do
       {:ok, members} ->
@@ -1541,6 +1547,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     socket
     |> stream(:programs, programs, reset: true)
     |> assign(programs_count: length(programs))
+    |> update_program_slots(length(domain_programs))
   end
 
   defp build_enrollment_data(domain_programs) do

--- a/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
@@ -67,6 +67,28 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       assert render(view) =~ "Program created successfully."
     end
 
+    test "updates program slots counter after creating a program", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      # Professional tier: 0 programs used out of 5 slots
+      assert has_element?(view, "#program-slots-counter", "0/5")
+
+      view |> element("#new-program-btn") |> render_click()
+
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => "Counter Test Program",
+          "description" => "Verifies program slots counter updates",
+          "category" => "arts",
+          "price" => "30.00"
+        }
+      })
+      |> render_submit()
+
+      assert has_element?(view, "#program-slots-counter", "1/5")
+    end
+
     test "creates program with instructor assigned", %{conn: conn, provider: provider} do
       staff =
         ProviderFixtures.staff_member_fixture(


### PR DESCRIPTION
## Summary

- Added `update_program_slots/2` private helper to `DashboardLive` (mirrors the existing `update_staff_count/2` pattern) to keep `business.program_slots_used` in sync with actual program count
- Wired the helper into mount, `create_new_program` success path, and `reset_programs_stream/1` -- the three places where program count can change
- Removed the inline `business` map mutation in mount (was only set once, never updated after)
- Added `id="program-slots-counter"` to the header counter element for testability
- Added regression test verifying the counter updates from `0/5` to `1/5` after creating a program

## Review Focus

- **The core fix** -- `dashboard_live.ex:815` adds `update_program_slots` to the program creation success path. Previously `programs_count` was incremented but `business.program_slots_used` (which the header reads) was not
- **Filtered vs. total count semantics** -- `dashboard_live.ex:1549-1550` intentionally uses `length(domain_programs)` (unfiltered total) for slots and `length(programs)` (post-filter) for `programs_count`. These must remain separate because search/staff filters affect display count but not slot usage
- **Safe read after assign** -- `dashboard_live.ex:815` reads `socket.assigns.business.program_slots_used` after a preceding `assign(...)` call in the pipe. This is safe because the preceding assign does not modify the `business` key
- **Helper placement** -- `dashboard_live.ex:1503-1506` placed adjacent to `update_staff_count/2` for discoverability. Intentionally does not set a standalone assign (unlike `update_staff_count` which also sets `staff_count`) because `programs_count` has different semantics (filtered)

## Test Plan

- [x] `mix compile --warnings-as-errors` passes (0 warnings)
- [x] `mix test` passes (3851 passed, 0 failures)
- [x] New test verifies counter goes from `0/5` to `1/5` after program creation
- [x] Manual: log in as provider, create a program, verify header counter updates without page refresh
- [x] Manual: with search filter active, create a program, verify slot counter still updates correctly

Closes #568