### PR TITLE
feat: show program name in provider session list cards

### DIFF
--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -201,6 +201,24 @@ defmodule KlassHero.Participation do
   end
 
   @doc """
+  Retrieves a session enriched with program_name for list views.
+
+  Fetches only the session and its program name — no roster or child data.
+
+  ## Parameters
+
+  - `session_id` - ID of the session
+
+  ## Returns
+
+  - `{:ok, session_map}` where session_map includes all session fields + program_name
+  - `{:error, :not_found}` if session doesn't exist
+  """
+  def get_session_for_list(session_id) when is_binary(session_id) do
+    GetSessionWithRoster.execute_for_list(session_id)
+  end
+
+  @doc """
   Retrieves a session with participation records attached for UI display.
 
   Returns the session with a `participation_records` field containing

--- a/lib/klass_hero/participation/adapters/driven/persistence/repositories/session_repository.ex
+++ b/lib/klass_hero/participation/adapters/driven/persistence/repositories/session_repository.ex
@@ -78,10 +78,22 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Sessi
       join: p in "programs",
       on: p.id == s.program_id,
       where: p.provider_id == type(^provider_id, Ecto.UUID) and s.session_date == ^date,
+      select: %{
+        id: s.id,
+        program_id: s.program_id,
+        program_name: p.title,
+        session_date: s.session_date,
+        start_time: s.start_time,
+        end_time: s.end_time,
+        status: s.status,
+        location: s.location,
+        notes: s.notes,
+        max_capacity: s.max_capacity
+      },
       order_by: [asc: s.start_time]
     )
     |> Repo.all()
-    |> Enum.map(&ProgramSessionMapper.to_domain/1)
+    |> Enum.map(&atomize_status/1)
   end
 
   @impl true

--- a/lib/klass_hero/participation/application/use_cases/get_session_with_roster.ex
+++ b/lib/klass_hero/participation/application/use_cases/get_session_with_roster.ex
@@ -71,6 +71,34 @@ defmodule KlassHero.Participation.Application.UseCases.GetSessionWithRoster do
   end
 
   @doc """
+  Retrieves a session enriched with program_name for list views.
+
+  Fetches only the session and its program name — no roster or child data.
+  Use this when only basic display fields are needed (e.g. the sessions list card).
+
+  ## Parameters
+
+  - `session_id` - ID of the session
+
+  ## Returns
+
+  - `{:ok, session_map}` where session_map includes all session fields + program_name
+  - `{:error, :not_found}` if session doesn't exist
+  """
+  @spec execute_for_list(String.t()) :: {:ok, map()} | {:error, :not_found}
+  def execute_for_list(session_id) when is_binary(session_id) do
+    with {:ok, session} <- @session_repository.get_by_id(session_id) do
+      program_name = @session_repository.get_program_name(session.program_id)
+
+      enriched =
+        Map.from_struct(session)
+        |> Map.put(:program_name, program_name)
+
+      {:ok, enriched}
+    end
+  end
+
+  @doc """
   Retrieves a session with participation records attached for UI display.
 
   Returns the session with a `participation_records` field containing

--- a/lib/klass_hero/participation/application/use_cases/list_provider_sessions.ex
+++ b/lib/klass_hero/participation/application/use_cases/list_provider_sessions.ex
@@ -5,8 +5,6 @@ defmodule KlassHero.Participation.Application.UseCases.ListProviderSessions do
   Used by provider dashboard to show their assigned sessions.
   """
 
-  alias KlassHero.Participation.Domain.Models.ProgramSession
-
   @session_repository Application.compile_env!(:klass_hero, [:participation, :session_repository])
 
   @type params :: %{
@@ -14,7 +12,7 @@ defmodule KlassHero.Participation.Application.UseCases.ListProviderSessions do
           optional(:date) => Date.t()
         }
 
-  @type result :: {:ok, [ProgramSession.t()]}
+  @type result :: {:ok, [map()]}
 
   @doc """
   Lists sessions for a provider on a specific date.

--- a/lib/klass_hero/participation/domain/ports/for_managing_sessions.ex
+++ b/lib/klass_hero/participation/domain/ports/for_managing_sessions.ex
@@ -32,13 +32,21 @@ defmodule KlassHero.Participation.Domain.Ports.ForManagingSessions do
   @callback update(ProgramSession.t()) ::
               {:ok, ProgramSession.t()} | {:error, :stale_data | :not_found | :validation_failed}
 
-  @doc """
-  Lists sessions for a provider on a specific date, ordered by start_time.
+  @type provider_session :: %{
+          id: String.t(),
+          program_id: String.t(),
+          program_name: String.t() | nil,
+          session_date: Date.t(),
+          start_time: Time.t(),
+          end_time: Time.t(),
+          status: ProgramSession.status(),
+          location: String.t() | nil,
+          notes: String.t() | nil,
+          max_capacity: pos_integer() | nil
+        }
 
-  Note: Requires provider-program relationship in schema for full filtering.
-  Currently filters by date only until schema is updated.
-  """
-  @callback list_by_provider_and_date(binary(), Date.t()) :: [ProgramSession.t()]
+  @doc "Lists sessions for a provider on a specific date, ordered by start_time. Returns enriched maps including program_name."
+  @callback list_by_provider_and_date(binary(), Date.t()) :: [provider_session()]
 
   @doc "Retrieves multiple sessions by their IDs (batch fetch)."
   @callback get_many_by_ids([binary()]) :: [ProgramSession.t()]

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -335,9 +335,9 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   defp humanize_error(reason), do: inspect(reason)
 
   defp update_session_in_stream(socket, session_id) do
-    case Participation.get_session_with_roster(session_id) do
-      {:ok, %{session: session}} ->
-        stream_insert(socket, :sessions, session)
+    case Participation.get_session_with_roster_enriched(session_id) do
+      {:ok, enriched_session} ->
+        stream_insert(socket, :sessions, enriched_session)
 
       {:error, reason} ->
         Logger.error(

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -335,7 +335,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   defp humanize_error(reason), do: inspect(reason)
 
   defp update_session_in_stream(socket, session_id) do
-    case Participation.get_session_with_roster_enriched(session_id) do
+    case Participation.get_session_for_list(session_id) do
       {:ok, enriched_session} ->
         stream_insert(socket, :sessions, enriched_session)
 

--- a/test/klass_hero/participation/adapters/driven/persistence/repositories/session_repository_test.exs
+++ b/test/klass_hero/participation/adapters/driven/persistence/repositories/session_repository_test.exs
@@ -289,6 +289,18 @@ defmodule KlassHero.Participation.Adapters.Driven.Persistence.Repositories.Sessi
       assert Enum.all?(sessions, &(&1.session_date == target_date))
     end
 
+    test "includes program_name from joined programs table" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      target_date = ~D[2025-02-15]
+
+      insert(:program_session_schema, program_id: program.id, session_date: target_date)
+
+      [session] = SessionRepository.list_by_provider_and_date(provider.id, target_date)
+
+      assert session.program_name == program.title
+    end
+
     test "does not return sessions from other providers" do
       provider = insert(:provider_profile_schema)
       other_provider = insert(:provider_profile_schema)

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -53,6 +53,20 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       assert has_element?(view, "button", "Start Session")
     end
 
+    test "shows program name in session card", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id, title: "Morning Yoga")
+
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: Date.utc_today(),
+        status: :scheduled
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+
+      assert has_element?(view, "h3", "Morning Yoga")
+    end
+
     test "does not show sessions for other providers", %{conn: conn} do
       other_provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: other_provider.id)


### PR DESCRIPTION
Closes #470

## Summary

- Added explicit `select` map with `program_name` from a programs table join in `list_by_provider_and_date`, replacing the `ProgramSessionMapper.to_domain/1` call with a lightweight `atomize_status/1` helper
- Defined `@type provider_session` in `ForManagingSessions` port to formalise the enriched map shape returned by the list query
- Added `execute_for_list/1` use case to `GetSessionWithRoster` and exposed it via `Participation.get_session_for_list/1` — fetches only the session and its program name with no roster data
- Wired `sessions_live.ex` stream updates to use `get_session_for_list/1` instead of the heavier `get_session_with_roster/1`, keeping stream items consistent with the initial list shape
- Added repository and LiveView tests covering program name in list results and session card rendering

## Review Focus

- **Return type change in list query** — `list_by_provider_and_date` now returns `[provider_session()]` plain maps instead of `[ProgramSession.t()]` structs; callers that pattern-match on structs will break. Current call path goes through `ListProviderSessions` → stream, which treats items as maps, so this is safe. Verify no other callers: `session_repository.ex:78-100`, `list_provider_sessions.ex:12-19`
- **Two-query path in `execute_for_list`** — calls `get_by_id` then `get_program_name` as two separate queries rather than a single join (the same join already used in `list_by_provider_and_date`). This is a known tradeoff — used only for stream updates, not the initial load. See `get_session_with_roster.ex:88-98`
- **Shape mismatch between list and stream-update items** — `list_by_provider_and_date` returns 10-key maps; `execute_for_list` uses `Map.from_struct` which produces 14 keys (includes `inserted_at`, `updated_at`, `lock_version`). No crash — `participation_card` uses `Map.get` with fallbacks — but the shapes differ. See `participation_components.ex` and `get_session_with_roster.ex:93-98`
- **`atomize_status/1` replaces mapper** — the previous `ProgramSessionMapper.to_domain/1` call is gone; status atom conversion is now done by a private `atomize_status/1` helper. Confirm the helper covers all status values (`:scheduled`, `:in_progress`, `:completed`, `:cancelled`): `session_repository.ex`

## Test Plan

- [x] `mix precommit` passes clean
- [x] `list_by_provider_and_date` returns maps with `program_name` populated (repository test)
- [x] Session card renders program name in `/provider/sessions` LiveView (LiveView test)
- [ ] Navigate to `/provider/sessions` as `claudia.wolf@example.com` and confirm program names appear in session cards
- [ ] Start a session and confirm the stream-update card still shows the correct program name after the status change