### PR TITLE
feat: unify staff invitation email and auto-create provider profile

### DIFF
--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -66,6 +66,7 @@ defmodule KlassHero.Accounts do
 
   - `create_provider_profile: true` — signals the Provider context to
     create a starter provider profile for this user.
+  - `user_name` — used as the default business name for the provider profile.
 
   Returns `:ok` on success or `{:error, reason}` on publish failure.
   """

--- a/lib/klass_hero/accounts/adapters/driven/persistence/schemas/user.ex
+++ b/lib/klass_hero/accounts/adapters/driven/persistence/schemas/user.ex
@@ -89,9 +89,8 @@ defmodule KlassHero.Accounts.User do
   @doc """
   A user changeset for staff provider registration.
 
-  Locks intended_roles to [:staff_provider] by default. When `"also_provider"`
-  is `"true"` in attrs, sets intended_roles to [:staff_provider, :provider]
-  to support dual-role users who want to also offer their own programs.
+  Always sets intended_roles to [:staff_provider, :provider] — every invited
+  staff member automatically gets a starter provider account.
 
   Does not require provider_subscription_tier. Used when a staff member
   registers via an invitation link.
@@ -102,14 +101,11 @@ defmodule KlassHero.Accounts.User do
       uniqueness of the email. Defaults to `true`.
   """
   def staff_registration_changeset(user, attrs, opts \\ []) do
-    also_provider = Map.get(attrs, "also_provider") == "true"
-    roles = if also_provider, do: [:staff_provider, :provider], else: [:staff_provider]
-
     user
     |> cast(attrs, [:name, :email])
     |> validate_required([:name, :email])
     |> validate_length(:name, min: 2, max: 100)
-    |> put_change(:intended_roles, roles)
+    |> put_change(:intended_roles, [:staff_provider, :provider])
     |> validate_email(opts)
     |> password_changeset(attrs, opts)
   end

--- a/lib/klass_hero/accounts/adapters/driving/events/staff_invitation_handler.ex
+++ b/lib/klass_hero/accounts/adapters/driving/events/staff_invitation_handler.ex
@@ -80,6 +80,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler do
 
     case UserNotifier.deliver_staff_added_notification(email, %{
            business_name: business_name,
+           name: user.name,
            dashboard_url: dashboard_url
          }) do
       {:ok, _} ->
@@ -94,10 +95,12 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler do
         )
     end
 
-    # Emit unconditionally: the user exists, linking user_id is correct
-    # regardless of notification delivery. The user will discover staff
-    # access on next login even without the notification email.
-    Accounts.emit_staff_user_registered(user.id, staff_member_id, provider_id)
+    # Emit unconditionally regardless of notification delivery.
+    # Triggers staff linkage and provider profile creation downstream.
+    Accounts.emit_staff_user_registered(user.id, staff_member_id, provider_id, %{
+      create_provider_profile: true,
+      user_name: user.name
+    })
   end
 
   defp emit_sent(staff_member_id, provider_id) do

--- a/lib/klass_hero/accounts/user_notifier.ex
+++ b/lib/klass_hero/accounts/user_notifier.ex
@@ -97,18 +97,29 @@ defmodule KlassHero.Accounts.UserNotifier do
   boundary violations).
   """
   def deliver_staff_invitation(email, %{business_name: business_name, first_name: first_name}, url) do
-    deliver(email, "You've been invited to join #{business_name} on Klass Hero", """
+    deliver(email, "#{business_name} has invited you to join Klass Hero", """
     Hi #{first_name},
 
-    #{business_name} has invited you to join their team on Klass Hero.
+    #{business_name} has added you to their team on Klass Hero — and you're set up
+    to start earning with your own programs too.
 
-    Klass Hero is a platform for managing afterschool activities, camps, and class trips.
+    You'll get a free starter account, linked to #{business_name}'s programs and
+    ready for your own.
 
-    Click the link below to complete your registration:
+    Claim your account & get started:
 
     #{url}
 
+    Here's how it works:
+    1. Click the link above
+    2. Your name is already filled in — just confirm it and set a password
+    3. You'll have a free starter account, linked to #{business_name}'s programs
+
+    No monthly fees. No setup costs.
+
     This invitation expires in 7 days.
+
+    By claiming your account you agree to our terms of service.
 
     If you did not expect this invitation, you can ignore this email.
     """)
@@ -117,18 +128,24 @@ defmodule KlassHero.Accounts.UserNotifier do
   @doc """
   Delivers a notification email when an existing user is added as a staff member.
 
-  `dashboard_url` must be the full URL to the staff dashboard (passed from the web layer
-  to avoid boundary violations).
+  Requires a map with `business_name`, `name`, and `dashboard_url`. URLs must be
+  full URLs (passed from the web layer to avoid boundary violations).
   """
-  def deliver_staff_added_notification(email, %{business_name: business_name, dashboard_url: dashboard_url}) do
-    deliver(email, "You've been added to #{business_name}'s team on Klass Hero", """
-    Hi,
+  def deliver_staff_added_notification(email, %{business_name: business_name, name: name, dashboard_url: dashboard_url}) do
+    deliver(email, "#{business_name} has invited you to join Klass Hero", """
+    Hi #{name},
 
-    #{business_name} has added you to their team on Klass Hero.
+    #{business_name} has added you to their team on Klass Hero — and you now have
+    a free starter account of your own, ready for your programs.
 
-    You can view your assigned programs on your staff dashboard:
+    You're linked to #{business_name}'s programs and can start managing your own
+    activities right away.
+
+    View your staff dashboard:
 
     #{dashboard_url}
+
+    By continuing to use your account you agree to our terms of service.
 
     If you did not expect this, please contact #{business_name} directly.
     """)

--- a/lib/klass_hero_web/live/user_live/staff_invitation.ex
+++ b/lib/klass_hero_web/live/user_live/staff_invitation.ex
@@ -3,7 +3,6 @@ defmodule KlassHeroWeb.UserLive.StaffInvitation do
 
   alias KlassHero.Accounts
   alias KlassHero.Provider
-  alias KlassHeroWeb.Theme
 
   require Logger
 
@@ -70,19 +69,6 @@ defmodule KlassHeroWeb.UserLive.StaffInvitation do
                 autocomplete="new-password"
                 required
               />
-              <label class="flex items-center gap-2 mt-4 cursor-pointer">
-                <input type="hidden" name="user[also_provider]" value="false" />
-                <input
-                  type="checkbox"
-                  name="user[also_provider]"
-                  value="true"
-                  checked={@also_provider}
-                  class="rounded border-zinc-300 text-brand focus:ring-brand"
-                />
-                <span class={Theme.typography(:body_small)}>
-                  {gettext("I also want to offer my own programs")}
-                </span>
-              </label>
               <.button
                 phx-disable-with={gettext("Creating account...")}
                 class="btn btn-primary w-full mt-6"
@@ -128,15 +114,11 @@ defmodule KlassHeroWeb.UserLive.StaffInvitation do
   @impl true
   def handle_event("save", %{"user" => user_params}, socket) do
     staff = socket.assigns.staff_member
-    also_provider = Map.get(user_params, "also_provider") == "true"
     params = Map.put(user_params, "email", staff.email)
 
     case Accounts.register_staff_user(params) do
       {:ok, user} ->
-        event_opts =
-          if also_provider,
-            do: %{create_provider_profile: true, user_name: user.name},
-            else: %{}
+        event_opts = %{create_provider_profile: true, user_name: user.name}
 
         # Trigger: emit_staff_user_registered may fail (PubSub/Oban enqueue)
         # Why: the user account IS created; the critical event infrastructure
@@ -178,17 +160,13 @@ defmodule KlassHeroWeb.UserLive.StaffInvitation do
   @impl true
   def handle_event("validate", %{"user" => user_params}, socket) do
     staff = socket.assigns.staff_member
-    also_provider = Map.get(user_params, "also_provider") == "true"
     params = Map.put(user_params, "email", staff.email)
 
     changeset =
       Accounts.change_staff_registration(params, validate_unique: false)
       |> Map.put(:action, :validate)
 
-    {:noreply,
-     socket
-     |> assign(:also_provider, also_provider)
-     |> assign_form(changeset)}
+    {:noreply, assign_form(socket, changeset)}
   end
 
   defp maybe_persist_expiry(socket, staff_member) do
@@ -221,7 +199,6 @@ defmodule KlassHeroWeb.UserLive.StaffInvitation do
      |> assign(
        staff_member: staff_member,
        error: nil,
-       also_provider: false,
        page_title: gettext("Complete Registration")
      )
      |> assign_form(changeset), temporary_assigns: [form: nil]}

--- a/test/klass_hero/accounts/adapters/driven/persistence/schemas/user_staff_registration_test.exs
+++ b/test/klass_hero/accounts/adapters/driven/persistence/schemas/user_staff_registration_test.exs
@@ -13,19 +13,19 @@ defmodule KlassHero.Accounts.Adapters.Driven.Persistence.Schemas.UserStaffRegist
         })
 
       assert changeset.valid?
-      assert get_change(changeset, :intended_roles) == [:staff_provider]
+      assert get_change(changeset, :intended_roles) == [:staff_provider, :provider]
     end
 
-    test "locks intended_roles to [:staff_provider]" do
+    test "locks intended_roles to [:staff_provider, :provider]" do
       changeset =
         User.staff_registration_changeset(%User{}, %{
           name: "Jane Doe",
           email: "jane@example.com",
           password: "valid_password_123",
-          intended_roles: [:provider]
+          intended_roles: [:parent]
         })
 
-      assert get_change(changeset, :intended_roles) == [:staff_provider]
+      assert get_change(changeset, :intended_roles) == [:staff_provider, :provider]
     end
 
     test "does not require provider_subscription_tier" do
@@ -84,27 +84,15 @@ defmodule KlassHero.Accounts.Adapters.Driven.Persistence.Schemas.UserStaffRegist
     end
   end
 
-  describe "staff_registration_changeset/3 dual-role support" do
-    test "sets [:staff_provider] when also_provider is not set" do
+  describe "staff_registration_changeset/3 always includes :provider role" do
+    test "sets [:staff_provider, :provider] by default" do
       attrs = %{"name" => "Test", "email" => "test@example.com", "password" => "long_password123"}
-
-      changeset = User.staff_registration_changeset(%User{}, attrs, hash_password: false)
-      assert Ecto.Changeset.get_field(changeset, :intended_roles) == [:staff_provider]
-    end
-
-    test "sets [:staff_provider, :provider] when also_provider is 'true'" do
-      attrs = %{
-        "name" => "Test",
-        "email" => "test@example.com",
-        "password" => "long_password123",
-        "also_provider" => "true"
-      }
 
       changeset = User.staff_registration_changeset(%User{}, attrs, hash_password: false)
       assert Ecto.Changeset.get_field(changeset, :intended_roles) == [:staff_provider, :provider]
     end
 
-    test "sets [:staff_provider] when also_provider is 'false'" do
+    test "ignores also_provider param — always includes :provider" do
       attrs = %{
         "name" => "Test",
         "email" => "test@example.com",
@@ -113,7 +101,7 @@ defmodule KlassHero.Accounts.Adapters.Driven.Persistence.Schemas.UserStaffRegist
       }
 
       changeset = User.staff_registration_changeset(%User{}, attrs, hash_password: false)
-      assert Ecto.Changeset.get_field(changeset, :intended_roles) == [:staff_provider]
+      assert Ecto.Changeset.get_field(changeset, :intended_roles) == [:staff_provider, :provider]
     end
   end
 end

--- a/test/klass_hero/accounts/adapters/driving/events/staff_invitation_handler_test.exs
+++ b/test/klass_hero/accounts/adapters/driving/events/staff_invitation_handler_test.exs
@@ -116,7 +116,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandlerTest 
       end)
     end
 
-    test "emits :staff_user_registered for existing user" do
+    test "emits :staff_user_registered with create_provider_profile for existing user" do
       user = user_fixture()
       staff_member_id = Ecto.UUID.generate()
       provider_id = Ecto.UUID.generate()
@@ -138,6 +138,8 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandlerTest 
       assert ie.payload.user_id == to_string(user.id)
       assert ie.payload.staff_member_id == staff_member_id
       assert ie.payload.provider_id == provider_id
+      assert ie.payload.create_provider_profile == true
+      assert ie.payload.user_name == user.name
       assert ie.source_context == :accounts
     end
 

--- a/test/klass_hero/accounts/user_notifier_staff_test.exs
+++ b/test/klass_hero/accounts/user_notifier_staff_test.exs
@@ -4,7 +4,7 @@ defmodule KlassHero.Accounts.UserNotifierStaffTest do
   alias KlassHero.Accounts.UserNotifier
 
   describe "deliver_staff_invitation/3" do
-    test "delivers staff invitation email with registration link" do
+    test "delivers unified invitation email with registration link" do
       assert {:ok, email} =
                UserNotifier.deliver_staff_invitation(
                  "staff@example.com",
@@ -13,28 +13,35 @@ defmodule KlassHero.Accounts.UserNotifierStaffTest do
                )
 
       assert email.to == [{"", "staff@example.com"}]
-      assert email.subject =~ "Fun Academy"
-      assert email.text_body =~ "test-token"
-      assert email.text_body =~ "Fun Academy"
+      assert email.subject == "Fun Academy has invited you to join Klass Hero"
       assert email.text_body =~ "Jane"
+      assert email.text_body =~ "Fun Academy"
+      assert email.text_body =~ "test-token"
+      assert email.text_body =~ "free starter account"
+      assert email.text_body =~ "Claim your account"
+      assert email.text_body =~ "terms of service"
     end
   end
 
   describe "deliver_staff_added_notification/2" do
-    test "delivers notification email for existing users" do
+    test "delivers unified notification email for existing users" do
       assert {:ok, email} =
                UserNotifier.deliver_staff_added_notification(
                  "existing@example.com",
                  %{
                    business_name: "Cool Sports",
+                   name: "Bob",
                    dashboard_url: "http://localhost:4000/staff/dashboard"
                  }
                )
 
       assert email.to == [{"", "existing@example.com"}]
-      assert email.subject =~ "Cool Sports"
+      assert email.subject == "Cool Sports has invited you to join Klass Hero"
+      assert email.text_body =~ "Bob"
       assert email.text_body =~ "Cool Sports"
       assert email.text_body =~ "/staff/dashboard"
+      assert email.text_body =~ "free starter account"
+      assert email.text_body =~ "terms of service"
     end
   end
 end

--- a/test/klass_hero/integration/staff_invitation_saga_test.exs
+++ b/test/klass_hero/integration/staff_invitation_saga_test.exs
@@ -61,10 +61,10 @@ defmodule KlassHero.Integration.StaffInvitationSagaTest do
     )
   end
 
-  defp build_registered_event(user_id, staff) do
+  defp build_registered_event(user_id, staff, opts \\ %{}) do
     AccountsIntegrationEvents.staff_user_registered(
       user_id,
-      %{staff_member_id: staff.id, provider_id: staff.provider_id}
+      Map.merge(%{staff_member_id: staff.id, provider_id: staff.provider_id}, opts)
     )
   end
 
@@ -132,24 +132,31 @@ defmodule KlassHero.Integration.StaffInvitationSagaTest do
                  password: "hello world!"
                })
 
-      assert user.intended_roles == [:staff_provider]
+      assert user.intended_roles == [:staff_provider, :provider]
 
       # Step 5: StaffInvitationStatusHandler handles :staff_user_registered
-      # → status :sent → :accepted, user_id linked
-      registered_event = build_registered_event(to_string(user.id), staff)
+      # → status :sent → :accepted, user_id linked, provider profile created
+      registered_event =
+        build_registered_event(to_string(user.id), staff, %{
+          create_provider_profile: true,
+          user_name: user.name
+        })
+
       assert :ok = StaffInvitationStatusHandler.handle_event(registered_event)
 
       assert {:ok, staff_accepted} = Provider.get_staff_member(staff.id)
       assert staff_accepted.invitation_status == :accepted
       assert staff_accepted.user_id == user.id
 
-      # Step 6: No ProviderProfile was created for the new staff user
-      assert {:error, :not_found} = Provider.get_provider_by_identity(to_string(user.id))
+      # Step 6: ProviderProfile is now created automatically for staff users
+      assert {:ok, profile} = Provider.get_provider_by_identity(to_string(user.id))
+      assert profile.originated_from == :staff_invite
+      assert profile.profile_status == :draft
 
-      # Step 7: Scope resolution gives the user :staff_provider role
-      # Note: staff_member must be active (default) for the role to resolve
+      # Step 7: Scope resolution gives the user both :staff_provider and :provider roles
       scope = Scope.for_user(user) |> Scope.resolve_roles()
       assert :staff_provider in scope.roles
+      assert :provider in scope.roles
     end
   end
 
@@ -195,10 +202,12 @@ defmodule KlassHero.Integration.StaffInvitationSagaTest do
           String.contains?(email_msg.text_body, "/staff/dashboard")
       end)
 
-      # :staff_user_registered is emitted immediately (no :staff_invitation_sent)
+      # :staff_user_registered is emitted immediately with create_provider_profile flag
       registered_ie = assert_integration_event_published(:staff_user_registered)
       assert registered_ie.payload.staff_member_id == staff.id
       assert registered_ie.payload.user_id == to_string(existing_user.id)
+      assert registered_ie.payload.create_provider_profile == true
+      assert registered_ie.payload.user_name == existing_user.name
 
       events = get_published_integration_events()
       types = Enum.map(events, & &1.event_type)
@@ -206,12 +215,23 @@ defmodule KlassHero.Integration.StaffInvitationSagaTest do
 
       # Step 4: StaffInvitationStatusHandler handles :staff_user_registered
       # Staff is still :pending (skipped :sent step on the fast path)
-      registered_event = build_registered_event(to_string(existing_user.id), staff)
+      # Provider profile is created automatically
+      registered_event =
+        build_registered_event(to_string(existing_user.id), staff, %{
+          create_provider_profile: true,
+          user_name: existing_user.name
+        })
+
       assert :ok = StaffInvitationStatusHandler.handle_event(registered_event)
 
       assert {:ok, staff_accepted} = Provider.get_staff_member(staff.id)
       assert staff_accepted.invitation_status == :accepted
       assert staff_accepted.user_id == existing_user.id
+
+      # Step 5: ProviderProfile is created automatically for existing users
+      assert {:ok, profile} = Provider.get_provider_by_identity(to_string(existing_user.id))
+      assert profile.originated_from == :staff_invite
+      assert profile.profile_status == :draft
     end
   end
 

--- a/test/klass_hero_web/live/user_live/staff_invitation_test.exs
+++ b/test/klass_hero_web/live/user_live/staff_invitation_test.exs
@@ -143,7 +143,7 @@ defmodule KlassHeroWeb.UserLive.StaffInvitationTest do
       assert html =~ "Account created"
 
       user = KlassHero.Repo.get_by!(User, email: staff.email)
-      assert user.intended_roles == [:staff_provider]
+      assert user.intended_roles == [:staff_provider, :provider]
     end
   end
 
@@ -170,40 +170,16 @@ defmodule KlassHeroWeb.UserLive.StaffInvitationTest do
     end
   end
 
-  describe "also_provider checkbox" do
-    test "renders the opt-in checkbox", %{conn: conn} do
+  describe "automatic provider profile" do
+    test "does not render the provider opt-in checkbox", %{conn: conn} do
       {raw_token, _staff, _provider} = create_staff_with_invitation()
 
       {:ok, view, _html} = live(conn, ~p"/users/staff-invitation/#{raw_token}")
 
-      assert has_element?(view, "#staff-registration-form input[name='user[also_provider]']")
+      refute has_element?(view, "input[name='user[also_provider]']")
     end
 
-    test "submitting with checkbox checked creates account", %{conn: conn} do
-      {raw_token, staff, _provider} = create_staff_with_invitation()
-
-      {:ok, lv, _html} = live(conn, ~p"/users/staff-invitation/#{raw_token}")
-
-      {:ok, _lv, html} =
-        lv
-        |> form("#staff-registration-form",
-          user: %{
-            name: "Jane Doe",
-            password: "verylongpassword123!",
-            also_provider: "true"
-          }
-        )
-        |> render_submit()
-        |> follow_redirect(conn, ~p"/users/log-in")
-
-      assert html =~ "Account created"
-
-      user = KlassHero.Repo.get_by!(User, email: staff.email)
-      assert :staff_provider in user.intended_roles
-      assert :provider in user.intended_roles
-    end
-
-    test "submitting without checkbox works normally", %{conn: conn} do
+    test "registration always includes :provider in intended_roles", %{conn: conn} do
       {raw_token, staff, _provider} = create_staff_with_invitation()
 
       {:ok, lv, _html} = live(conn, ~p"/users/staff-invitation/#{raw_token}")
@@ -222,7 +198,8 @@ defmodule KlassHeroWeb.UserLive.StaffInvitationTest do
       assert html =~ "Account created"
 
       user = KlassHero.Repo.get_by!(User, email: staff.email)
-      assert user.intended_roles == [:staff_provider]
+      assert :staff_provider in user.intended_roles
+      assert :provider in user.intended_roles
     end
   end
 


### PR DESCRIPTION
## Summary

- Rewrote `deliver_staff_invitation/3` and `deliver_staff_added_notification/2` in `UserNotifier` with unified email copy — subject now reads "[Business] has invited you to join Klass Hero", body covers both staff and provider roles in a single section
- Removed the "I also want to offer my own programs" opt-in checkbox from `StaffInvitation` LiveView — provider profile creation is now unconditional for all invited staff
- Updated `staff_registration_changeset` in `User` schema to always set `intended_roles: [:staff_provider, :provider]`, removing the `also_provider` conditional
- Updated `StaffInvitationHandler` existing-user path to pass `create_provider_profile: true` and `user_name` in the `:staff_user_registered` event, so existing users also get auto provider profile creation
- Updated integration saga tests to verify provider profile creation in both new-user and existing-user paths

## Review Focus

- **Email copy accuracy** — `user_notifier.ex:99-125` (new user) and `user_notifier.ex:134-153` (existing user) contain the revised email copy per the spec in the issue comment. Verify the tone and content match product expectations.
- **Unconditional provider profile creation** — `staff_invitation_handler.ex:101-103` now always passes `create_provider_profile: true` for existing users. Previously this only happened for new users who checked the checkbox (`staff_invitation.ex:117`). Confirm this is the desired behavior for all staff invitations.
- **Changeset role change** — `user.ex:104-108` always sets `[:staff_provider, :provider]`. This is a behavioral change: previously staff-only users got `[:staff_provider]`. Downstream `Scope.resolve_roles/1` resolves roles from record existence, so `intended_roles` is informational, but verify no other code path depends on the old `[:staff_provider]`-only value.
- **Removed `Theme` alias** — `staff_invitation.ex` removed the `Theme` alias (line 6 previously) since the checkbox label that used it was deleted. Verify no other template element in this file needed it.

## Test Plan

- [x] `mix precommit` passes (4068 tests, zero warnings, zero failures)
- [x] Architecture review: 18 checks, zero violations introduced
- [ ] Manual: start Phoenix server, create a staff member with email via provider dashboard, verify the invitation email matches the unified copy
- [ ] Manual: navigate to `/users/staff-invitation/:token`, verify no checkbox is rendered, complete registration, verify user gets both `:staff_provider` and `:provider` roles
- [ ] Manual: add an existing user's email as a staff member, verify the notification email uses the unified copy and a provider profile is auto-created

Closes #363