### PR TITLE
feat: add FAQ entry for activity types on homepage

### DIFF
--- a/lib/klass_hero_web/live/home_live.ex
+++ b/lib/klass_hero_web/live/home_live.ex
@@ -769,6 +769,16 @@ defmodule KlassHeroWeb.HomeLive do
                 )
               }
             />
+
+            <.faq_item
+              id="faq-13"
+              question={gettext("What types of activities can I find on Klass Hero?")}
+              answer={
+                gettext(
+                  "Tutoring (math, English, German, science), music lessons (piano, guitar, violin), sports coaching (football, tennis, swimming), arts & crafts, STEM workshops, language classes, summer camps, and after-school programmes — all in Berlin."
+                )
+              }
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #135

## Summary

- Added `faq-13` FAQ item to `home_live.ex` listing activity types available on Klass Hero in Berlin

## Review Focus

- **Content accuracy** — answer text lists tutoring, music, sports, arts, STEM, languages, summer camps, and after-school programmes; confirm the Berlin-specific framing is intentional for the current platform scope
- **Gettext** — question and answer strings are wrapped in `gettext/1`; German translations will need adding to `priv/gettext/de/LC_MESSAGES/default.po`

## Test Plan

- [x] `mix precommit` passes clean
- [ ] Navigate to `http://localhost:4000` and verify the new FAQ item is visible and expands correctly