### PR TITLE
fix: left-align step numbers and center icons in vetting cards

### DIFF
--- a/lib/klass_hero_web/live/about_live.ex
+++ b/lib/klass_hero_web/live/about_live.ex
@@ -219,12 +219,12 @@ defmodule KlassHeroWeb.AboutLive do
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
             <div :for={step <- vetting_steps()} class="bg-white rounded-xl p-6 text-center">
               <div class={[
-                "w-16 h-16 mx-auto mb-4 rounded-full flex items-center justify-center",
+                "w-16 h-16 mb-4 rounded-full flex items-center justify-center",
                 step.number_bg
               ]}>
                 <span class={["text-2xl font-bold", step.number_color]}>{step.number}</span>
               </div>
-              <div class="mb-4">
+              <div class="mb-4 flex justify-center">
                 <UIComponents.gradient_icon
                   gradient_class={step.icon_gradient}
                   size="md"


### PR DESCRIPTION
## Summary
- Removed `mx-auto` from the step number badge so it left-aligns within the card (`about_live.ex:222`)
- Added `flex justify-center` to the icon wrapper so the gradient icon centers horizontally (`about_live.ex:227`)

Closes #545

## Review Focus
- **Alignment swap** — the number badge lost `mx-auto` at `about_live.ex:222` and the icon wrapper gained `flex justify-center` at `about_live.ex:227`. Verify this matches the intended design (number left, icon centered).
- **Parent text-center interaction** — the card container still has `text-center`, which centers inline text (title, description) but does not affect block-level fixed-width elements like the badge. The `flex justify-center` on the icon wrapper overrides `text-center` for that element.

## Test Plan
- [x] `mix precommit` passes (compile, format, tests)
- [ ] Visual check: navigate to `/about`, scroll to "Our 6-Step Vetting Process" — number badges should be left-aligned, icons centered