### PR TITLE
feat: show parent name and enrolled child names in direct conversation header

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -63,6 +63,7 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.Application.UseCases.GetBookingUsageInfo
   alias KlassHero.Enrollment.Application.UseCases.GetEnrollment
   alias KlassHero.Enrollment.Application.UseCases.ImportEnrollmentCsv
+  alias KlassHero.Enrollment.Application.UseCases.ListEnrolledChildFirstNamesForParent
   alias KlassHero.Enrollment.Application.UseCases.ListEnrolledIdentityIds
   alias KlassHero.Enrollment.Application.UseCases.ListParentEnrollments
   alias KlassHero.Enrollment.Application.UseCases.ListProgramEnrollments
@@ -247,6 +248,21 @@ defmodule KlassHero.Enrollment do
   @spec enrolled?(String.t(), String.t()) :: boolean()
   def enrolled?(program_id, identity_id) when is_binary(program_id) and is_binary(identity_id) do
     CheckEnrollment.execute(program_id, identity_id)
+  end
+
+  @doc """
+  Returns the first names of children enrolled by a specific parent in a program.
+
+  `parent_user_id` is the parent's user identity ID (i.e. `user.id`).
+  Used by the Messaging context to enrich direct conversation headers.
+
+  Returns [] when the parent has no enrolled children in the program,
+  or when any ACL resolution fails (graceful degradation).
+  """
+  @spec list_enrolled_child_first_names_for_parent(String.t(), String.t()) :: [String.t()]
+  def list_enrolled_child_first_names_for_parent(program_id, parent_user_id)
+      when is_binary(program_id) and is_binary(parent_user_id) do
+    ListEnrolledChildFirstNamesForParent.execute(program_id, parent_user_id)
   end
 
   # ============================================================================

--- a/lib/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent.ex
+++ b/lib/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent.ex
@@ -1,0 +1,66 @@
+defmodule KlassHero.Enrollment.Application.UseCases.ListEnrolledChildFirstNamesForParent do
+  @moduledoc """
+  Returns the first names of children enrolled by a specific parent in a program.
+
+  Used by the Messaging context to enrich the direct conversation header
+  with context about which children the conversation relates to.
+
+  Returns [] when:
+  - The program has no enrollments
+  - The parent has no enrollments in the program
+  - ACL resolution fails (graceful degradation)
+  """
+
+  require Logger
+
+  @enrollment_repository Application.compile_env!(:klass_hero, [
+                           :enrollment,
+                           :for_managing_enrollments
+                         ])
+  @child_info_adapter Application.compile_env!(:klass_hero, [
+                        :enrollment,
+                        :for_resolving_child_info
+                      ])
+  @parent_info_adapter Application.compile_env!(:klass_hero, [
+                         :enrollment,
+                         :for_resolving_parent_info
+                       ])
+
+  @doc """
+  Returns the first names of children enrolled by the given parent in a program.
+
+  `parent_user_id` is the user's identity_id (i.e. `user.id` from Accounts).
+  """
+  @spec execute(String.t(), String.t()) :: [String.t()]
+  def execute(program_id, parent_user_id) when is_binary(program_id) and is_binary(parent_user_id) do
+    Logger.debug(
+      "[Enrollment.ListEnrolledChildFirstNamesForParent] Resolving child names",
+      program_id: program_id,
+      parent_user_id: parent_user_id
+    )
+
+    enrollments = @enrollment_repository.list_by_program(program_id)
+
+    if enrollments == [] do
+      []
+    else
+      parent_ids = enrollments |> Enum.map(& &1.parent_id) |> Enum.uniq()
+      parents = @parent_info_adapter.get_parents_by_ids(parent_ids)
+
+      case Enum.find(parents, fn p -> p.identity_id == parent_user_id end) do
+        nil ->
+          []
+
+        matching_parent ->
+          child_ids =
+            enrollments
+            |> Enum.filter(fn e -> e.parent_id == matching_parent.id end)
+            |> Enum.map(& &1.child_id)
+            |> Enum.uniq()
+
+          @child_info_adapter.get_children_by_ids(child_ids)
+          |> Enum.map(& &1.first_name)
+      end
+    end
+  end
+end

--- a/lib/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent.ex
+++ b/lib/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent.ex
@@ -5,6 +5,15 @@ defmodule KlassHero.Enrollment.Application.UseCases.ListEnrolledChildFirstNamesF
   Used by the Messaging context to enrich the direct conversation header
   with context about which children the conversation relates to.
 
+  ## Return type
+
+  Returns a plain `[String.t()]` rather than the `{:ok, _} | {:error, _}` tuple
+  used by most use cases. This is intentional: the function is a best-effort UI
+  enrichment query with no meaningful error distinction. All failure modes
+  (unknown parent, no enrollments, ACL resolution error) are treated the same
+  way by callers — by showing less context, not by failing. A tagged tuple would
+  add branching overhead with no benefit.
+
   Returns [] when:
   - The program has no enrollments
   - The parent has no enrollments in the program

--- a/lib/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent.ex
+++ b/lib/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent.ex
@@ -39,28 +39,28 @@ defmodule KlassHero.Enrollment.Application.UseCases.ListEnrolledChildFirstNamesF
       parent_user_id: parent_user_id
     )
 
-    enrollments = @enrollment_repository.list_by_program(program_id)
+    case @enrollment_repository.list_by_program(program_id) do
+      [] ->
+        []
 
-    if enrollments == [] do
-      []
-    else
-      parent_ids = enrollments |> Enum.map(& &1.parent_id) |> Enum.uniq()
-      parents = @parent_info_adapter.get_parents_by_ids(parent_ids)
+      enrollments ->
+        parent_ids = enrollments |> Enum.map(& &1.parent_id) |> Enum.uniq()
+        parents = @parent_info_adapter.get_parents_by_ids(parent_ids)
 
-      case Enum.find(parents, fn p -> p.identity_id == parent_user_id end) do
-        nil ->
-          []
+        case Enum.find(parents, fn p -> p.identity_id == parent_user_id end) do
+          nil ->
+            []
 
-        matching_parent ->
-          child_ids =
-            enrollments
-            |> Enum.filter(fn e -> e.parent_id == matching_parent.id end)
-            |> Enum.map(& &1.child_id)
-            |> Enum.uniq()
+          matching_parent ->
+            child_ids =
+              enrollments
+              |> Enum.filter(fn e -> e.parent_id == matching_parent.id end)
+              |> Enum.map(& &1.child_id)
+              |> Enum.uniq()
 
-          @child_info_adapter.get_children_by_ids(child_ids)
-          |> Enum.map(& &1.first_name)
-      end
+            @child_info_adapter.get_children_by_ids(child_ids)
+            |> Enum.map(& &1.first_name)
+        end
     end
   end
 end

--- a/lib/klass_hero_web/live/messaging_live_helper.ex
+++ b/lib/klass_hero_web/live/messaging_live_helper.ex
@@ -387,37 +387,26 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
         p.user_id != current_user_id and not MapSet.member?(provider_user_ids, p.user_id)
       end)
 
-    case parent_participant do
-      nil ->
-        gettext("Conversation")
-
-      %{user_id: parent_user_id} ->
-        case Messaging.get_display_name(parent_user_id) do
-          {:error, _} ->
-            gettext("Conversation")
-
-          {:ok, name} ->
-            child_names =
-              if conversation.program_id do
-                Enrollment.list_enrolled_child_first_names_for_parent(
-                  conversation.program_id,
-                  parent_user_id
-                )
-              else
-                []
-              end
-
-            case child_names do
-              [] ->
-                name
-
-              names ->
-                gettext("%{parent_name}  for  %{child_names}",
-                  parent_name: name,
-                  child_names: Enum.join(names, ", ")
-                )
-            end
+    with %{user_id: parent_user_id} <- parent_participant,
+         {:ok, name} <- Messaging.get_display_name(parent_user_id) do
+      child_names =
+        case conversation.program_id do
+          nil -> []
+          program_id -> Enrollment.list_enrolled_child_first_names_for_parent(program_id, parent_user_id)
         end
+
+      case child_names do
+        [] ->
+          name
+
+        names ->
+          gettext("%{parent_name}  for  %{child_names}",
+            parent_name: name,
+            child_names: Enum.join(names, ", ")
+          )
+      end
+    else
+      _ -> gettext("Conversation")
     end
   end
 

--- a/lib/klass_hero_web/live/messaging_live_helper.ex
+++ b/lib/klass_hero_web/live/messaging_live_helper.ex
@@ -40,6 +40,8 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
       stream_insert: 4
     ]
 
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Enrollment
   alias KlassHero.Messaging
   alias KlassHero.Messaging.Domain.Models.Attachment
   alias KlassHero.Messaging.Domain.Models.Message
@@ -134,9 +136,19 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
 
         {provider_user_ids, provider_name} = resolve_provider_info(conversation)
 
+        scope = socket.assigns.current_scope
+
+        page_title =
+          if (Scope.provider?(scope) or Scope.staff_provider?(scope)) and
+               conversation.type == :direct do
+            resolve_direct_title(conversation, user_id, provider_user_ids)
+          else
+            get_conversation_title(conversation)
+          end
+
         socket =
           socket
-          |> assign(:page_title, get_conversation_title(conversation))
+          |> assign(:page_title, page_title)
           |> assign(:conversation, conversation)
           |> assign(:has_more, has_more)
           |> assign(:messages_empty?, Enum.empty?(messages))
@@ -366,6 +378,41 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
 
       _ ->
         {MapSet.new(staff_ids), nil}
+    end
+  end
+
+  defp resolve_direct_title(conversation, current_user_id, provider_user_ids) do
+    parent_participant =
+      Enum.find(conversation.participants, fn p ->
+        not MapSet.member?(provider_user_ids, p.user_id)
+      end) ||
+        Enum.find(conversation.participants, fn p -> p.user_id != current_user_id end)
+
+    case parent_participant do
+      nil ->
+        gettext("Conversation")
+
+      %{user_id: parent_user_id} ->
+        case Messaging.get_display_name(parent_user_id) do
+          {:error, _} ->
+            gettext("Conversation")
+
+          {:ok, name} ->
+            child_names =
+              if conversation.program_id do
+                Enrollment.list_enrolled_child_first_names_for_parent(
+                  conversation.program_id,
+                  parent_user_id
+                )
+              else
+                []
+              end
+
+            case child_names do
+              [] -> name
+              names -> "#{name}  #{gettext("for")}  #{Enum.join(names, ", ")}"
+            end
+        end
     end
   end
 

--- a/lib/klass_hero_web/live/messaging_live_helper.ex
+++ b/lib/klass_hero_web/live/messaging_live_helper.ex
@@ -384,9 +384,8 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
   defp resolve_direct_title(conversation, current_user_id, provider_user_ids) do
     parent_participant =
       Enum.find(conversation.participants, fn p ->
-        not MapSet.member?(provider_user_ids, p.user_id)
-      end) ||
-        Enum.find(conversation.participants, fn p -> p.user_id != current_user_id end)
+        p.user_id != current_user_id and not MapSet.member?(provider_user_ids, p.user_id)
+      end)
 
     case parent_participant do
       nil ->
@@ -409,8 +408,14 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
               end
 
             case child_names do
-              [] -> name
-              names -> "#{name}  #{gettext("for")}  #{Enum.join(names, ", ")}"
+              [] ->
+                name
+
+              names ->
+                gettext("%{parent_name}  for  %{child_names}",
+                  parent_name: name,
+                  child_names: Enum.join(names, ", ")
+                )
             end
         end
     end

--- a/test/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent_test.exs
+++ b/test/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent_test.exs
@@ -1,0 +1,114 @@
+defmodule KlassHero.Enrollment.Application.UseCases.ListEnrolledChildFirstNamesForParentTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment.Application.UseCases.ListEnrolledChildFirstNamesForParent
+
+  describe "execute/2" do
+    test "returns child first names for a parent enrolled in a program" do
+      program = insert(:program_schema)
+      {child, parent} = insert_child_with_guardian(first_name: "Emma", last_name: "Smith")
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: child.id,
+        parent_id: parent.id,
+        status: "pending"
+      )
+
+      result = ListEnrolledChildFirstNamesForParent.execute(program.id, to_string(parent.identity_id))
+
+      assert result == ["Emma"]
+    end
+
+    test "returns multiple first names when parent has multiple children enrolled" do
+      program = insert(:program_schema)
+      {child1, parent} = insert_child_with_guardian(first_name: "Emma", last_name: "Smith")
+      child2 = insert(:child_schema, first_name: "Liam", last_name: "Smith")
+      insert(:child_guardian_schema, child_id: child2.id, guardian_id: parent.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: child1.id,
+        parent_id: parent.id,
+        status: "pending"
+      )
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: child2.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      result = ListEnrolledChildFirstNamesForParent.execute(program.id, to_string(parent.identity_id))
+
+      assert Enum.sort(result) == ["Emma", "Liam"]
+    end
+
+    test "returns only children for the specified parent when multiple parents are enrolled" do
+      program = insert(:program_schema)
+      {child1, parent1} = insert_child_with_guardian(first_name: "Emma", last_name: "Smith")
+      {child2, parent2} = insert_child_with_guardian(first_name: "Liam", last_name: "Jones")
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: child1.id,
+        parent_id: parent1.id,
+        status: "pending"
+      )
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: child2.id,
+        parent_id: parent2.id,
+        status: "pending"
+      )
+
+      result = ListEnrolledChildFirstNamesForParent.execute(program.id, to_string(parent1.identity_id))
+
+      assert result == ["Emma"]
+    end
+
+    test "returns empty list when parent has no enrollments in the program" do
+      program = insert(:program_schema)
+      {other_child, other_parent} = insert_child_with_guardian()
+      {_child, target_parent} = insert_child_with_guardian()
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: other_child.id,
+        parent_id: other_parent.id,
+        status: "pending"
+      )
+
+      result = ListEnrolledChildFirstNamesForParent.execute(program.id, to_string(target_parent.identity_id))
+
+      assert result == []
+    end
+
+    test "returns empty list when program has no enrollments" do
+      program = insert(:program_schema)
+      parent_user_id = Ecto.UUID.generate()
+
+      assert ListEnrolledChildFirstNamesForParent.execute(program.id, parent_user_id) == []
+    end
+
+    test "returns empty list for unknown parent_user_id" do
+      program = insert(:program_schema)
+      {child, parent} = insert_child_with_guardian()
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: child.id,
+        parent_id: parent.id,
+        status: "pending"
+      )
+
+      unknown_user_id = Ecto.UUID.generate()
+
+      assert ListEnrolledChildFirstNamesForParent.execute(program.id, unknown_user_id) == []
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/messages_live/show_test.exs
+++ b/test/klass_hero_web/live/provider/messages_live/show_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.Provider.MessagesLive.ShowTest do
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
+  alias KlassHero.AccountsFixtures
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.MessageRepository
 
   describe "authentication and authorization" do
@@ -164,6 +165,122 @@ defmodule KlassHeroWeb.Provider.MessagesLive.ShowTest do
 
       html = render(view)
       refute html =~ "Hello from provider!"
+    end
+  end
+
+  describe "direct conversation title" do
+    setup :register_and_log_in_provider
+
+    test "shows parent name and enrolled child first name in header", %{
+      conn: conn,
+      user: provider_user,
+      provider: provider
+    } do
+      parent_user =
+        AccountsFixtures.user_fixture(%{
+          name: "Sarah Johnson",
+          intended_roles: [:parent]
+        })
+
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+      {child, _} = insert_child_with_guardian(first_name: "Emma", last_name: "Smith", parent: parent)
+      program = insert(:program_schema)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        child_id: child.id,
+        parent_id: parent.id,
+        status: "pending"
+      )
+
+      conversation =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          program_id: program.id,
+          type: "direct"
+        )
+
+      insert(:participant_schema, conversation_id: conversation.id, user_id: provider_user.id)
+      insert(:participant_schema, conversation_id: conversation.id, user_id: parent_user.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/messages/#{conversation.id}")
+
+      assert has_element?(view, "h1", "Sarah Johnson")
+      assert has_element?(view, "h1", "Emma")
+    end
+
+    test "shows only parent name when no enrolled children", %{
+      conn: conn,
+      user: provider_user,
+      provider: provider
+    } do
+      parent_user =
+        AccountsFixtures.user_fixture(%{
+          name: "Sarah Johnson",
+          intended_roles: [:parent]
+        })
+
+      program = insert(:program_schema)
+
+      conversation =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          program_id: program.id,
+          type: "direct"
+        )
+
+      insert(:participant_schema, conversation_id: conversation.id, user_id: provider_user.id)
+      insert(:participant_schema, conversation_id: conversation.id, user_id: parent_user.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/messages/#{conversation.id}")
+
+      assert has_element?(view, "h1", "Sarah Johnson")
+      refute render(view) =~ "  for  "
+    end
+
+    test "shows parent name when conversation has no program_id", %{
+      conn: conn,
+      user: provider_user,
+      provider: provider
+    } do
+      parent_user =
+        AccountsFixtures.user_fixture(%{
+          name: "Sarah Johnson",
+          intended_roles: [:parent]
+        })
+
+      conversation =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          program_id: nil,
+          type: "direct"
+        )
+
+      insert(:participant_schema, conversation_id: conversation.id, user_id: provider_user.id)
+      insert(:participant_schema, conversation_id: conversation.id, user_id: parent_user.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/messages/#{conversation.id}")
+
+      assert has_element?(view, "h1", "Sarah Johnson")
+    end
+
+    test "falls back to 'Conversation' when there is no other participant", %{
+      conn: conn,
+      user: provider_user,
+      provider: provider
+    } do
+      conversation =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: "direct"
+        )
+
+      # Only the provider is a participant — no parent to resolve
+      insert(:participant_schema, conversation_id: conversation.id, user_id: provider_user.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/messages/#{conversation.id}")
+
+      assert has_element?(view, "h1", "Conversation")
     end
   end
 


### PR DESCRIPTION
## Summary

Providers viewing a direct conversation now see the parent's full name and enrolled child first names in the conversation header (e.g. `Sarah Johnson  for  Emma, Liam`), replacing the generic "Conversation" fallback. Falls back to parent name only when no children are enrolled, or to "Conversation" if the participant can't be resolved.

## Review Focus

- `messaging_live_helper.ex` — `resolve_direct_title/3`: uses `with` to flatten the dispatch: finds the non-provider participant, fetches their display name via `Messaging.get_display_name/1`, then calls `Enrollment.list_enrolled_child_first_names_for_parent/2` when a `program_id` is present.
- `enrollment/use_cases/list_enrolled_child_first_names_for_parent.ex` — new use case exposed via `Enrollment.list_enrolled_child_first_names_for_parent/2` in the public context API.

## Test Plan

- [ ] `mix test test/klass_hero_web/live/provider/messages_live/show_test.exs` — 4 tests under `"direct conversation title"`: parent+child names, parent only (no children), parent only (no program_id), fallback to "Conversation"
- [ ] `mix test test/klass_hero/enrollment/application/use_cases/list_enrolled_child_first_names_for_parent_test.exs` — 6 unit tests for the new use case
- [ ] `mix precommit` — 4022 passed

Closes #551