### PR TITLE
feat: update Community Focused homepage section with secure messaging copy

### DIFF
--- a/lib/klass_hero_web/live/home_live.ex
+++ b/lib/klass_hero_web/live/home_live.ex
@@ -248,7 +248,7 @@ defmodule KlassHeroWeb.HomeLive do
               title={gettext("Community Focused")}
               description={
                 gettext(
-                  "Built for the Berlin international community. Connect with local families and trusted educators nearby."
+                  "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
                 )
               }
             />

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -180,8 +180,8 @@ msgstr "Buchen Sie Camps, Nachhilfe und Workshops sofort. Unser integrierter Pla
 
 #: lib/klass_hero_web/live/home_live.ex:245
 #, elixir-autogen, elixir-format
-msgid "Built for the Berlin international community. Connect with local families and trusted educators nearby."
-msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Verbinden Sie sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe."
+msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
+msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
 
 #: lib/klass_hero_web/live/booking_live.ex:508
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -180,7 +180,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/home_live.ex:245
 #, elixir-autogen, elixir-format
-msgid "Built for the Berlin international community. Connect with local families and trusted educators nearby."
+msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:508


### PR DESCRIPTION
## Summary

- Updated `gettext` description string in the "Community Focused" feature card on the homepage (`home_live.ex:251`)
- Updated `msgid` in `priv/gettext/en/LC_MESSAGES/default.po` to match new string
- Updated `msgid` and `msgstr` in `priv/gettext/de/LC_MESSAGES/default.po` with German translation

## Review Focus

- **Copy accuracy** — new text reads: "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby." (`lib/klass_hero_web/live/home_live.ex:251`)
- **Gettext sync** — `msgid` in both EN and DE `.po` files updated to match the source string; DE `msgstr` updated with translation (`priv/gettext/de/LC_MESSAGES/default.po:183`)

## Test Plan

- [x] `mix precommit` — all 4012 tests pass, no warnings
- [x] Homepage "Community Focused" card renders new copy at desktop (1280px)
- [x] Homepage "Community Focused" card renders new copy at mobile (375px)
- [ ] Verify German locale renders translated copy correctly

Closes #643