### PR TITLE
feat: add provider business profile card to program detail page

### DIFF
--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -257,6 +257,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           />
           <div
             :if={!@provider.logo_url}
+            id="provider-logo-placeholder"
             class={[
               "w-16 h-16 flex items-center justify-center text-white text-xl font-bold flex-shrink-0",
               Theme.rounded(:full),

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -231,6 +231,52 @@ defmodule KlassHeroWeb.ProviderComponents do
     """
   end
 
+  @doc """
+  Renders a public-facing read-only provider profile card for program detail pages.
+
+  Shows logo (or initials avatar), business name, and description.
+  """
+  attr :provider, :map, required: true
+
+  def provider_public_card(assigns) do
+    ~H"""
+    <div class={[Theme.bg(:surface), Theme.rounded(:xl), "shadow-sm border overflow-hidden", Theme.border_color(:light)]}>
+      <div class={["p-4 border-b", Theme.border_color(:light)]}>
+        <h3 class={["font-semibold flex items-center gap-2", Theme.text_color(:heading)]}>
+          <.icon name="hero-building-storefront" class="w-5 h-5 text-hero-blue-500" />
+          {gettext("About the Provider")}
+        </h3>
+      </div>
+      <div class="p-6">
+        <div class="flex items-start space-x-4">
+          <img
+            :if={@provider.logo_url}
+            src={@provider.logo_url}
+            alt={@provider.name}
+            class={["w-16 h-16 object-cover flex-shrink-0", Theme.rounded(:full)]}
+          />
+          <div
+            :if={!@provider.logo_url}
+            class={[
+              "w-16 h-16 flex items-center justify-center text-white text-xl font-bold flex-shrink-0",
+              Theme.rounded(:full),
+              Theme.gradient(:primary)
+            ]}
+          >
+            {@provider.initials}
+          </div>
+          <div class="flex-1">
+            <h4 class={["font-semibold mb-1", Theme.text_color(:heading)]}>{@provider.name}</h4>
+            <p :if={@provider.description} class={["text-sm leading-relaxed", Theme.text_color(:secondary)]}>
+              {@provider.description}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   attr :status, :atom, required: true
 
   defp verification_status_badge(%{status: :verified} = assigns) do

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -2,6 +2,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   use KlassHeroWeb, :live_view
 
   import KlassHeroWeb.ProgramComponents
+  import KlassHeroWeb.ProviderComponents
   import KlassHeroWeb.UIComponents
 
   alias KlassHero.Enrollment
@@ -9,6 +10,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   alias KlassHero.Provider
   alias KlassHeroWeb.Presenters.ParticipantPolicyPresenter
   alias KlassHeroWeb.Presenters.ProgramPresenter
+  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Theme
 
@@ -26,13 +28,14 @@ defmodule KlassHeroWeb.ProgramDetailLive do
           )
         end
 
-        # Run two independent DB queries in parallel to reduce total mount latency.
+        # Run three independent DB queries in parallel to reduce total mount latency.
         team_task = Task.async(fn -> load_team_members(program.provider_id) end)
-
         policy_task = Task.async(fn -> load_participant_policy(program.id) end)
+        provider_task = Task.async(fn -> load_provider_profile(program.provider_id) end)
 
         team_members = Task.await(team_task)
         participant_policy = Task.await(policy_task)
+        provider_profile = Task.await(provider_task)
 
         socket =
           socket
@@ -42,6 +45,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
           |> assign(team_members: team_members)
           |> assign(registration_status: ProgramCatalog.registration_status(program))
           |> assign(participant_policy: participant_policy)
+          |> assign(provider_profile: provider_profile)
 
         {:ok, socket}
 
@@ -108,6 +112,15 @@ defmodule KlassHeroWeb.ProgramDetailLive do
     case Provider.list_staff_members(provider_id) do
       {:ok, members} -> StaffMemberPresenter.to_card_view_list(members)
       {:error, _} -> []
+    end
+  end
+
+  defp load_provider_profile(nil), do: nil
+
+  defp load_provider_profile(provider_id) do
+    case Provider.get_provider_profile(provider_id) do
+      {:ok, profile} -> ProviderPresenter.to_public_card_view(profile)
+      {:error, _} -> nil
     end
   end
 
@@ -499,6 +512,9 @@ defmodule KlassHeroWeb.ProgramDetailLive do
           </div>
         </section>
         --%>
+
+        <%!-- Provider Profile Card --%>
+        <.provider_public_card :if={@provider_profile} provider={@provider_profile} />
 
         <%!-- Bottom CTA (Hidden on Mobile - Mobile has sticky footer) --%>
         <div class="hidden md:block mt-8">

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -513,7 +513,6 @@ defmodule KlassHeroWeb.ProgramDetailLive do
         </section>
         --%>
 
-        <%!-- Provider Profile Card --%>
         <.provider_public_card :if={@provider_profile} provider={@provider_profile} />
 
         <%!-- Bottom CTA (Hidden on Mobile - Mobile has sticky footer) --%>

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -52,6 +52,24 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   end
 
   @doc """
+  Transforms a Provider domain model to a minimal public card format.
+
+  Used for the read-only provider card on program detail pages.
+
+  Returns a map with: id, name, description, logo_url, initials
+  """
+  @spec to_public_card_view(ProviderProfile.t()) :: map()
+  def to_public_card_view(%ProviderProfile{} = provider) do
+    %{
+      id: provider.id,
+      name: provider.business_name,
+      description: provider.description,
+      logo_url: provider.logo_url,
+      initials: build_initials(provider.business_name)
+    }
+  end
+
+  @doc """
   Derives the aggregate verification status from a list of verification documents.
 
   Status priority:

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -253,6 +253,40 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
     end
   end
 
+  describe "provider profile display" do
+    test "shows provider name and description when provider profile exists", %{conn: conn} do
+      provider =
+        provider_profile_fixture(%{
+          business_name: "Kinder Sports GmbH",
+          description: "We run great camps for kids"
+        })
+
+      program = insert(:program_schema, provider_id: provider.id)
+      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert html =~ "Kinder Sports GmbH"
+      assert html =~ "We run great camps for kids"
+      assert has_element?(view, "h3", "About the Provider")
+    end
+
+    test "shows initials avatar when provider has no logo", %{conn: conn} do
+      provider =
+        provider_profile_fixture(%{business_name: "Kinder Sports", logo_url: nil})
+
+      program = insert(:program_schema, provider_id: provider.id)
+      {:ok, _view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert html =~ "KS"
+    end
+
+    test "hides provider section when program has no provider_id", %{conn: conn} do
+      program = insert(:program_schema, provider_id: nil)
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      refute has_element?(view, "h3", "About the Provider")
+    end
+  end
+
   describe "pricing display" do
     test "renders formatted program price", %{conn: conn} do
       program = insert(:program_schema, price: Decimal.new("149.99"))

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -274,9 +274,9 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
         provider_profile_fixture(%{business_name: "Kinder Sports", logo_url: nil})
 
       program = insert(:program_schema, provider_id: provider.id)
-      {:ok, _view, html} = live(conn, ~p"/programs/#{program.id}")
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
 
-      assert html =~ "KS"
+      assert has_element?(view, "#provider-logo-placeholder", "KS")
     end
 
     test "hides provider section when program has no provider_id", %{conn: conn} do


### PR DESCRIPTION
## Summary

- Added `provider_public_card/1` read-only component to `provider_components.ex` — displays provider logo (or initials avatar), business name, and description
- Added `to_public_card_view/1` to `ProviderPresenter` — transforms `ProviderProfile.t()` to a minimal 5-field public map (id, name, description, logo_url, initials)
- Wired `load_provider_profile/1` into `ProgramDetailLive.mount/3` as a third parallel `Task.async` alongside the existing team members and participant policy fetches
- Card renders in the main content `space-y-6` section, after "Meet the Heroes" and before the bottom CTA enroll button; conditionally hidden when `provider_profile` is `nil`
- Added 3 LiveView tests covering: card shown with name and description, initials avatar when no logo, card absent when `provider_id` is nil

## Review Focus

- **Nil safety** — `load_provider_profile/1` has a dedicated `nil` clause (`program_detail_live.ex:115`) that short-circuits without a DB call; the template uses `:if={@provider_profile}` (`program_detail_live.ex:516`) so the card is fully suppressed when the provider cannot be loaded
- **Boundary compliance** — LiveView accesses Provider only via the public facade `KlassHero.Provider.get_provider_profile/1`; `ProviderProfile` is in the Provider context's `exports` list, so the presenter alias is within declared boundaries
- **Parallel fetch pattern** — provider profile is loaded as `provider_task` concurrently with `team_task` and `policy_task` (`program_detail_live.ex:30-34`), consistent with the existing pattern; total mount latency is bounded by the slowest query, not the sum
- **Presenter shape** — `to_public_card_view/1` (`provider_presenter.ex:54-62`) returns only the 5 fields needed for the public card — no tier info, verification badges, or internal fields are exposed to the template

## Test Plan

- [x] `mix precommit` — 4011 tests pass, zero warnings
- [x] `Provider.get_provider_profile/1` round-trip verified via Tidewave with real seed data
- [x] Initials correctly derived: "Hartmann Sport Studio" → "HS", "Klein Kreativ Werkstatt" → "KK"
- [x] `{:error, :not_found}` path handled gracefully — `provider_profile` assigned `nil`, card hidden
- [x] Card renders on `/programs/:id` for programs with a linked provider (verified against dev DB)
- [x] Card position correct — after program info sections, before enroll CTA
- [ ] Manual check: verify `<img>` logo path renders correctly once a provider with a `logo_url` exists in seed data (no providers currently have logos in dev DB)

Closes #550