### PR TITLE
feat: add session counter to provider overview dashboard

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -46,12 +46,12 @@ alias KlassHero.Messaging.Adapters.Driven.ResendEmailContentAdapter
 alias KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler
 alias KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker
 alias KlassHero.Messaging.Adapters.Driving.Workers.RetentionPolicyWorker
-alias KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver
 alias KlassHero.Participation.Adapters.Driven.ACL.ChildInfoResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.BehavioralNoteRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.ParticipationRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.SessionRepository
-alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramListingsRepository
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramRepository
 alias KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,8 +54,10 @@ alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.SessionRe
 alias KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramProviderResolver
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramListingsRepository
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramRepository
+alias KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProgramStaffAssignmentRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProviderProfileRepository
+alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMemberRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.VerificationDocumentRepository
 alias KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitationStatusHandler
@@ -282,7 +284,9 @@ config :klass_hero, :provider,
   for_storing_staff_members: StaffMemberRepository,
   for_querying_staff_members: StaffMemberRepository,
   for_storing_program_staff_assignments: ProgramStaffAssignmentRepository,
-  for_querying_program_staff_assignments: ProgramStaffAssignmentRepository
+  for_querying_program_staff_assignments: ProgramStaffAssignmentRepository,
+  for_querying_session_stats: SessionStatsRepository,
+  for_resolving_session_stats: ParticipationSessionStatsACL
 
 config :klass_hero, :resend_req_options, []
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -46,12 +46,12 @@ alias KlassHero.Messaging.Adapters.Driven.ResendEmailContentAdapter
 alias KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler
 alias KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker
 alias KlassHero.Messaging.Adapters.Driving.Workers.RetentionPolicyWorker
-alias KlassHero.Participation.Adapters.Driven.EnrollmentContext.EnrolledChildrenResolver
-alias KlassHero.Participation.Adapters.Driven.FamilyContext.ChildInfoResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.ChildInfoResolver
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.BehavioralNoteRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.ParticipationRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.SessionRepository
-alias KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramProviderResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramListingsRepository
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramRepository
 alias KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL

--- a/config/config.exs
+++ b/config/config.exs
@@ -258,15 +258,15 @@ config :klass_hero, :messaging,
 
 # Configure Participation bounded context
 config :klass_hero, :participation,
-  session_repository: SessionRepository,
-  session_query_repository: SessionRepository,
-  participation_repository: ParticipationRepository,
-  participation_query_repository: ParticipationRepository,
-  child_info_resolver: ChildInfoResolver,
-  behavioral_note_repository: BehavioralNoteRepository,
-  behavioral_note_query_repository: BehavioralNoteRepository,
-  program_provider_resolver: ProgramProviderResolver,
-  enrolled_children_resolver: EnrolledChildrenResolver
+  for_storing_sessions: SessionRepository,
+  for_querying_sessions: SessionRepository,
+  for_storing_participation_records: ParticipationRepository,
+  for_querying_participation_records: ParticipationRepository,
+  for_resolving_child_info: ChildInfoResolver,
+  for_storing_behavioral_notes: BehavioralNoteRepository,
+  for_querying_behavioral_notes: BehavioralNoteRepository,
+  for_resolving_program_provider: ProgramProviderResolver,
+  for_resolving_enrolled_children: EnrolledChildrenResolver
 
 # Configure Program Catalog bounded context
 config :klass_hero, :program_catalog,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,12 +1,12 @@
 import Config
 
 alias KlassHero.Messaging.Adapters.Driven.ResendEmailContentAdapter
-alias KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver
 alias KlassHero.Participation.Adapters.Driven.ACL.ChildInfoResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.BehavioralNoteRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.ParticipationRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.SessionRepository
-alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
 alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
 alias KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher
 alias KlassHero.Shared.Adapters.Driven.FeatureFlags.StubFeatureFlagsAdapter

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,12 +1,12 @@
 import Config
 
 alias KlassHero.Messaging.Adapters.Driven.ResendEmailContentAdapter
-alias KlassHero.Participation.Adapters.Driven.EnrollmentContext.EnrolledChildrenResolver
-alias KlassHero.Participation.Adapters.Driven.FamilyContext.ChildInfoResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.ChildInfoResolver
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.BehavioralNoteRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.ParticipationRepository
 alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.SessionRepository
-alias KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramProviderResolver
+alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
 alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
 alias KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher
 alias KlassHero.Shared.Adapters.Driven.FeatureFlags.StubFeatureFlagsAdapter

--- a/config/test.exs
+++ b/config/test.exs
@@ -50,15 +50,15 @@ config :klass_hero, :integration_event_publisher,
   pubsub: KlassHero.PubSub
 
 config :klass_hero, :participation,
-  session_repository: SessionRepository,
-  session_query_repository: SessionRepository,
-  participation_repository: ParticipationRepository,
-  participation_query_repository: ParticipationRepository,
-  child_info_resolver: ChildInfoResolver,
-  behavioral_note_repository: BehavioralNoteRepository,
-  behavioral_note_query_repository: BehavioralNoteRepository,
-  program_provider_resolver: ProgramProviderResolver,
-  enrolled_children_resolver: EnrolledChildrenResolver
+  for_storing_sessions: SessionRepository,
+  for_querying_sessions: SessionRepository,
+  for_storing_participation_records: ParticipationRepository,
+  for_querying_participation_records: ParticipationRepository,
+  for_resolving_child_info: ChildInfoResolver,
+  for_storing_behavioral_notes: BehavioralNoteRepository,
+  for_querying_behavioral_notes: BehavioralNoteRepository,
+  for_resolving_program_provider: ProgramProviderResolver,
+  for_resolving_enrolled_children: EnrolledChildrenResolver
 
 config :klass_hero, :resend_req_options,
   plug: {Req.Test, ResendEmailContentAdapter},

--- a/docs/superpowers/plans/2026-04-15-provider-session-counter.md
+++ b/docs/superpowers/plans/2026-04-15-provider-session-counter.md
@@ -1,0 +1,1349 @@
+# Provider Session Counter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Required skills:** `idiomatic-elixir` (activate for every Elixir file).
+> **Tidewave MCP:** Use `project_eval` to verify module compilation, `get_docs` to check Ecto/Phoenix APIs, `execute_sql_query` to inspect table state, and `get_logs` to catch warnings after each task. The Phoenix dev server must be running.
+
+**Goal:** Add an event-driven projection that tracks completed session counts per (provider, program) and surfaces the total on the Provider Overview Dashboard.
+
+**Architecture:** CQRS read model — a `ProviderSessionStats` GenServer subscribes to `session_completed` integration events from the Participation context, maintains a denormalized `provider_session_stats` table, and publishes PubSub updates for real-time dashboard refresh.
+
+**Tech Stack:** Elixir 1.20, Phoenix 1.8, LiveView 1.1, Ecto, Phoenix.PubSub, ExMachina
+
+**Spec:** `docs/superpowers/specs/2026-04-15-provider-session-counter-design.md`
+
+---
+
+## File Structure
+
+### New files (Provider context)
+
+| File | Purpose |
+|------|---------|
+| `priv/repo/migrations/TIMESTAMP_create_provider_session_stats.exs` | Migration for read model table |
+| `lib/klass_hero/provider/domain/read_models/session_stats.ex` | Read model DTO struct |
+| `lib/klass_hero/provider/domain/ports/for_resolving_session_stats.ex` | Bootstrap ACL port |
+| `lib/klass_hero/provider/domain/ports/for_querying_session_stats.ex` | Read repository port |
+| `lib/klass_hero/provider/adapters/driven/persistence/schemas/session_stats_schema.ex` | Ecto schema for read table |
+| `lib/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository.ex` | Read repository |
+| `lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex` | Bootstrap ACL adapter |
+| `lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex` | Projection GenServer |
+
+### New test files
+
+| File | Purpose |
+|------|---------|
+| `test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs` | ACL unit test |
+| `test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs` | Repository unit test |
+| `test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs` | Projection unit test |
+| `test/klass_hero/participation/domain/events/participation_integration_events_test.exs` | Event enrichment test (may exist — append) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `lib/klass_hero/participation/domain/events/participation_events.ex` | Add `provider_id`, `program_title` to `session_completed` payload |
+| `lib/klass_hero/participation/domain/events/participation_integration_events.ex` | Add `provider_id`, `program_title` to required payload keys + typespec |
+| `lib/klass_hero/projection_supervisor.ex` | Switch to `:one_for_one`, add `ProviderSessionStats` child |
+| `lib/klass_hero/provider.ex` | Add Boundary exports for new modules |
+| `config/config.exs` | Wire new ports under `:provider` config key |
+| `test/support/factory.ex` | Add `session_stats_schema_factory` |
+| `lib/klass_hero_web/live/provider/dashboard_live.ex` | Wire session count into overview section |
+
+---
+
+### Task 1: Enrich `session_completed` Event with `provider_id` and `program_title`
+
+**Files:**
+- Modify: `lib/klass_hero/participation/domain/events/participation_events.ex:66-73`
+- Modify: `lib/klass_hero/participation/domain/events/participation_integration_events.ex:237-263`
+- Modify: `lib/klass_hero/participation/application/commands/complete_session.ex:79-81`
+- Test: `test/klass_hero/participation/domain/events/participation_integration_events_test.exs`
+
+- [ ] **Step 1: Write the failing test for enriched integration event**
+
+Create or append to the integration events test file:
+
+```elixir
+# test/klass_hero/participation/domain/events/participation_integration_events_test.exs
+defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEventsTest do
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents
+
+  describe "session_completed/3" do
+    test "requires provider_id and program_title in payload" do
+      event =
+        ParticipationIntegrationEvents.session_completed("session-1", %{
+          program_id: "prog-1",
+          provider_id: "prov-1",
+          program_title: "Art Class"
+        })
+
+      assert event.event_type == :session_completed
+      assert event.payload.provider_id == "prov-1"
+      assert event.payload.program_title == "Art Class"
+      assert event.payload.program_id == "prog-1"
+      assert event.payload.session_id == "session-1"
+    end
+
+    test "raises when provider_id is missing" do
+      assert_raise ArgumentError, ~r/missing required payload keys/, fn ->
+        ParticipationIntegrationEvents.session_completed("session-1", %{
+          program_id: "prog-1"
+        })
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/klass_hero/participation/domain/events/participation_integration_events_test.exs -v`
+Expected: FAIL — current `session_completed/3` only requires `program_id`, not `provider_id` or `program_title`.
+
+- [ ] **Step 3: Update integration event builder to require `provider_id` and `program_title`**
+
+In `lib/klass_hero/participation/domain/events/participation_integration_events.ex`, update the typespec and pattern match:
+
+```elixir
+  @typedoc "Payload for `:session_completed` events."
+  @type session_completed_payload :: %{
+          required(:session_id) => String.t(),
+          required(:program_id) => String.t(),
+          required(:provider_id) => String.t(),
+          required(:program_title) => String.t(),
+          optional(atom()) => term()
+        }
+```
+
+Update the function head (line 239) to pattern match on the new required keys:
+
+```elixir
+  def session_completed(session_id, %{program_id: _, provider_id: _, program_title: _} = payload, opts)
+      when is_binary(session_id) and byte_size(session_id) > 0 do
+    base_payload = %{session_id: session_id}
+
+    IntegrationEvent.new(
+      :session_completed,
+      @source_context,
+      :session,
+      session_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+```
+
+Update the error clause (line 253) to list the new required keys:
+
+```elixir
+  def session_completed(session_id, payload, _opts) when is_binary(session_id) and byte_size(session_id) > 0 do
+    missing = [:program_id, :provider_id, :program_title] -- Map.keys(payload)
+
+    raise ArgumentError,
+          "session_completed missing required payload keys: #{inspect(missing)}"
+  end
+```
+
+- [ ] **Step 4: Update domain event to carry `provider_id` and `program_title`**
+
+The `CompleteSession` use case needs to resolve `provider_id` and pass `program_title` into the domain event so the promotion handler has them. Update `participation_events.ex`:
+
+```elixir
+  @doc "Creates a session_completed event."
+  @spec session_completed(ProgramSession.t(), keyword()) :: DomainEvent.t()
+  def session_completed(%ProgramSession{} = session, opts \\ []) do
+    payload = %{
+      session_id: session.id,
+      program_id: session.program_id,
+      completed_at: DateTime.utc_now()
+    }
+
+    # Merge any extra keys from opts[:extra_payload] (e.g., provider_id, program_title)
+    extra = Keyword.get(opts, :extra_payload, %{})
+
+    DomainEvent.new(:session_completed, session.id, @aggregate_type, Map.merge(payload, extra), opts)
+  end
+```
+
+Update `CompleteSession.publish_session_completed/1` to resolve and include the extra fields:
+
+```elixir
+  @program_provider_resolver Application.compile_env!(:klass_hero, [
+                               :participation,
+                               :program_provider_resolver
+                             ])
+
+  defp publish_session_completed(session) do
+    extra_payload = resolve_provider_details(session.program_id)
+    event = ParticipationEvents.session_completed(session, extra_payload: extra_payload)
+    DomainEventBus.dispatch(@context, event)
+  end
+
+  defp resolve_provider_details(program_id) do
+    case @program_provider_resolver.resolve_provider_id(program_id) do
+      {:ok, provider_id} ->
+        program_title = resolve_program_title(program_id)
+        %{provider_id: provider_id, program_title: program_title}
+
+      {:error, _} ->
+        %{}
+    end
+  end
+
+  defp resolve_program_title(program_id) do
+    case KlassHero.ProgramCatalog.get_programs_by_ids([program_id]) do
+      [program] -> program.title
+      _ -> "Unknown Program"
+    end
+  end
+```
+
+**Note:** Verify ProgramCatalog public API with Tidewave: `get_docs KlassHero.ProgramCatalog.get_programs_by_ids/1`
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `mix test test/klass_hero/participation/domain/events/participation_integration_events_test.exs -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full participation test suite**
+
+Run: `mix test test/klass_hero/participation/ --max-failures 3`
+Expected: PASS — existing tests should still work since the extra payload keys flow through `Map.merge`.
+
+Use Tidewave to verify compilation: `project_eval "Code.ensure_compiled!(KlassHero.Participation.Application.Commands.CompleteSession)"`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/klass_hero/participation/ test/klass_hero/participation/
+git commit -m "feat: enrich session_completed event with provider_id and program_title"
+```
+
+---
+
+### Task 2: Create Migration and Ecto Schema for `provider_session_stats`
+
+**Files:**
+- Create: `priv/repo/migrations/TIMESTAMP_create_provider_session_stats.exs`
+- Create: `lib/klass_hero/provider/adapters/driven/persistence/schemas/session_stats_schema.ex`
+
+- [ ] **Step 1: Generate the migration**
+
+Run: `mix ecto.gen.migration create_provider_session_stats`
+
+- [ ] **Step 2: Write the migration**
+
+```elixir
+defmodule KlassHero.Repo.Migrations.CreateProviderSessionStats do
+  use Ecto.Migration
+
+  def change do
+    create table(:provider_session_stats, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :provider_id, :binary_id, null: false
+      add :program_id, :binary_id, null: false
+      add :program_title, :string, null: false
+      add :sessions_completed_count, :integer, null: false, default: 0
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:provider_session_stats, [:provider_id, :program_id])
+    create index(:provider_session_stats, [:provider_id])
+  end
+end
+```
+
+- [ ] **Step 3: Create the Ecto schema**
+
+```elixir
+# lib/klass_hero/provider/adapters/driven/persistence/schemas/session_stats_schema.ex
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema do
+  @moduledoc """
+  Ecto schema for the provider_session_stats read model table.
+
+  Write-only from the projection's perspective, read-only from the repository's.
+  No user-facing changesets — the projection controls all writes.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @timestamps_opts [type: :utc_datetime]
+
+  schema "provider_session_stats" do
+    field :provider_id, :binary_id
+    field :program_id, :binary_id
+    field :program_title, :string
+    field :sessions_completed_count, :integer, default: 0
+
+    timestamps()
+  end
+end
+```
+
+- [ ] **Step 4: Run migration and verify with Tidewave**
+
+Run: `mix ecto.migrate`
+
+Use Tidewave to verify: `execute_sql_query "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'provider_session_stats' ORDER BY ordinal_position"`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add priv/repo/migrations/*create_provider_session_stats* lib/klass_hero/provider/adapters/driven/persistence/schemas/session_stats_schema.ex
+git commit -m "feat: add provider_session_stats read model table and schema"
+```
+
+---
+
+### Task 3: Create Read Model DTO and Read Repository Port
+
+**Files:**
+- Create: `lib/klass_hero/provider/domain/read_models/session_stats.ex`
+- Create: `lib/klass_hero/provider/domain/ports/for_querying_session_stats.ex`
+
+- [ ] **Step 1: Create the read model DTO**
+
+```elixir
+# lib/klass_hero/provider/domain/read_models/session_stats.ex
+defmodule KlassHero.Provider.Domain.ReadModels.SessionStats do
+  @moduledoc """
+  Read-optimized DTO for provider session statistics.
+
+  Lightweight struct for display — no business logic, no value objects.
+  Populated from the denormalized provider_session_stats read table.
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          provider_id: String.t(),
+          program_id: String.t(),
+          program_title: String.t(),
+          sessions_completed_count: non_neg_integer(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  @enforce_keys [:id, :provider_id, :program_id, :program_title, :sessions_completed_count]
+
+  defstruct [
+    :id,
+    :provider_id,
+    :program_id,
+    :program_title,
+    :inserted_at,
+    :updated_at,
+    sessions_completed_count: 0
+  ]
+
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    struct!(__MODULE__, attrs)
+  end
+end
+```
+
+- [ ] **Step 2: Create the read repository port**
+
+```elixir
+# lib/klass_hero/provider/domain/ports/for_querying_session_stats.ex
+defmodule KlassHero.Provider.Domain.Ports.ForQueryingSessionStats do
+  @moduledoc """
+  Read-only port for querying provider session statistics.
+
+  Separated from the bootstrap ACL port. Read operations never mutate state.
+  """
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionStats
+
+  @doc """
+  Lists all session stats for a provider, ordered by count descending.
+  """
+  @callback list_for_provider(provider_id :: binary()) :: [SessionStats.t()]
+
+  @doc """
+  Returns the total completed session count across all programs for a provider.
+  """
+  @callback get_total_count(provider_id :: binary()) :: non_neg_integer()
+end
+```
+
+- [ ] **Step 3: Verify compilation with Tidewave**
+
+Use Tidewave: `project_eval "Code.ensure_compiled!(KlassHero.Provider.Domain.ReadModels.SessionStats)"`
+Use Tidewave: `project_eval "Code.ensure_compiled!(KlassHero.Provider.Domain.Ports.ForQueryingSessionStats)"`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/klass_hero/provider/domain/read_models/session_stats.ex lib/klass_hero/provider/domain/ports/for_querying_session_stats.ex
+git commit -m "feat: add SessionStats read model DTO and query port"
+```
+
+---
+
+### Task 4: Implement Read Repository (TDD)
+
+**Files:**
+- Create: `lib/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository.ex`
+- Create: `test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs`
+- Modify: `test/support/factory.ex` (add factory)
+- Modify: `config/config.exs` (wire port)
+
+- [ ] **Step 1: Add factory for session_stats_schema**
+
+Append to `test/support/factory.ex` after the existing factories:
+
+```elixir
+  @doc """
+  Factory for creating SessionStatsSchema Ecto schemas (CQRS read model).
+
+  Used in tests that interact with the provider_session_stats read table.
+
+  ## Examples
+
+      schema = insert(:session_stats_schema)
+      schema = insert(:session_stats_schema, sessions_completed_count: 5)
+  """
+  def session_stats_schema_factory do
+    %KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema{
+      id: Ecto.UUID.generate(),
+      provider_id: Ecto.UUID.generate(),
+      program_id: Ecto.UUID.generate(),
+      program_title: sequence(:session_stats_title, &"Program #{&1}"),
+      sessions_completed_count: 0
+    }
+  end
+```
+
+Also add the alias at the top of the factory module alongside the other schema aliases.
+
+- [ ] **Step 2: Write failing tests for the repository**
+
+```elixir
+# test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepositoryTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepository
+  alias KlassHero.Provider.Domain.ReadModels.SessionStats
+
+  describe "list_for_provider/1" do
+    test "returns empty list when no stats exist" do
+      assert [] == SessionStatsRepository.list_for_provider(Ecto.UUID.generate())
+    end
+
+    test "returns stats for the given provider ordered by count descending" do
+      provider_id = Ecto.UUID.generate()
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        program_title: "Art",
+        sessions_completed_count: 3
+      )
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        program_title: "Music",
+        sessions_completed_count: 7
+      )
+
+      # Different provider — should not appear
+      insert(:session_stats_schema, sessions_completed_count: 10)
+
+      result = SessionStatsRepository.list_for_provider(provider_id)
+
+      assert [%SessionStats{program_title: "Music"}, %SessionStats{program_title: "Art"}] = result
+      assert length(result) == 2
+    end
+  end
+
+  describe "get_total_count/1" do
+    test "returns 0 when no stats exist" do
+      assert 0 == SessionStatsRepository.get_total_count(Ecto.UUID.generate())
+    end
+
+    test "returns sum of all session counts for the provider" do
+      provider_id = Ecto.UUID.generate()
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        sessions_completed_count: 3
+      )
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        sessions_completed_count: 7
+      )
+
+      assert 10 == SessionStatsRepository.get_total_count(provider_id)
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `mix test test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs -v`
+Expected: FAIL — module does not exist yet.
+
+- [ ] **Step 4: Implement the repository**
+
+```elixir
+# lib/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository.ex
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepository do
+  @moduledoc """
+  Read-side repository for the provider_session_stats denormalized table.
+
+  Implements the ForQueryingSessionStats port. This repository only reads —
+  the projection GenServer handles all writes.
+
+  Returns lightweight SessionStats DTOs (no domain entities, no value objects).
+  """
+
+  @behaviour KlassHero.Provider.Domain.Ports.ForQueryingSessionStats
+
+  import Ecto.Query
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionStats
+  alias KlassHero.Repo
+
+  @impl true
+  def list_for_provider(provider_id) when is_binary(provider_id) do
+    SessionStatsSchema
+    |> where([s], s.provider_id == ^provider_id)
+    |> order_by([s], desc: s.sessions_completed_count)
+    |> Repo.all()
+    |> Enum.map(&to_dto/1)
+  end
+
+  @impl true
+  def get_total_count(provider_id) when is_binary(provider_id) do
+    SessionStatsSchema
+    |> where([s], s.provider_id == ^provider_id)
+    |> select([s], coalesce(sum(s.sessions_completed_count), 0))
+    |> Repo.one()
+  end
+
+  defp to_dto(%SessionStatsSchema{} = schema) do
+    SessionStats.new(%{
+      id: schema.id,
+      provider_id: schema.provider_id,
+      program_id: schema.program_id,
+      program_title: schema.program_title,
+      sessions_completed_count: schema.sessions_completed_count,
+      inserted_at: schema.inserted_at,
+      updated_at: schema.updated_at
+    })
+  end
+end
+```
+
+- [ ] **Step 5: Wire the port in config.exs**
+
+Add to the `:provider` config block in `config/config.exs`:
+
+```elixir
+config :klass_hero, :provider,
+  repo: KlassHero.Repo,
+  for_storing_provider_profiles: ProviderProfileRepository,
+  for_querying_provider_profiles: ProviderProfileRepository,
+  for_storing_verification_documents: VerificationDocumentRepository,
+  for_querying_verification_documents: VerificationDocumentRepository,
+  for_storing_staff_members: StaffMemberRepository,
+  for_querying_staff_members: StaffMemberRepository,
+  for_storing_program_staff_assignments: ProgramStaffAssignmentRepository,
+  for_querying_program_staff_assignments: ProgramStaffAssignmentRepository,
+  for_querying_session_stats: SessionStatsRepository,
+  for_resolving_session_stats: ParticipationSessionStatsACL
+```
+
+Add the alias to the config aliases block (search for existing Provider aliases).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `mix test test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs -v`
+Expected: PASS
+
+Use Tidewave: `get_logs --tail 20 --grep warning` to check for compilation warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository.ex test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs test/support/factory.ex config/config.exs
+git commit -m "feat: add SessionStats read repository with query port"
+```
+
+---
+
+### Task 5: Create Bootstrap ACL Port and Adapter (TDD)
+
+**Files:**
+- Create: `lib/klass_hero/provider/domain/ports/for_resolving_session_stats.ex`
+- Create: `lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex`
+- Create: `test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs`
+
+- [ ] **Step 1: Create the bootstrap ACL port**
+
+```elixir
+# lib/klass_hero/provider/domain/ports/for_resolving_session_stats.ex
+defmodule KlassHero.Provider.Domain.Ports.ForResolvingSessionStats do
+  @moduledoc """
+  Port for resolving initial session completion counts from the Participation context.
+
+  Used exclusively during projection bootstrap. Cross-context query is acceptable
+  here because it runs once on startup, not on every request.
+  """
+
+  @doc """
+  Returns completed session counts grouped by (provider_id, program_id).
+  """
+  @callback list_completed_session_counts() ::
+              {:ok,
+               [
+                 %{
+                   provider_id: String.t(),
+                   program_id: String.t(),
+                   program_title: String.t(),
+                   sessions_completed_count: non_neg_integer()
+                 }
+               ]}
+              | {:error, term()}
+end
+```
+
+- [ ] **Step 2: Write failing test for the ACL**
+
+```elixir
+# test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs
+defmodule KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACLTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL
+
+  describe "list_completed_session_counts/0" do
+    test "returns empty list when no completed sessions exist" do
+      assert {:ok, []} = ParticipationSessionStatsACL.list_completed_session_counts()
+    end
+
+    test "counts completed sessions grouped by provider and program" do
+      # Create a program owned by a provider
+      provider_schema = insert(:provider_profile_schema)
+      program_schema = insert(:program_schema, provider_id: provider_schema.id)
+
+      # Create completed sessions for this program
+      insert(:program_session_schema,
+        program_id: program_schema.id,
+        status: "completed"
+      )
+
+      insert(:program_session_schema,
+        program_id: program_schema.id,
+        status: "completed"
+      )
+
+      # Create a non-completed session — should NOT be counted
+      insert(:program_session_schema,
+        program_id: program_schema.id,
+        status: "scheduled"
+      )
+
+      {:ok, results} = ParticipationSessionStatsACL.list_completed_session_counts()
+
+      assert [result] = results
+      assert result.provider_id == provider_schema.id
+      assert result.program_id == program_schema.id
+      assert result.program_title == program_schema.title
+      assert result.sessions_completed_count == 2
+    end
+
+    test "groups by program across multiple providers" do
+      provider_a = insert(:provider_profile_schema)
+      provider_b = insert(:provider_profile_schema)
+      program_a = insert(:program_schema, provider_id: provider_a.id, title: "Art")
+      program_b = insert(:program_schema, provider_id: provider_b.id, title: "Music")
+
+      insert(:program_session_schema, program_id: program_a.id, status: "completed")
+      insert(:program_session_schema, program_id: program_b.id, status: "completed")
+      insert(:program_session_schema, program_id: program_b.id, status: "completed")
+
+      {:ok, results} = ParticipationSessionStatsACL.list_completed_session_counts()
+
+      by_provider = Map.new(results, &{&1.provider_id, &1})
+      assert by_provider[provider_a.id].sessions_completed_count == 1
+      assert by_provider[provider_b.id].sessions_completed_count == 2
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `mix test test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 4: Check if `provider_profile_schema` factory exists**
+
+Use Tidewave: `project_eval "KlassHero.Factory.__info__(:functions) |> Enum.filter(fn {name, _} -> name |> to_string() |> String.contains?(\"provider_profile_schema\") end)"`
+
+If missing, add a `provider_profile_schema_factory` to `test/support/factory.ex` using the `ProviderProfileSchema` directly (like the existing `program_schema_factory` pattern).
+
+- [ ] **Step 5: Implement the ACL adapter**
+
+```elixir
+# lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex
+defmodule KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL do
+  @moduledoc """
+  Anti-corruption layer for resolving session completion counts from Participation.
+
+  Cross-context bootstrap query: joins Participation's `program_sessions` with
+  Program Catalog's `programs` to compute counts grouped by (provider_id, program_id).
+
+  Used exclusively during ProviderSessionStats projection bootstrap.
+  """
+
+  @behaviour KlassHero.Provider.Domain.Ports.ForResolvingSessionStats
+
+  import Ecto.Query
+
+  alias KlassHero.Repo
+
+  require Logger
+
+  @impl true
+  def list_completed_session_counts do
+    results =
+      from(s in "program_sessions",
+        join: p in "programs",
+        on: s.program_id == p.id,
+        where: s.status == "completed",
+        group_by: [p.provider_id, p.id, p.title],
+        select: %{
+          provider_id: type(p.provider_id, :binary_id),
+          program_id: type(p.id, :binary_id),
+          program_title: p.title,
+          sessions_completed_count: count(s.id)
+        }
+      )
+      |> Repo.all()
+
+    Logger.debug("[ParticipationSessionStatsACL] Bootstrap query returned #{length(results)} rows")
+
+    {:ok, results}
+  rescue
+    error ->
+      Logger.error("[ParticipationSessionStatsACL] Bootstrap query failed",
+        error: Exception.message(error)
+      )
+
+      {:error, :bootstrap_query_failed}
+  end
+end
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `mix test test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/klass_hero/provider/domain/ports/for_resolving_session_stats.ex lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs test/support/factory.ex
+git commit -m "feat: add bootstrap ACL for session completion counts"
+```
+
+---
+
+### Task 6: Implement Projection GenServer (TDD)
+
+**Files:**
+- Create: `lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex`
+- Create: `test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs`
+
+- [ ] **Step 1: Write failing test for live event handling**
+
+```elixir
+# test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  defp build_session_completed_event(attrs) do
+    %IntegrationEvent{
+      event_id: Ecto.UUID.generate(),
+      event_type: :session_completed,
+      source_context: :participation,
+      entity_type: :session,
+      entity_id: attrs[:session_id] || Ecto.UUID.generate(),
+      occurred_at: DateTime.utc_now(),
+      payload: %{
+        session_id: attrs[:session_id] || Ecto.UUID.generate(),
+        program_id: attrs[:program_id] || Ecto.UUID.generate(),
+        provider_id: attrs[:provider_id] || Ecto.UUID.generate(),
+        program_title: attrs[:program_title] || "Test Program"
+      },
+      metadata: %{},
+      version: 1
+    }
+  end
+
+  describe "handle_info/2 session_completed event" do
+    test "inserts a new row on first event for a provider+program" do
+      # Start the projection without bootstrap (no ACL data)
+      {:ok, pid} = ProviderSessionStats.start_link(name: :"test_projection_#{System.unique_integer()}", skip_bootstrap: true)
+
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      event = build_session_completed_event(
+        provider_id: provider_id,
+        program_id: program_id,
+        program_title: "Art Class"
+      )
+
+      send(pid, {:integration_event, event})
+
+      # Give the GenServer time to process
+      :sys.get_state(pid)
+
+      stats = Repo.all(from s in SessionStatsSchema, where: s.provider_id == ^provider_id)
+
+      assert [stat] = stats
+      assert stat.program_id == program_id
+      assert stat.program_title == "Art Class"
+      assert stat.sessions_completed_count == 1
+    end
+
+    test "increments count on subsequent events for same provider+program" do
+      {:ok, pid} = ProviderSessionStats.start_link(name: :"test_projection_#{System.unique_integer()}", skip_bootstrap: true)
+
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      event = build_session_completed_event(
+        provider_id: provider_id,
+        program_id: program_id,
+        program_title: "Art Class"
+      )
+
+      send(pid, {:integration_event, event})
+      :sys.get_state(pid)
+
+      send(pid, {:integration_event, event})
+      :sys.get_state(pid)
+
+      send(pid, {:integration_event, event})
+      :sys.get_state(pid)
+
+      stat = Repo.one!(from s in SessionStatsSchema,
+        where: s.provider_id == ^provider_id and s.program_id == ^program_id
+      )
+
+      assert stat.sessions_completed_count == 3
+    end
+
+    test "tracks separate counts per program" do
+      {:ok, pid} = ProviderSessionStats.start_link(name: :"test_projection_#{System.unique_integer()}", skip_bootstrap: true)
+
+      provider_id = Ecto.UUID.generate()
+      program_a = Ecto.UUID.generate()
+      program_b = Ecto.UUID.generate()
+
+      send(pid, {:integration_event, build_session_completed_event(
+        provider_id: provider_id,
+        program_id: program_a,
+        program_title: "Art"
+      )})
+
+      send(pid, {:integration_event, build_session_completed_event(
+        provider_id: provider_id,
+        program_id: program_b,
+        program_title: "Music"
+      )})
+
+      send(pid, {:integration_event, build_session_completed_event(
+        provider_id: provider_id,
+        program_id: program_b,
+        program_title: "Music"
+      )})
+
+      :sys.get_state(pid)
+
+      stats =
+        SessionStatsSchema
+        |> where([s], s.provider_id == ^provider_id)
+        |> order_by([s], asc: s.program_title)
+        |> Repo.all()
+
+      assert [art, music] = stats
+      assert art.sessions_completed_count == 1
+      assert music.sessions_completed_count == 2
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mix test test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the projection GenServer**
+
+```elixir
+# lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats do
+  @moduledoc """
+  Event-driven projection maintaining the `provider_session_stats` read table.
+
+  Subscribes to `session_completed` integration events from the Participation
+  context and tracks per-(provider, program) completion counts.
+
+  ## Startup Behavior
+
+  On init:
+  1. Subscribes to the session_completed PubSub topic
+  2. Bootstraps from Participation source data via ACL
+  3. Live events atomically increment counts
+
+  ## Counter Accuracy
+
+  Bootstrap computes the full accurate count from source. Live events increment
+  atomically using SQL `sessions_completed_count + 1`. On crash/restart, the
+  supervisor triggers a fresh bootstrap that recomputes from source.
+  """
+
+  use GenServer
+
+  import Ecto.Query
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  require Logger
+
+  @session_completed_topic "integration:participation:session_completed"
+
+  @acl Application.compile_env!(:klass_hero, [:provider, :for_resolving_session_stats])
+
+  # Client API
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(opts) do
+    unless Keyword.get(opts, :skip_bootstrap, false) do
+      Phoenix.PubSub.subscribe(KlassHero.PubSub, @session_completed_topic)
+    end
+
+    skip_bootstrap = Keyword.get(opts, :skip_bootstrap, false)
+
+    if skip_bootstrap do
+      {:ok, %{bootstrapped: true}}
+    else
+      {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+    end
+  end
+
+  @impl true
+  def handle_continue(:bootstrap, state) do
+    attempt_bootstrap(state)
+  end
+
+  @impl true
+  def handle_info(:retry_bootstrap, state) do
+    {:noreply, state, {:continue, :bootstrap}}
+  end
+
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_completed} = event}, state) do
+    %{provider_id: provider_id, program_id: program_id} = event.payload
+    program_title = Map.get(event.payload, :program_title, "Unknown Program")
+
+    Logger.debug("ProviderSessionStats projecting session_completed",
+      provider_id: provider_id,
+      program_id: program_id,
+      event_id: event.event_id
+    )
+
+    upsert_session_count(provider_id, program_id, program_title)
+    notify_dashboard(provider_id)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    Logger.warning("ProviderSessionStats received unexpected message",
+      message: inspect(msg, limit: 200)
+    )
+
+    {:noreply, state}
+  end
+
+  # Private Functions
+
+  defp attempt_bootstrap(state) do
+    case @acl.list_completed_session_counts() do
+      {:ok, counts} ->
+        bootstrap_counts(counts)
+        Logger.info("ProviderSessionStats projection started", count: length(counts))
+        {:noreply, %{state | bootstrapped: true}}
+
+      {:error, reason} ->
+        retry_count = Map.get(state, :retry_count, 0) + 1
+
+        if retry_count > 3 do
+          raise "ProviderSessionStats bootstrap failed after 3 retries: #{inspect(reason)}"
+        else
+          Logger.error("ProviderSessionStats: bootstrap failed, scheduling retry",
+            reason: inspect(reason),
+            retry_count: retry_count
+          )
+
+          Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
+          {:noreply, Map.put(state, :retry_count, retry_count)}
+        end
+    end
+  end
+
+  defp bootstrap_counts([]), do: :ok
+
+  defp bootstrap_counts(counts) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    entries =
+      Enum.map(counts, fn row ->
+        %{
+          id: Ecto.UUID.generate(),
+          provider_id: row.provider_id,
+          program_id: row.program_id,
+          program_title: row.program_title,
+          sessions_completed_count: row.sessions_completed_count,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    Repo.insert_all(SessionStatsSchema, entries,
+      on_conflict: {:replace_all_except, [:id, :inserted_at]},
+      conflict_target: [:provider_id, :program_id]
+    )
+  end
+
+  defp upsert_session_count(provider_id, program_id, program_title) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    attrs = %{
+      id: Ecto.UUID.generate(),
+      provider_id: provider_id,
+      program_id: program_id,
+      program_title: program_title,
+      sessions_completed_count: 1,
+      inserted_at: now,
+      updated_at: now
+    }
+
+    %SessionStatsSchema{}
+    |> Ecto.Changeset.change(attrs)
+    |> Repo.insert!(
+      on_conflict:
+        from(s in SessionStatsSchema,
+          update: [
+            set: [
+              sessions_completed_count: fragment("? + 1", s.sessions_completed_count),
+              program_title: ^program_title,
+              updated_at: ^now
+            ]
+          ]
+        ),
+      conflict_target: [:provider_id, :program_id]
+    )
+  end
+
+  defp notify_dashboard(provider_id) do
+    Phoenix.PubSub.broadcast(
+      KlassHero.PubSub,
+      "provider:#{provider_id}:stats_updated",
+      :session_stats_updated
+    )
+  end
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mix test test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+git commit -m "feat: add ProviderSessionStats projection GenServer"
+```
+
+---
+
+### Task 7: Refactor ProjectionSupervisor to `:one_for_one`
+
+**Files:**
+- Modify: `lib/klass_hero/projection_supervisor.ex`
+
+- [ ] **Step 1: Update the supervisor strategy and add new child**
+
+```elixir
+defmodule KlassHero.ProjectionSupervisor do
+  @moduledoc """
+  Supervises all CQRS projection GenServers under an isolated subtree.
+
+  Uses `:one_for_one` strategy — each projection crashes and restarts
+  independently. Projections that depend on others during bootstrap
+  (e.g., ProgramListings → VerifiedProviders) handle unavailability
+  via their own retry logic.
+  """
+
+  use Supervisor
+
+  alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
+  alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings
+  alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children = [
+      VerifiedProviders,
+      ProgramListings,
+      ConversationSummaries,
+      ProviderSessionStats
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one, max_restarts: 10, max_seconds: 60)
+  end
+end
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+Run: `mix test --max-failures 5`
+Expected: PASS — projections are disabled in test config (`start_projections: false`), so the supervision strategy change has no test impact.
+
+Use Tidewave to verify the supervisor is healthy in dev: `project_eval "Supervisor.which_children(KlassHero.ProjectionSupervisor)"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/klass_hero/projection_supervisor.ex
+git commit -m "refactor: switch ProjectionSupervisor to one_for_one strategy
+
+Independent supervision prevents cascading restarts between unrelated
+projections. Adds ProviderSessionStats as fourth projection child."
+```
+
+---
+
+### Task 8: Update Boundary Exports for Provider Context
+
+**Files:**
+- Modify: `lib/klass_hero/provider.ex`
+
+- [ ] **Step 1: Add new module exports to Boundary config**
+
+In `lib/klass_hero/provider.ex`, add to the `exports` list:
+
+```elixir
+  use Boundary,
+    top_level?: true,
+    deps: [KlassHero, KlassHero.Shared],
+    exports: [
+      Domain.Models.ProviderProfile,
+      Domain.Models.StaffMember,
+      Domain.Models.VerificationDocument,
+      Domain.Models.ProgramStaffAssignment,
+      Domain.ReadModels.SessionStats,
+      Adapters.Driven.Persistence.ChangeProviderProfile,
+      Adapters.Driven.Persistence.ChangeStaffMember,
+      # Pragmatic export: Backpex admin operates directly on Ecto schemas
+      Adapters.Driven.Persistence.Schemas.ProviderProfileSchema,
+      Adapters.Driven.Persistence.Schemas.StaffMemberSchema
+    ]
+```
+
+- [ ] **Step 2: Verify compilation with Tidewave**
+
+Use Tidewave: `project_eval "Code.ensure_compiled!(KlassHero.Provider)"`
+
+Run: `mix compile --warnings-as-errors`
+Expected: No warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/klass_hero/provider.ex
+git commit -m "chore: export SessionStats read model from Provider boundary"
+```
+
+---
+
+### Task 9: Wire Session Count into Provider Dashboard (TDD)
+
+**Files:**
+- Modify: `lib/klass_hero_web/live/provider/dashboard_live.ex`
+
+- [ ] **Step 1: Update mount to assign initial session count**
+
+In the `mount` function, after the existing assigns (around line 116), add:
+
+```elixir
+|> assign(total_sessions_completed: 0)
+```
+
+- [ ] **Step 2: Update `handle_params(:overview)` to load and subscribe**
+
+```elixir
+  @impl true
+  def handle_params(_params, _uri, %{assigns: %{live_action: :overview}} = socket) do
+    provider = socket.assigns.current_scope.provider
+
+    docs = fetch_verification_docs(provider.id)
+
+    verification_status =
+      ProviderPresenter.verification_status_from_docs(provider.verified, docs)
+
+    business = %{socket.assigns.business | verification_status: verification_status}
+
+    total_sessions = fetch_total_sessions_completed(provider.id)
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(KlassHero.PubSub, "provider:#{provider.id}:stats_updated")
+    end
+
+    {:noreply,
+     socket
+     |> assign(business: business)
+     |> assign(total_sessions_completed: total_sessions)}
+  end
+```
+
+Add the private helper:
+
+```elixir
+  @session_stats_repo Application.compile_env!(:klass_hero, [:provider, :for_querying_session_stats])
+
+  defp fetch_total_sessions_completed(provider_id) do
+    @session_stats_repo.get_total_count(provider_id)
+  end
+```
+
+- [ ] **Step 3: Add `handle_info` for real-time stats updates**
+
+```elixir
+  @impl true
+  def handle_info(:session_stats_updated, socket) do
+    provider = socket.assigns.current_scope.provider
+    total_sessions = fetch_total_sessions_completed(provider.id)
+
+    {:noreply, assign(socket, total_sessions_completed: total_sessions)}
+  end
+```
+
+- [ ] **Step 4: Update `overview_section` template to show session count**
+
+Replace the commented-out stats section (lines 1295-1328) with a single stat card:
+
+```heex
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <.provider_stat_card
+        label={gettext("Sessions Completed")}
+        value={to_string(@total_sessions_completed)}
+        icon="hero-check-badge-mini"
+        icon_bg="bg-green-100"
+        icon_color="text-green-600"
+      />
+    </div>
+```
+
+Keep the TODO comment for other future stat cards removed.
+
+- [ ] **Step 5: Verify compilation and run existing dashboard tests**
+
+Run: `mix compile --warnings-as-errors`
+Run: `mix test test/klass_hero_web/live/provider/ --max-failures 3`
+Expected: PASS
+
+Use Tidewave to verify the page loads: `project_eval "KlassHeroWeb.Provider.DashboardLive.__info__(:functions)"`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/klass_hero_web/live/provider/dashboard_live.ex
+git commit -m "feat: display session counter on provider overview dashboard"
+```
+
+---
+
+### Task 10: Final Verification
+
+- [ ] **Step 1: Run full precommit**
+
+Run: `mix precommit`
+Expected: PASS — compile with warnings-as-errors, format, lint_typography, full test suite.
+
+- [ ] **Step 2: Verify with Tidewave end-to-end**
+
+Use Tidewave to check the projection table state:
+`execute_sql_query "SELECT * FROM provider_session_stats LIMIT 10"`
+
+Use Tidewave to check for warnings in logs:
+`get_logs --tail 50 --grep warning`
+
+Use Tidewave to verify the projection is running:
+`project_eval "Supervisor.which_children(KlassHero.ProjectionSupervisor) |> Enum.map(fn {id, _, _, _} -> id end)"`
+
+- [ ] **Step 3: Run credo**
+
+Run: `mix credo --strict`
+Expected: No new issues.
+
+- [ ] **Step 4: Commit any formatting/credo fixes**
+
+```bash
+git add -A
+git commit -m "chore: formatting and credo fixes"
+```
+
+(Skip if nothing to commit.)
+
+- [ ] **Step 5: Push**
+
+```bash
+git push -u origin feat/372-session-counter
+```

--- a/docs/superpowers/specs/2026-04-15-provider-session-counter-design.md
+++ b/docs/superpowers/specs/2026-04-15-provider-session-counter-design.md
@@ -1,0 +1,157 @@
+# Provider Session Counter — Design Spec
+
+**Issue:** #372 — [FEATURE] Add Session Counter to Provider Overview Dashboard
+**Date:** 2026-04-15
+**Approach:** Event-driven projection (CQRS read model)
+
+## Summary
+
+Add a `ProviderSessionStats` projection that tracks completed session counts per (provider, program). The projection subscribes to `session_completed` integration events from the Participation context, maintains a denormalized read table, and surfaces the count on the Provider Overview Dashboard.
+
+As a prerequisite, refactor the `ProjectionSupervisor` to use `:one_for_one` strategy so all projections (including this new one) are independently supervised.
+
+## Data Model
+
+### New table: `provider_session_stats`
+
+| Column                     | Type               | Notes                                      |
+| -------------------------- | ------------------ | ------------------------------------------ |
+| `id`                       | `binary_id`        | PK                                         |
+| `provider_id`              | `binary_id`        | Not a DB-level FK (read model)             |
+| `program_id`               | `binary_id`        | Not a DB-level FK (read model)             |
+| `program_title`            | `string`           | Denormalized for display                   |
+| `sessions_completed_count` | `integer`          | Default 0                                  |
+| `inserted_at`              | `utc_datetime_usec`|                                            |
+| `updated_at`               | `utc_datetime_usec`|                                            |
+
+- Unique index on `(provider_id, program_id)` — upsert key.
+
+### Read model DTO
+
+`Provider.Domain.ReadModels.SessionStats` — lightweight struct matching the table columns. No business logic.
+
+## Projection GenServer
+
+**Module:** `Provider.Adapters.Driven.Projections.ProviderSessionStats`
+
+### Lifecycle
+
+1. `init/1` — subscribes to `integration:participation:session_completed` via PubSub (subscribe-before-bootstrap pattern).
+2. Bootstraps by computing current counts from Participation source data via ACL.
+3. Live events arrive via `handle_info({:integration_event, event})`.
+
+### Live event handling
+
+On `session_completed`:
+
+1. Extract `provider_id`, `program_id`, `program_title` from event payload.
+2. Upsert into `provider_session_stats`:
+   - `ON CONFLICT (provider_id, program_id) DO UPDATE SET sessions_completed_count = sessions_completed_count + 1, program_title = EXCLUDED.program_title, updated_at = EXCLUDED.updated_at`
+   - Uses SQL-level atomic increment to avoid race conditions.
+3. Publish to `provider:#{provider_id}:stats_updated` PubSub topic for real-time dashboard refresh.
+
+### Counter accuracy strategy
+
+Bootstrap computes the full accurate count from source. Live events increment atomically from there. On crash/restart, the supervisor triggers a fresh bootstrap that recomputes from source, then live events resume.
+
+## Event Enrichment
+
+The `session_completed` integration event in the Participation context currently carries `session_id` and `program_id`. This design adds `provider_id` and `program_title` to the payload.
+
+**Change location:** `ParticipationIntegrationEvents.session_completed/1` builder function (defines the payload shape). The `PromoteIntegrationEvents` handler passes through whatever the builder produces — no changes needed there.
+
+**Source:** Participation already has a `ProgramProviderResolver` ACL that resolves `program_id -> provider_id`. Program title can be resolved from the same source or from the session's associated program.
+
+## Bootstrap & ACL
+
+### New port
+
+`Provider.Domain.Ports.ForResolvingSessionStats` — behaviour with:
+
+```elixir
+@callback list_completed_session_counts() :: {:ok, [map()]} | {:error, term()}
+```
+
+Returns a list of `%{provider_id, program_id, program_title, sessions_completed_count}`.
+
+### New ACL adapter
+
+`Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL`
+
+Cross-context bootstrap query (acceptable for one-time startup):
+- Queries Participation's `sessions` table for completed sessions, grouped by `program_id`.
+- Joins Program Catalog's `programs` table to resolve `provider_id` and `program_title` for each program.
+
+### Bootstrap flow
+
+1. Call ACL via DI-wired port.
+2. Bulk upsert all rows with `insert_all` + `on_conflict: :replace_all_except [:id, :inserted_at]`.
+3. Retry up to 3 times with exponential backoff on failure.
+
+## Read Repository
+
+**Module:** `Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepository`
+
+**Port:** `Provider.Domain.Ports.ForQueryingSessionStats`
+
+Callbacks:
+- `list_for_provider(provider_id)` — returns `[SessionStats.t()]` ordered by `sessions_completed_count DESC`.
+- `get_total_count(provider_id)` — returns `non_neg_integer()` (SUM of all counts).
+
+## Dashboard Integration
+
+**File:** `lib/klass_hero_web/live/provider/dashboard_live.ex`
+
+### On mount / handle_params for `:overview` tab
+
+1. Query read repo for total session count via `get_total_count/1`.
+2. Subscribe to `provider:#{provider_id}:stats_updated` PubSub topic.
+
+### On `handle_info` for stats update
+
+1. Re-query and re-assign the count.
+
+### Template
+
+Render session count in one of the existing (currently commented-out) stats card slots in the overview section.
+
+Per-program breakdown is available in the data but not surfaced in this iteration.
+
+## Supervision Tree Refactor
+
+### Change
+
+Switch `ProjectionSupervisor` strategy from `:rest_for_one` to `:one_for_one`. Each projection crashes and restarts independently.
+
+### Caveat
+
+`ProgramListings` calls `VerifiedProviders.verified?/1` during bootstrap. Under `:one_for_one`, if `VerifiedProviders` is down, that call may fail. The existing retry logic (3 attempts with backoff) should cover this, but verify during implementation. A `Process.whereis` guard is available as fallback.
+
+### New child
+
+Add `ProviderSessionStats` GenServer to the supervision tree. Order does not matter under `:one_for_one`.
+
+## Testing Strategy
+
+### Unit tests
+
+1. **Projection GenServer** — handling `session_completed` event upserts correct row. Replay idempotency: bootstrap + event produces correct count (no double-counting).
+2. **ACL adapter** — bootstrap query correctly counts completed sessions grouped by `(provider_id, program_id)`.
+3. **Read repository** — `list_for_provider/1` returns DTOs ordered by count DESC; `get_total_count/1` sums correctly.
+4. **Event enrichment** — `session_completed` integration event includes `provider_id` in payload.
+
+### Integration tests
+
+5. **Dashboard LiveView** — overview section renders session count.
+6. **Acceptance criteria:**
+   - Session count increments on attendance completion.
+   - Manual check-in without completing does NOT increment (verify `check_in` events don't trigger projection).
+   - Count tied to specific provider and program (test with multiple providers/programs, verify isolation).
+
+## Acceptance Criteria Mapping
+
+| Criterion | Mechanism |
+| --- | --- |
+| Count increments on attendance completion | Projection handles `session_completed` event, atomic increment |
+| Manual check-in without completion does not increment | Only `session_completed` events trigger the projection, not `check_in` |
+| Count tied to specific provider and program | Unique index on `(provider_id, program_id)`, per-row isolation |

--- a/docs/superpowers/specs/2026-04-15-provider-session-counter-design.md
+++ b/docs/superpowers/specs/2026-04-15-provider-session-counter-design.md
@@ -21,8 +21,8 @@ As a prerequisite, refactor the `ProjectionSupervisor` to use `:one_for_one` str
 | `program_id`               | `binary_id`        | Not a DB-level FK (read model)             |
 | `program_title`            | `string`           | Denormalized for display                   |
 | `sessions_completed_count` | `integer`          | Default 0                                  |
-| `inserted_at`              | `utc_datetime_usec`|                                            |
-| `updated_at`               | `utc_datetime_usec`|                                            |
+| `inserted_at`              | `utc_datetime`|                                            |
+| `updated_at`               | `utc_datetime`|                                            |
 
 - Unique index on `(provider_id, program_id)` — upsert key.
 
@@ -79,7 +79,7 @@ Returns a list of `%{provider_id, program_id, program_title, sessions_completed_
 `Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL`
 
 Cross-context bootstrap query (acceptable for one-time startup):
-- Queries Participation's `sessions` table for completed sessions, grouped by `program_id`.
+- Queries Participation's `program_sessions` table for completed sessions, grouped by `program_id`.
 - Joins Program Catalog's `programs` table to resolve `provider_id` and `program_title` for each program.
 
 ### Bootstrap flow

--- a/lib/klass_hero/participation/adapters/driven/acl/child_info_resolver.ex
+++ b/lib/klass_hero/participation/adapters/driven/acl/child_info_resolver.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Participation.Adapters.Driven.FamilyContext.ChildInfoResolver do
+defmodule KlassHero.Participation.Adapters.Driven.ACL.ChildInfoResolver do
   @moduledoc """
   Adapter for resolving child info (name + consent-gated safety data) from Family context.
 

--- a/lib/klass_hero/participation/adapters/driven/acl/enrolled_children_resolver.ex
+++ b/lib/klass_hero/participation/adapters/driven/acl/enrolled_children_resolver.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Participation.Adapters.Driven.EnrollmentContext.EnrolledChildrenResolver do
+defmodule KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver do
   @moduledoc """
   ACL adapter that resolves enrolled child IDs from the Enrollment context.
 

--- a/lib/klass_hero/participation/adapters/driven/acl/program_provider_resolver.ex
+++ b/lib/klass_hero/participation/adapters/driven/acl/program_provider_resolver.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramProviderResolver do
+defmodule KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver do
   @moduledoc """
   Adapter for resolving program ownership from ProgramCatalog context.
 

--- a/lib/klass_hero/participation/adapters/driven/program_catalog_context/program_provider_resolver.ex
+++ b/lib/klass_hero/participation/adapters/driven/program_catalog_context/program_provider_resolver.ex
@@ -39,4 +39,23 @@ defmodule KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramP
 
       {:error, :program_not_found}
   end
+
+  @impl true
+  def resolve_provider_details(program_id) when is_binary(program_id) do
+    case ProgramCatalog.get_programs_by_ids([program_id]) do
+      [program] ->
+        {:ok, %{provider_id: program.provider_id, program_title: program.title}}
+
+      _other ->
+        {:error, :program_not_found}
+    end
+  rescue
+    error ->
+      Logger.warning("[ProgramProviderResolver] Failed to resolve provider details",
+        program_id: program_id,
+        error: Exception.message(error)
+      )
+
+      {:error, :program_not_found}
+  end
 end

--- a/lib/klass_hero/participation/adapters/driven/program_catalog_context/program_provider_resolver.ex
+++ b/lib/klass_hero/participation/adapters/driven/program_catalog_context/program_provider_resolver.ex
@@ -26,32 +26,24 @@ defmodule KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramP
 
   @impl true
   def resolve_provider_id(program_id) when is_binary(program_id) do
-    case ProgramCatalog.get_programs_by_ids([program_id]) do
-      [program] -> {:ok, program.provider_id}
-      _other -> {:error, :program_not_found}
-    end
-  rescue
-    error ->
-      Logger.warning("[ProgramProviderResolver] Failed to resolve provider",
-        program_id: program_id,
-        error: Exception.message(error)
-      )
-
-      {:error, :program_not_found}
+    with {:ok, program} <- fetch_program(program_id), do: {:ok, program.provider_id}
   end
 
   @impl true
   def resolve_provider_details(program_id) when is_binary(program_id) do
-    case ProgramCatalog.get_programs_by_ids([program_id]) do
-      [program] ->
-        {:ok, %{provider_id: program.provider_id, program_title: program.title}}
+    with {:ok, program} <- fetch_program(program_id) do
+      {:ok, %{provider_id: program.provider_id, program_title: program.title}}
+    end
+  end
 
-      _other ->
-        {:error, :program_not_found}
+  defp fetch_program(program_id) do
+    case ProgramCatalog.get_programs_by_ids([program_id]) do
+      [program] -> {:ok, program}
+      _other -> {:error, :program_not_found}
     end
   rescue
     error ->
-      Logger.warning("[ProgramProviderResolver] Failed to resolve provider details",
+      Logger.warning("[ProgramProviderResolver] Failed to fetch program",
         program_id: program_id,
         error: Exception.message(error)
       )

--- a/lib/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views.ex
+++ b/lib/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views.ex
@@ -24,7 +24,7 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
 
   @program_provider_resolver Application.compile_env!(
                                :klass_hero,
-                               [:participation, :program_provider_resolver]
+                               [:participation, :for_resolving_program_provider]
                              )
 
   @doc "Handles a domain event by publishing to generic and provider-specific topics."

--- a/lib/klass_hero/participation/application/commands/anonymize_behavioral_notes_for_child.ex
+++ b/lib/klass_hero/participation/application/commands/anonymize_behavioral_notes_for_child.ex
@@ -11,7 +11,7 @@ defmodule KlassHero.Participation.Application.Commands.AnonymizeBehavioralNotesF
 
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_repository
+                                :for_storing_behavioral_notes
                               ])
 
   @type result :: {:ok, non_neg_integer()}

--- a/lib/klass_hero/participation/application/commands/bulk_check_in.ex
+++ b/lib/klass_hero/participation/application/commands/bulk_check_in.ex
@@ -24,14 +24,14 @@ defmodule KlassHero.Participation.Application.Commands.BulkCheckIn do
 
   @participation_reader Application.compile_env!(:klass_hero, [
                           :participation,
-                          :participation_query_repository
+                          :for_querying_participation_records
                         ])
   @participation_repository Application.compile_env!(:klass_hero, [
                               :participation,
-                              :participation_repository
+                              :for_storing_participation_records
                             ])
 
-  @session_reader Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
+  @session_reader Application.compile_env!(:klass_hero, [:participation, :for_querying_sessions])
 
   @type params :: %{
           required(:record_ids) => [String.t()],

--- a/lib/klass_hero/participation/application/commands/complete_session.ex
+++ b/lib/klass_hero/participation/application/commands/complete_session.ex
@@ -99,7 +99,7 @@ defmodule KlassHero.Participation.Application.Commands.CompleteSession do
           reason: inspect(reason)
         )
 
-        %{provider_id: "unknown", program_title: "Unknown Program"}
+        %{provider_id: "00000000-0000-0000-0000-000000000000", program_title: "Unknown Program"}
     end
   end
 

--- a/lib/klass_hero/participation/application/commands/complete_session.ex
+++ b/lib/klass_hero/participation/application/commands/complete_session.ex
@@ -94,12 +94,12 @@ defmodule KlassHero.Participation.Application.Commands.CompleteSession do
         details
 
       {:error, reason} ->
-        Logger.warning("[CompleteSession] Could not resolve provider details",
+        Logger.warning("Could not resolve provider details for session_completed event",
           program_id: program_id,
-          error: reason
+          reason: inspect(reason)
         )
 
-        %{}
+        %{provider_id: "unknown", program_title: "Unknown Program"}
     end
   end
 

--- a/lib/klass_hero/participation/application/commands/complete_session.ex
+++ b/lib/klass_hero/participation/application/commands/complete_session.ex
@@ -18,6 +18,8 @@ defmodule KlassHero.Participation.Application.Commands.CompleteSession do
   alias KlassHero.Participation.Domain.Models.ProgramSession
   alias KlassHero.Shared.DomainEventBus
 
+  require Logger
+
   @context KlassHero.Participation
 
   @session_reader Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
@@ -30,6 +32,10 @@ defmodule KlassHero.Participation.Application.Commands.CompleteSession do
                               :participation,
                               :participation_repository
                             ])
+  @program_provider_resolver Application.compile_env!(:klass_hero, [
+                               :participation,
+                               :program_provider_resolver
+                             ])
 
   @type result :: {:ok, ProgramSession.t()} | {:error, term()}
 
@@ -77,8 +83,24 @@ defmodule KlassHero.Participation.Application.Commands.CompleteSession do
   end
 
   defp publish_session_completed(session) do
-    event = ParticipationEvents.session_completed(session)
+    extra_payload = resolve_provider_details(session.program_id)
+    event = ParticipationEvents.session_completed(session, extra_payload: extra_payload)
     DomainEventBus.dispatch(@context, event)
+  end
+
+  defp resolve_provider_details(program_id) do
+    case @program_provider_resolver.resolve_provider_details(program_id) do
+      {:ok, details} ->
+        details
+
+      {:error, reason} ->
+        Logger.warning("[CompleteSession] Could not resolve provider details",
+          program_id: program_id,
+          error: reason
+        )
+
+        %{}
+    end
   end
 
   defp publish_child_absent(record, session) do

--- a/lib/klass_hero/participation/application/commands/complete_session.ex
+++ b/lib/klass_hero/participation/application/commands/complete_session.ex
@@ -22,19 +22,19 @@ defmodule KlassHero.Participation.Application.Commands.CompleteSession do
 
   @context KlassHero.Participation
 
-  @session_reader Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
-  @session_repository Application.compile_env!(:klass_hero, [:participation, :session_repository])
+  @session_reader Application.compile_env!(:klass_hero, [:participation, :for_querying_sessions])
+  @session_repository Application.compile_env!(:klass_hero, [:participation, :for_storing_sessions])
   @participation_reader Application.compile_env!(:klass_hero, [
                           :participation,
-                          :participation_query_repository
+                          :for_querying_participation_records
                         ])
   @participation_repository Application.compile_env!(:klass_hero, [
                               :participation,
-                              :participation_repository
+                              :for_storing_participation_records
                             ])
   @program_provider_resolver Application.compile_env!(:klass_hero, [
                                :participation,
-                               :program_provider_resolver
+                               :for_resolving_program_provider
                              ])
 
   @type result :: {:ok, ProgramSession.t()} | {:error, term()}

--- a/lib/klass_hero/participation/application/commands/correct_attendance.ex
+++ b/lib/klass_hero/participation/application/commands/correct_attendance.ex
@@ -11,11 +11,11 @@ defmodule KlassHero.Participation.Application.Commands.CorrectAttendance do
 
   @participation_reader Application.compile_env!(
                           :klass_hero,
-                          [:participation, :participation_query_repository]
+                          [:participation, :for_querying_participation_records]
                         )
   @participation_repository Application.compile_env!(
                               :klass_hero,
-                              [:participation, :participation_repository]
+                              [:participation, :for_storing_participation_records]
                             )
 
   @type params :: %{

--- a/lib/klass_hero/participation/application/commands/create_session.ex
+++ b/lib/klass_hero/participation/application/commands/create_session.ex
@@ -19,7 +19,7 @@ defmodule KlassHero.Participation.Application.Commands.CreateSession do
 
   @context KlassHero.Participation
 
-  @session_repository Application.compile_env!(:klass_hero, [:participation, :session_repository])
+  @session_repository Application.compile_env!(:klass_hero, [:participation, :for_storing_sessions])
 
   @type params :: %{
           required(:program_id) => String.t(),

--- a/lib/klass_hero/participation/application/commands/review_behavioral_note.ex
+++ b/lib/klass_hero/participation/application/commands/review_behavioral_note.ex
@@ -24,11 +24,11 @@ defmodule KlassHero.Participation.Application.Commands.ReviewBehavioralNote do
 
   @behavioral_note_reader Application.compile_env!(:klass_hero, [
                             :participation,
-                            :behavioral_note_query_repository
+                            :for_querying_behavioral_notes
                           ])
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_repository
+                                :for_storing_behavioral_notes
                               ])
 
   @type params :: %{

--- a/lib/klass_hero/participation/application/commands/revise_behavioral_note.ex
+++ b/lib/klass_hero/participation/application/commands/revise_behavioral_note.ex
@@ -22,11 +22,11 @@ defmodule KlassHero.Participation.Application.Commands.ReviseBehavioralNote do
 
   @behavioral_note_reader Application.compile_env!(:klass_hero, [
                             :participation,
-                            :behavioral_note_query_repository
+                            :for_querying_behavioral_notes
                           ])
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_repository
+                                :for_storing_behavioral_notes
                               ])
 
   @type params :: %{

--- a/lib/klass_hero/participation/application/commands/seed_session_roster.ex
+++ b/lib/klass_hero/participation/application/commands/seed_session_roster.ex
@@ -27,11 +27,11 @@ defmodule KlassHero.Participation.Application.Commands.SeedSessionRoster do
 
   @enrolled_children_resolver Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :enrolled_children_resolver
+                                :for_resolving_enrolled_children
                               ])
   @participation_repository Application.compile_env!(:klass_hero, [
                               :participation,
-                              :participation_repository
+                              :for_storing_participation_records
                             ])
 
   @doc """

--- a/lib/klass_hero/participation/application/commands/start_session.ex
+++ b/lib/klass_hero/participation/application/commands/start_session.ex
@@ -18,8 +18,8 @@ defmodule KlassHero.Participation.Application.Commands.StartSession do
 
   @context KlassHero.Participation
 
-  @session_reader Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
-  @session_repository Application.compile_env!(:klass_hero, [:participation, :session_repository])
+  @session_reader Application.compile_env!(:klass_hero, [:participation, :for_querying_sessions])
+  @session_repository Application.compile_env!(:klass_hero, [:participation, :for_storing_sessions])
 
   @type result :: {:ok, ProgramSession.t()} | {:error, term()}
 

--- a/lib/klass_hero/participation/application/commands/submit_behavioral_note.ex
+++ b/lib/klass_hero/participation/application/commands/submit_behavioral_note.ex
@@ -25,11 +25,11 @@ defmodule KlassHero.Participation.Application.Commands.SubmitBehavioralNote do
 
   @participation_reader Application.compile_env!(:klass_hero, [
                           :participation,
-                          :participation_query_repository
+                          :for_querying_participation_records
                         ])
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_repository
+                                :for_storing_behavioral_notes
                               ])
 
   @type params :: %{

--- a/lib/klass_hero/participation/application/queries/get_approved_behavioral_notes.ex
+++ b/lib/klass_hero/participation/application/queries/get_approved_behavioral_notes.ex
@@ -10,7 +10,7 @@ defmodule KlassHero.Participation.Application.Queries.GetApprovedBehavioralNotes
 
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_query_repository
+                                :for_querying_behavioral_notes
                               ])
 
   @type result :: {:ok, [BehavioralNote.t()]}

--- a/lib/klass_hero/participation/application/queries/get_behavioral_note_for_record.ex
+++ b/lib/klass_hero/participation/application/queries/get_behavioral_note_for_record.ex
@@ -10,7 +10,7 @@ defmodule KlassHero.Participation.Application.Queries.GetBehavioralNoteForRecord
 
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_query_repository
+                                :for_querying_behavioral_notes
                               ])
 
   @type result :: {:ok, BehavioralNote.t()} | {:error, :not_found}

--- a/lib/klass_hero/participation/application/queries/get_participation_history.ex
+++ b/lib/klass_hero/participation/application/queries/get_participation_history.ex
@@ -10,7 +10,7 @@ defmodule KlassHero.Participation.Application.Queries.GetParticipationHistory do
 
   @participation_repository Application.compile_env!(:klass_hero, [
                               :participation,
-                              :participation_query_repository
+                              :for_querying_participation_records
                             ])
 
   @type single_child_params :: %{

--- a/lib/klass_hero/participation/application/queries/get_participation_record.ex
+++ b/lib/klass_hero/participation/application/queries/get_participation_record.ex
@@ -7,7 +7,7 @@ defmodule KlassHero.Participation.Application.Queries.GetParticipationRecord do
 
   @participation_repository Application.compile_env!(:klass_hero, [
                               :participation,
-                              :participation_query_repository
+                              :for_querying_participation_records
                             ])
 
   @type result :: {:ok, ParticipationRecord.t()} | {:error, :not_found}

--- a/lib/klass_hero/participation/application/queries/get_session_with_roster.ex
+++ b/lib/klass_hero/participation/application/queries/get_session_with_roster.ex
@@ -10,18 +10,18 @@ defmodule KlassHero.Participation.Application.Queries.GetSessionWithRoster do
   alias KlassHero.Participation.Domain.Models.ParticipationRecord
   alias KlassHero.Participation.Domain.Models.ProgramSession
 
-  @session_repository Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
+  @session_repository Application.compile_env!(:klass_hero, [:participation, :for_querying_sessions])
   @participation_repository Application.compile_env!(:klass_hero, [
                               :participation,
-                              :participation_query_repository
+                              :for_querying_participation_records
                             ])
   @child_info_resolver Application.compile_env!(:klass_hero, [
                          :participation,
-                         :child_info_resolver
+                         :for_resolving_child_info
                        ])
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_query_repository
+                                :for_querying_behavioral_notes
                               ])
 
   @type roster_entry :: %{

--- a/lib/klass_hero/participation/application/queries/list_pending_behavioral_notes.ex
+++ b/lib/klass_hero/participation/application/queries/list_pending_behavioral_notes.ex
@@ -9,7 +9,7 @@ defmodule KlassHero.Participation.Application.Queries.ListPendingBehavioralNotes
 
   @behavioral_note_repository Application.compile_env!(:klass_hero, [
                                 :participation,
-                                :behavioral_note_query_repository
+                                :for_querying_behavioral_notes
                               ])
 
   @type result :: {:ok, [BehavioralNote.t()]}

--- a/lib/klass_hero/participation/application/queries/list_provider_sessions.ex
+++ b/lib/klass_hero/participation/application/queries/list_provider_sessions.ex
@@ -7,7 +7,7 @@ defmodule KlassHero.Participation.Application.Queries.ListProviderSessions do
 
   alias KlassHero.Participation.Domain.Models.ProgramSession
 
-  @session_repository Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
+  @session_repository Application.compile_env!(:klass_hero, [:participation, :for_querying_sessions])
 
   @type params :: %{
           required(:provider_id) => String.t(),

--- a/lib/klass_hero/participation/application/queries/list_sessions.ex
+++ b/lib/klass_hero/participation/application/queries/list_sessions.ex
@@ -7,7 +7,7 @@ defmodule KlassHero.Participation.Application.Queries.ListSessions do
 
   alias KlassHero.Participation.Domain.Models.ProgramSession
 
-  @session_repository Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
+  @session_repository Application.compile_env!(:klass_hero, [:participation, :for_querying_sessions])
 
   @type params :: %{
           optional(:program_id) => String.t(),

--- a/lib/klass_hero/participation/application/shared.ex
+++ b/lib/klass_hero/participation/application/shared.ex
@@ -14,14 +14,14 @@ defmodule KlassHero.Participation.Application.Shared do
 
   @participation_reader Application.compile_env!(:klass_hero, [
                           :participation,
-                          :participation_query_repository
+                          :for_querying_participation_records
                         ])
   @participation_repository Application.compile_env!(:klass_hero, [
                               :participation,
-                              :participation_repository
+                              :for_storing_participation_records
                             ])
 
-  @session_reader Application.compile_env!(:klass_hero, [:participation, :session_query_repository])
+  @session_reader Application.compile_env!(:klass_hero, [:participation, :for_querying_sessions])
 
   @doc """
   Normalizes notes by trimming whitespace and converting empty strings to nil.

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -66,13 +66,13 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   def session_completed(%ProgramSession{} = session, opts \\ []) do
     {extra, event_opts} = Keyword.pop(opts, :extra_payload, %{})
 
-    payload =
-      %{
-        session_id: session.id,
-        program_id: session.program_id,
-        completed_at: DateTime.utc_now()
-      }
-      |> Map.merge(extra)
+    base_payload = %{
+      session_id: session.id,
+      program_id: session.program_id,
+      completed_at: DateTime.utc_now()
+    }
+
+    payload = Map.merge(extra, base_payload)
 
     DomainEvent.new(:session_completed, session.id, @aggregate_type, payload, event_opts)
   end

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -64,13 +64,17 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   @doc "Creates a session_completed event."
   @spec session_completed(ProgramSession.t(), keyword()) :: DomainEvent.t()
   def session_completed(%ProgramSession{} = session, opts \\ []) do
-    payload = %{
-      session_id: session.id,
-      program_id: session.program_id,
-      completed_at: DateTime.utc_now()
-    }
+    {extra, event_opts} = Keyword.pop(opts, :extra_payload, %{})
 
-    DomainEvent.new(:session_completed, session.id, @aggregate_type, payload, opts)
+    payload =
+      %{
+        session_id: session.id,
+        program_id: session.program_id,
+        completed_at: DateTime.utc_now()
+      }
+      |> Map.merge(extra)
+
+    DomainEvent.new(:session_completed, session.id, @aggregate_type, payload, event_opts)
   end
 
   @doc "Creates a roster_seeded event."

--- a/lib/klass_hero/participation/domain/events/participation_integration_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_integration_events.ex
@@ -228,7 +228,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents d
   ## Parameters
 
   - `session_id` - The ID of the completed session
-  - `payload` - Event-specific data (program_id)
+  - `payload` - Event-specific data (program_id, provider_id, program_title)
   - `opts` - Metadata options (correlation_id, causation_id)
 
   ## Raises

--- a/lib/klass_hero/participation/domain/events/participation_integration_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_integration_events.ex
@@ -52,6 +52,8 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents d
   @type session_completed_payload :: %{
           required(:session_id) => String.t(),
           required(:program_id) => String.t(),
+          required(:provider_id) => String.t(),
+          required(:program_title) => String.t(),
           optional(atom()) => term()
         }
 
@@ -236,7 +238,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents d
   """
   def session_completed(session_id, payload \\ %{}, opts \\ [])
 
-  def session_completed(session_id, %{program_id: _} = payload, opts)
+  def session_completed(session_id, %{program_id: _, provider_id: _, program_title: _} = payload, opts)
       when is_binary(session_id) and byte_size(session_id) > 0 do
     base_payload = %{session_id: session_id}
 
@@ -251,7 +253,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents d
   end
 
   def session_completed(session_id, payload, _opts) when is_binary(session_id) and byte_size(session_id) > 0 do
-    missing = [:program_id] -- Map.keys(payload)
+    missing = [:program_id, :provider_id, :program_title] -- Map.keys(payload)
 
     raise ArgumentError,
           "session_completed missing required payload keys: #{inspect(missing)}"

--- a/lib/klass_hero/participation/domain/ports/for_resolving_program_provider.ex
+++ b/lib/klass_hero/participation/domain/ports/for_resolving_program_provider.ex
@@ -24,4 +24,13 @@ defmodule KlassHero.Participation.Domain.Ports.ForResolvingProgramProvider do
   """
   @callback resolve_provider_id(program_id :: binary()) ::
               {:ok, binary()} | {:error, :program_not_found}
+
+  @doc """
+  Resolves provider details (provider_id and program_title) for a given program.
+
+  Returns `{:ok, %{provider_id: binary(), program_title: binary()}}` or
+  `{:error, :program_not_found}`.
+  """
+  @callback resolve_provider_details(program_id :: binary()) ::
+              {:ok, %{provider_id: binary(), program_title: binary()}} | {:error, :program_not_found}
 end

--- a/lib/klass_hero/projection_supervisor.ex
+++ b/lib/klass_hero/projection_supervisor.ex
@@ -2,13 +2,10 @@ defmodule KlassHero.ProjectionSupervisor do
   @moduledoc """
   Supervises all CQRS projection GenServers under an isolated subtree.
 
-  Uses `:rest_for_one` strategy because ProgramListings depends on
-  VerifiedProviders during bootstrap (calls `VerifiedProviders.verified?/1`).
-  If VerifiedProviders crashes, ProgramListings must also restart to
-  re-bootstrap with correct verification data.
-
-  Isolated supervision prevents projection crashes from taking down
-  infrastructure children (Repo, PubSub, Endpoint) in the top-level supervisor.
+  Uses `:one_for_one` strategy — each projection crashes and restarts
+  independently. Projections that depend on others during bootstrap
+  (e.g., ProgramListings → VerifiedProviders) handle unavailability
+  via their own retry logic.
   """
 
   use Supervisor
@@ -16,6 +13,7 @@ defmodule KlassHero.ProjectionSupervisor do
   alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
 
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
@@ -24,14 +22,12 @@ defmodule KlassHero.ProjectionSupervisor do
   @impl true
   def init(_init_arg) do
     children = [
-      # Trigger: VerifiedProviders must start before ProgramListings
-      # Why: ProgramListings.bootstrap calls VerifiedProviders.verified?/1
-      # Outcome: rest_for_one ensures ProgramListings restarts if VerifiedProviders crashes
       VerifiedProviders,
       ProgramListings,
-      ConversationSummaries
+      ConversationSummaries,
+      ProviderSessionStats
     ]
 
-    Supervisor.init(children, strategy: :rest_for_one, max_restarts: 10, max_seconds: 60)
+    Supervisor.init(children, strategy: :one_for_one, max_restarts: 10, max_seconds: 60)
   end
 end

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -482,6 +482,16 @@ defmodule KlassHero.Provider do
     ProgramStaffAssignmentQueries.list_active_for_staff_member(staff_member_id)
   end
 
+  @session_stats_repo Application.compile_env!(:klass_hero, [:provider, :for_querying_session_stats])
+
+  @doc """
+  Returns the total completed session count across all programs for a provider.
+  """
+  @spec get_total_session_count(String.t()) :: non_neg_integer()
+  def get_total_session_count(provider_id) when is_binary(provider_id) do
+    @session_stats_repo.get_total_count(provider_id)
+  end
+
   # ===========================================================================
   # Forms
   # ===========================================================================

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -30,6 +30,7 @@ defmodule KlassHero.Provider do
       Domain.Models.StaffMember,
       Domain.Models.VerificationDocument,
       Domain.Models.ProgramStaffAssignment,
+      Domain.ReadModels.SessionStats,
       Adapters.Driven.Persistence.ChangeProviderProfile,
       Adapters.Driven.Persistence.ChangeStaffMember,
       # Pragmatic export: Backpex admin operates directly on Ecto schemas

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -31,6 +31,7 @@ defmodule KlassHero.Provider do
       Domain.Models.VerificationDocument,
       Domain.Models.ProgramStaffAssignment,
       Domain.ReadModels.SessionStats,
+      Adapters.Driven.Persistence.Repositories.SessionStatsRepository,
       Adapters.Driven.Persistence.ChangeProviderProfile,
       Adapters.Driven.Persistence.ChangeStaffMember,
       # Pragmatic export: Backpex admin operates directly on Ecto schemas

--- a/lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex
+++ b/lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex
@@ -1,0 +1,53 @@
+defmodule KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL do
+  @moduledoc """
+  Anti-corruption layer for resolving session completion counts from Participation.
+
+  Cross-context bootstrap query: joins Participation's `program_sessions` with
+  Program Catalog's `programs` to compute counts grouped by (provider_id, program_id).
+
+  Used exclusively during ProviderSessionStats projection bootstrap.
+  """
+
+  @behaviour KlassHero.Provider.Domain.Ports.ForResolvingSessionStats
+
+  use KlassHero.Shared.Tracing
+
+  import Ecto.Query
+
+  alias KlassHero.Repo
+
+  require Logger
+
+  @impl true
+  def list_completed_session_counts do
+    span do
+      set_attributes("acl",
+        source: "provider",
+        target: "participation",
+        operation: "list_completed_session_counts"
+      )
+
+      results =
+        from(s in "program_sessions",
+          join: p in "programs",
+          on: s.program_id == p.id,
+          where: s.status == "completed",
+          group_by: [p.provider_id, p.id, p.title],
+          select: %{
+            provider_id: type(p.provider_id, :binary_id),
+            program_id: type(p.id, :binary_id),
+            program_title: p.title,
+            sessions_completed_count: count(s.id)
+          }
+        )
+        |> Repo.all()
+
+      {:ok, results}
+    end
+  rescue
+    error ->
+      Logger.error("[ParticipationSessionStatsACL] Bootstrap query failed: #{Exception.message(error)}")
+
+      {:error, :bootstrap_query_failed}
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository.ex
@@ -1,0 +1,47 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepository do
+  @moduledoc """
+  Read-side repository for the provider_session_stats denormalized table.
+
+  Implements the ForQueryingSessionStats port. This repository only reads —
+  the projection GenServer handles all writes.
+
+  Returns lightweight SessionStats DTOs (no domain entities, no value objects).
+  """
+
+  @behaviour KlassHero.Provider.Domain.Ports.ForQueryingSessionStats
+
+  import Ecto.Query
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionStats
+  alias KlassHero.Repo
+
+  @impl true
+  def list_for_provider(provider_id) when is_binary(provider_id) do
+    SessionStatsSchema
+    |> where([s], s.provider_id == ^provider_id)
+    |> order_by([s], desc: s.sessions_completed_count)
+    |> Repo.all()
+    |> Enum.map(&to_dto/1)
+  end
+
+  @impl true
+  def get_total_count(provider_id) when is_binary(provider_id) do
+    SessionStatsSchema
+    |> where([s], s.provider_id == ^provider_id)
+    |> select([s], coalesce(sum(s.sessions_completed_count), 0))
+    |> Repo.one()
+  end
+
+  defp to_dto(%SessionStatsSchema{} = schema) do
+    SessionStats.new(%{
+      id: schema.id,
+      provider_id: schema.provider_id,
+      program_id: schema.program_id,
+      program_title: schema.program_title,
+      sessions_completed_count: schema.sessions_completed_count,
+      inserted_at: schema.inserted_at,
+      updated_at: schema.updated_at
+    })
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/persistence/schemas/session_stats_schema.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/schemas/session_stats_schema.ex
@@ -1,0 +1,22 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema do
+  @moduledoc """
+  Ecto schema for the provider_session_stats read model table.
+
+  Write-only from the projection's perspective, read-only from the repository's.
+  No user-facing changesets — the projection controls all writes.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @timestamps_opts [type: :utc_datetime]
+
+  schema "provider_session_stats" do
+    field :provider_id, :binary_id
+    field :program_id, :binary_id
+    field :program_title, :string
+    field :sessions_completed_count, :integer, default: 0
+
+    timestamps()
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex
@@ -1,0 +1,229 @@
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats do
+  @moduledoc """
+  Event-driven projection maintaining the `provider_session_stats` read table.
+
+  This GenServer subscribes to `session_completed` integration events from the
+  Participation context and maintains a denormalized counter of completed sessions
+  per provider+program pair.
+
+  ## Architecture
+
+  This is a "driven adapter" in the Ports & Adapters architecture — it's driven
+  by integration events from the Participation context. The read-side repository
+  (`SessionStatsRepository`) queries the table this projection writes.
+
+  ## Startup Behavior
+
+  On init, the GenServer:
+  1. Subscribes to the `integration:participation:session_completed` PubSub topic
+  2. Uses `handle_continue(:bootstrap)` to bulk-upsert initial counts from the ACL
+
+  Pass `skip_bootstrap: true` in tests to skip both PubSub subscription and
+  bootstrap, allowing direct `send/2` of events for isolated testing.
+
+  ## Event Handling
+
+  - `:session_completed` — atomic SQL increment of `sessions_completed_count`
+    via `INSERT ... ON CONFLICT DO UPDATE SET count = count + 1`
+
+  ## Dashboard Notification
+
+  After each upsert, broadcasts `:session_stats_updated` to the provider's
+  stats PubSub topic so the dashboard LiveView can refresh.
+  """
+
+  use GenServer
+
+  import Ecto.Query
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  require Logger
+
+  @session_completed_topic "integration:participation:session_completed"
+
+  @acl Application.compile_env!(:klass_hero, [:provider, :for_resolving_session_stats])
+
+  # ---------------------------------------------------------------------------
+  # Client API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Starts the ProviderSessionStats projection GenServer.
+
+  ## Options
+
+  - `:name` - Process name (defaults to `__MODULE__`)
+  - `:skip_bootstrap` - When `true`, skips PubSub subscription and bootstrap
+    (for isolated testing). Defaults to `false`.
+  """
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Server Callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    skip_bootstrap = Keyword.get(opts, :skip_bootstrap, false)
+
+    if skip_bootstrap do
+      {:ok, %{bootstrapped: false}}
+    else
+      Phoenix.PubSub.subscribe(KlassHero.PubSub, @session_completed_topic)
+      {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+    end
+  end
+
+  @impl true
+  def handle_continue(:bootstrap, state) do
+    attempt_bootstrap(state)
+  end
+
+  @impl true
+  def handle_info(:retry_bootstrap, state) do
+    {:noreply, state, {:continue, :bootstrap}}
+  end
+
+  # Trigger: Received a session_completed integration event
+  # Why: a session was completed, the counter for that provider+program must increment
+  # Outcome: atomic SQL increment of sessions_completed_count, dashboard notified
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_completed} = event}, state) do
+    %{provider_id: provider_id, program_id: program_id, program_title: program_title} =
+      event.payload
+
+    Logger.debug("ProviderSessionStats projecting session_completed",
+      provider_id: provider_id,
+      program_id: program_id,
+      event_id: event.event_id
+    )
+
+    upsert_session_count(provider_id, program_id, program_title)
+    notify_dashboard(provider_id)
+
+    {:noreply, state}
+  end
+
+  # Catch-all for unhandled messages
+  @impl true
+  def handle_info(msg, state) do
+    Logger.warning("ProviderSessionStats received unexpected message",
+      message: inspect(msg, limit: 200)
+    )
+
+    {:noreply, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private Functions
+  # ---------------------------------------------------------------------------
+
+  # Trigger: bootstrap attempt with retry logic
+  # Why: transient DB failures shouldn't crash the GenServer immediately
+  # Outcome: successful bootstrap or scheduled retry (up to 3 times before crashing)
+  defp attempt_bootstrap(state) do
+    count = bootstrap_counts()
+    Logger.info("ProviderSessionStats projection started", count: count)
+    {:noreply, %{state | bootstrapped: true}}
+  rescue
+    error ->
+      retry_count = Map.get(state, :retry_count, 0) + 1
+
+      if retry_count > 3 do
+        reraise error, __STACKTRACE__
+      else
+        Logger.error("ProviderSessionStats: bootstrap failed, scheduling retry",
+          error: Exception.message(error),
+          retry_count: retry_count
+        )
+
+        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
+        {:noreply, Map.put(state, :retry_count, retry_count)}
+      end
+  end
+
+  # Trigger: bootstrap phase -- read table may be empty or stale
+  # Why: cold start recovery -- populate read table from ACL cross-context query
+  # Outcome: provider_session_stats contains one row per provider+program with correct counts
+  defp bootstrap_counts do
+    case @acl.list_completed_session_counts() do
+      {:ok, []} ->
+        0
+
+      {:ok, rows} ->
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+        entries =
+          Enum.map(rows, fn row ->
+            %{
+              id: Ecto.UUID.generate(),
+              provider_id: row.provider_id,
+              program_id: row.program_id,
+              program_title: row.program_title,
+              sessions_completed_count: row.sessions_completed_count,
+              inserted_at: now,
+              updated_at: now
+            }
+          end)
+
+        {count, _} =
+          Repo.insert_all(SessionStatsSchema, entries,
+            on_conflict: {:replace_all_except, [:id, :inserted_at]},
+            conflict_target: [:provider_id, :program_id]
+          )
+
+        count
+
+      {:error, reason} ->
+        raise "Bootstrap ACL query failed: #{inspect(reason)}"
+    end
+  end
+
+  # Trigger: session_completed event received
+  # Why: atomic increment avoids race conditions with concurrent events
+  # Outcome: row inserted with count=1 or existing count incremented by 1
+  defp upsert_session_count(provider_id, program_id, program_title) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %SessionStatsSchema{}
+    |> Ecto.Changeset.change(%{
+      id: Ecto.UUID.generate(),
+      provider_id: provider_id,
+      program_id: program_id,
+      program_title: program_title,
+      sessions_completed_count: 1,
+      inserted_at: now,
+      updated_at: now
+    })
+    |> Repo.insert!(
+      on_conflict:
+        from(s in SessionStatsSchema,
+          update: [
+            set: [
+              sessions_completed_count: fragment("? + 1", s.sessions_completed_count),
+              program_title: ^program_title,
+              updated_at: ^now
+            ]
+          ]
+        ),
+      conflict_target: [:provider_id, :program_id]
+    )
+  end
+
+  # Trigger: upsert completed successfully
+  # Why: dashboard LiveView needs to know stats changed to refresh the counter
+  # Outcome: PubSub broadcast to provider-specific topic
+  defp notify_dashboard(provider_id) do
+    Phoenix.PubSub.broadcast(
+      KlassHero.PubSub,
+      "provider:#{provider_id}:stats_updated",
+      :session_stats_updated
+    )
+  end
+end

--- a/lib/klass_hero/provider/domain/ports/for_querying_session_stats.ex
+++ b/lib/klass_hero/provider/domain/ports/for_querying_session_stats.ex
@@ -1,0 +1,23 @@
+defmodule KlassHero.Provider.Domain.Ports.ForQueryingSessionStats do
+  @moduledoc """
+  Read-only port for querying provider session statistics.
+
+  Separated from the write side of the projection. Read operations never mutate state.
+  """
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionStats
+
+  @doc """
+  Lists all session stats for a provider, ordered by sessions_completed_count descending.
+
+  Returns an empty list when no stats exist for the given provider.
+  """
+  @callback list_for_provider(provider_id :: binary()) :: [SessionStats.t()]
+
+  @doc """
+  Returns the total completed session count across all programs for a provider.
+
+  Returns 0 when no stats exist for the given provider.
+  """
+  @callback get_total_count(provider_id :: binary()) :: non_neg_integer()
+end

--- a/lib/klass_hero/provider/domain/ports/for_resolving_session_stats.ex
+++ b/lib/klass_hero/provider/domain/ports/for_resolving_session_stats.ex
@@ -1,0 +1,20 @@
+defmodule KlassHero.Provider.Domain.Ports.ForResolvingSessionStats do
+  @moduledoc """
+  Port for resolving initial session completion counts from the Participation context.
+
+  Used exclusively during projection bootstrap. Cross-context query is acceptable
+  here because it runs once on startup, not on every request.
+  """
+
+  @callback list_completed_session_counts() ::
+              {:ok,
+               [
+                 %{
+                   provider_id: String.t(),
+                   program_id: String.t(),
+                   program_title: String.t(),
+                   sessions_completed_count: non_neg_integer()
+                 }
+               ]}
+              | {:error, term()}
+end

--- a/lib/klass_hero/provider/domain/read_models/session_stats.ex
+++ b/lib/klass_hero/provider/domain/read_models/session_stats.ex
@@ -1,0 +1,36 @@
+defmodule KlassHero.Provider.Domain.ReadModels.SessionStats do
+  @moduledoc """
+  Read-optimized DTO for provider session statistics.
+
+  Lightweight struct for display — no business logic, no value objects.
+  Populated from the denormalized provider_session_stats read table.
+  """
+
+  @typedoc "A denormalized session stats record for display in the provider dashboard."
+  @type t :: %__MODULE__{
+          id: String.t(),
+          provider_id: String.t(),
+          program_id: String.t(),
+          program_title: String.t(),
+          sessions_completed_count: non_neg_integer(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  @enforce_keys [:id, :provider_id, :program_id, :program_title, :sessions_completed_count]
+
+  defstruct [
+    :id,
+    :provider_id,
+    :program_id,
+    :program_title,
+    :inserted_at,
+    :updated_at,
+    sessions_completed_count: 0
+  ]
+
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    struct!(__MODULE__, attrs)
+  end
+end

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -28,8 +28,6 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
   require Logger
 
-  @session_stats_repo Application.compile_env!(:klass_hero, [:provider, :for_querying_session_stats])
-
   @impl true
   def mount(_params, _session, socket) do
     case socket.assigns.current_scope.provider do
@@ -187,7 +185,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
     business = %{socket.assigns.business | verification_status: verification_status}
 
-    total_sessions = @session_stats_repo.get_total_count(provider.id)
+    total_sessions = Provider.get_total_session_count(provider.id)
 
     if connected?(socket) do
       Phoenix.PubSub.subscribe(KlassHero.PubSub, "provider:#{provider.id}:stats_updated")
@@ -232,7 +230,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   @impl true
   def handle_info(:session_stats_updated, %{assigns: %{live_action: :overview}} = socket) do
     provider = socket.assigns.current_scope.provider
-    new_count = @session_stats_repo.get_total_count(provider.id)
+    new_count = Provider.get_total_session_count(provider.id)
 
     if new_count == socket.assigns.total_sessions_completed do
       {:noreply, socket}

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -28,6 +28,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
   require Logger
 
+  @session_stats_repo Application.compile_env!(:klass_hero, [:provider, :for_querying_session_stats])
+
   @impl true
   def mount(_params, _session, socket) do
     case socket.assigns.current_scope.provider do
@@ -122,6 +124,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
           |> assign(instructor_options: build_instructor_options(staff_members))
           |> assign(categories: ProgramCatalog.program_categories())
           |> assign(document_types: Provider.valid_document_types())
+          |> assign(total_sessions_completed: 0)
           |> allow_upload(:logo,
             accept: ~w(.jpg .jpeg .png .webp),
             max_entries: 1,
@@ -184,7 +187,16 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
     business = %{socket.assigns.business | verification_status: verification_status}
 
-    {:noreply, assign(socket, business: business)}
+    total_sessions = @session_stats_repo.get_total_count(provider.id)
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(KlassHero.PubSub, "provider:#{provider.id}:stats_updated")
+    end
+
+    {:noreply,
+     socket
+     |> assign(business: business)
+     |> assign(total_sessions_completed: total_sessions)}
   end
 
   @impl true
@@ -212,6 +224,20 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   def handle_params(_params, _uri, socket) do
     {:noreply, socket}
   end
+
+  # ============================================================================
+  # PubSub Handlers
+  # ============================================================================
+
+  @impl true
+  def handle_info(:session_stats_updated, socket) do
+    provider = socket.assigns.current_scope.provider
+    total_sessions = @session_stats_repo.get_total_count(provider.id)
+
+    {:noreply, assign(socket, total_sessions_completed: total_sessions)}
+  end
+
+  def handle_info(_message, socket), do: {:noreply, socket}
 
   # ============================================================================
   # Staff Member CRUD Events
@@ -1068,7 +1094,10 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
             <%= case @live_action do %>
               <% :overview -> %>
-                <.overview_section business={@business} />
+                <.overview_section
+                  business={@business}
+                  total_sessions_completed={@total_sessions_completed}
+                />
               <% :team -> %>
                 <.team_section
                   team_members={@streams.team_members}
@@ -1292,40 +1321,15 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   defp overview_section(assigns) do
     ~H"""
     <div class="space-y-6">
-      <%!-- TODO: Stats cards — re-enable when analytics backend is implemented.
-           Dependencies: @stats assign, format_currency/1, format_number/1 helpers (all removed). --%>
-      <%!--
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <.provider_stat_card
-          label={gettext("Total Revenue")}
-          value={format_currency(@stats.total_revenue)}
-          icon="hero-currency-euro-mini"
+          label={gettext("Sessions Completed")}
+          value={to_string(@total_sessions_completed)}
+          icon="hero-check-badge-mini"
           icon_bg="bg-green-100"
           icon_color="text-green-600"
         />
-        <.provider_stat_card
-          label={gettext("Active Bookings")}
-          value={to_string(@stats.active_bookings)}
-          icon="hero-calendar-days-mini"
-          icon_bg="bg-hero-cyan-100"
-          icon_color="text-hero-cyan"
-        />
-        <.provider_stat_card
-          label={gettext("Profile Views")}
-          value={format_number(@stats.profile_views)}
-          icon="hero-eye-mini"
-          icon_bg="bg-purple-100"
-          icon_color="text-purple-600"
-        />
-        <.provider_stat_card
-          label={gettext("Avg Rating")}
-          value={to_string(@stats.average_rating)}
-          icon="hero-star-mini"
-          icon_bg="bg-hero-yellow-100"
-          icon_color="text-hero-yellow"
-        />
       </div>
-      --%>
 
       <.business_profile_card business={@business} />
 

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -230,11 +230,15 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   # ============================================================================
 
   @impl true
-  def handle_info(:session_stats_updated, socket) do
+  def handle_info(:session_stats_updated, %{assigns: %{live_action: :overview}} = socket) do
     provider = socket.assigns.current_scope.provider
-    total_sessions = @session_stats_repo.get_total_count(provider.id)
+    new_count = @session_stats_repo.get_total_count(provider.id)
 
-    {:noreply, assign(socket, total_sessions_completed: total_sessions)}
+    if new_count == socket.assigns.total_sessions_completed do
+      {:noreply, socket}
+    else
+      {:noreply, assign(socket, total_sessions_completed: new_count)}
+    end
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}

--- a/priv/repo/migrations/20260415095209_create_provider_session_stats.exs
+++ b/priv/repo/migrations/20260415095209_create_provider_session_stats.exs
@@ -1,0 +1,18 @@
+defmodule KlassHero.Repo.Migrations.CreateProviderSessionStats do
+  use Ecto.Migration
+
+  def change do
+    create table(:provider_session_stats, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :provider_id, :binary_id, null: false
+      add :program_id, :binary_id, null: false
+      add :program_title, :string, null: false
+      add :sessions_completed_count, :integer, null: false, default: 0
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:provider_session_stats, [:provider_id, :program_id])
+    create index(:provider_session_stats, [:provider_id])
+  end
+end

--- a/test/klass_hero/participation/adapters/driven/acl/child_info_resolver_test.exs
+++ b/test/klass_hero/participation/adapters/driven/acl/child_info_resolver_test.exs
@@ -1,7 +1,7 @@
-defmodule KlassHero.Participation.Adapters.Driven.FamilyContext.ChildInfoResolverTest do
+defmodule KlassHero.Participation.Adapters.Driven.ACL.ChildInfoResolverTest do
   use KlassHero.DataCase, async: true
 
-  alias KlassHero.Participation.Adapters.Driven.FamilyContext.ChildInfoResolver
+  alias KlassHero.Participation.Adapters.Driven.ACL.ChildInfoResolver
 
   describe "resolve_child_info/1" do
     test "returns name and safety info when child has active provider_data_sharing consent" do

--- a/test/klass_hero/participation/adapters/driven/acl/enrolled_children_resolver_test.exs
+++ b/test/klass_hero/participation/adapters/driven/acl/enrolled_children_resolver_test.exs
@@ -1,9 +1,9 @@
-defmodule KlassHero.Participation.Adapters.Driven.EnrollmentContext.EnrolledChildrenResolverTest do
+defmodule KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolverTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.Factory
 
-  alias KlassHero.Participation.Adapters.Driven.EnrollmentContext.EnrolledChildrenResolver
+  alias KlassHero.Participation.Adapters.Driven.ACL.EnrolledChildrenResolver
 
   describe "list_enrolled_child_ids/1" do
     test "returns child IDs for children with active enrollments in the program" do

--- a/test/klass_hero/participation/adapters/driven/acl/program_provider_resolver_test.exs
+++ b/test/klass_hero/participation/adapters/driven/acl/program_provider_resolver_test.exs
@@ -1,7 +1,7 @@
-defmodule KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramProviderResolverTest do
+defmodule KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolverTest do
   use KlassHero.DataCase, async: true
 
-  alias KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramProviderResolver
+  alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
 
   describe "resolve_provider_id/1" do
     test "returns provider_id for an existing program" do

--- a/test/klass_hero/participation/adapters/driven/program_catalog_context/program_provider_resolver_test.exs
+++ b/test/klass_hero/participation/adapters/driven/program_catalog_context/program_provider_resolver_test.exs
@@ -19,4 +19,22 @@ defmodule KlassHero.Participation.Adapters.Driven.ProgramCatalogContext.ProgramP
                ProgramProviderResolver.resolve_provider_id(non_existent_id)
     end
   end
+
+  describe "resolve_provider_details/1" do
+    test "returns provider_id and program_title for an existing program" do
+      provider = KlassHero.Factory.insert(:provider_profile_schema)
+      program = KlassHero.Factory.insert(:program_schema, provider_id: provider.id)
+
+      assert {:ok, details} = ProgramProviderResolver.resolve_provider_details(program.id)
+      assert details.provider_id == provider.id
+      assert details.program_title == program.title
+    end
+
+    test "returns :program_not_found when program does not exist" do
+      non_existent_id = Ecto.UUID.generate()
+
+      assert {:error, :program_not_found} =
+               ProgramProviderResolver.resolve_provider_details(non_existent_id)
+    end
+  end
 end

--- a/test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -100,11 +100,14 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteI
     test "promotes to session_completed integration event" do
       session_id = Ecto.UUID.generate()
       program_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
 
       domain_event =
         DomainEvent.new(:session_completed, session_id, :participation, %{
           session_id: session_id,
           program_id: program_id,
+          provider_id: provider_id,
+          program_title: "Art Class",
           completed_at: DateTime.utc_now()
         })
 
@@ -122,6 +125,8 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteI
         DomainEvent.new(:session_completed, session_id, :participation, %{
           session_id: session_id,
           program_id: Ecto.UUID.generate(),
+          provider_id: Ecto.UUID.generate(),
+          program_title: "Art Class",
           completed_at: DateTime.utc_now()
         })
 

--- a/test/klass_hero/participation/domain/events/participation_events_payload_test.exs
+++ b/test/klass_hero/participation/domain/events/participation_events_payload_test.exs
@@ -95,6 +95,19 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEventsPayloadTest d
       assert event.payload.program_id == session.program_id
       assert %DateTime{} = event.payload.completed_at
     end
+
+    test "merges extra_payload into session_completed event" do
+      session = %{build_session() | status: :completed}
+
+      event =
+        ParticipationEvents.session_completed(session,
+          extra_payload: %{provider_id: "prov-1", program_title: "Art Class"}
+        )
+
+      assert event.payload.provider_id == "prov-1"
+      assert event.payload.program_title == "Art Class"
+      assert event.payload.program_id == session.program_id
+    end
   end
 
   describe "roster_seeded/4" do

--- a/test/klass_hero/participation/domain/events/participation_integration_events_test.exs
+++ b/test/klass_hero/participation/domain/events/participation_integration_events_test.exs
@@ -149,13 +149,33 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEventsTe
 
       event =
         ParticipationIntegrationEvents.session_completed(session_id, %{
-          program_id: Ecto.UUID.generate()
+          program_id: Ecto.UUID.generate(),
+          provider_id: Ecto.UUID.generate(),
+          program_title: "Art Class"
         })
 
       assert event.event_type == :session_completed
       assert event.source_context == :participation
       assert event.entity_type == :session
       assert event.entity_id == session_id
+    end
+
+    test "includes provider_id and program_title in payload" do
+      session_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      event =
+        ParticipationIntegrationEvents.session_completed(session_id, %{
+          program_id: program_id,
+          provider_id: provider_id,
+          program_title: "Art Class"
+        })
+
+      assert event.payload.provider_id == provider_id
+      assert event.payload.program_title == "Art Class"
+      assert event.payload.program_id == program_id
+      assert event.payload.session_id == session_id
     end
 
     test "base_payload session_id wins over caller-supplied" do
@@ -165,6 +185,8 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEventsTe
         ParticipationIntegrationEvents.session_completed(real_id, %{
           session_id: "should-be-overridden",
           program_id: Ecto.UUID.generate(),
+          provider_id: Ecto.UUID.generate(),
+          program_title: "Art Class",
           extra: "data"
         })
 
@@ -172,7 +194,33 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEventsTe
       assert event.payload.extra == "data"
     end
 
-    test "raises when required payload keys are missing" do
+    test "raises when provider_id is missing" do
+      session_id = Ecto.UUID.generate()
+
+      assert_raise ArgumentError,
+                   ~r/session_completed missing required payload keys/,
+                   fn ->
+                     ParticipationIntegrationEvents.session_completed(session_id, %{
+                       program_id: Ecto.UUID.generate(),
+                       program_title: "Art Class"
+                     })
+                   end
+    end
+
+    test "raises when program_title is missing" do
+      session_id = Ecto.UUID.generate()
+
+      assert_raise ArgumentError,
+                   ~r/session_completed missing required payload keys/,
+                   fn ->
+                     ParticipationIntegrationEvents.session_completed(session_id, %{
+                       program_id: Ecto.UUID.generate(),
+                       provider_id: Ecto.UUID.generate()
+                     })
+                   end
+    end
+
+    test "raises when all required payload keys are missing" do
       session_id = Ecto.UUID.generate()
 
       assert_raise ArgumentError,
@@ -183,7 +231,11 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEventsTe
     end
 
     test "raises for nil or empty session_id" do
-      valid_payload = %{program_id: Ecto.UUID.generate()}
+      valid_payload = %{
+        program_id: Ecto.UUID.generate(),
+        provider_id: Ecto.UUID.generate(),
+        program_title: "Art Class"
+      }
 
       assert_raise ArgumentError,
                    ~r/requires a non-empty session_id string/,

--- a/test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs
+++ b/test/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl_test.exs
@@ -1,0 +1,76 @@
+defmodule KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACLTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL
+
+  describe "list_completed_session_counts/0" do
+    test "returns empty list when no completed sessions exist" do
+      assert {:ok, []} = ParticipationSessionStatsACL.list_completed_session_counts()
+    end
+
+    test "counts completed sessions grouped by provider and program" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      insert(:program_session_schema,
+        program_id: program.id,
+        status: "completed",
+        session_date: ~D[2026-01-01]
+      )
+
+      insert(:program_session_schema,
+        program_id: program.id,
+        status: "completed",
+        session_date: ~D[2026-01-02]
+      )
+
+      # Non-completed session -- should NOT count
+      insert(:program_session_schema,
+        program_id: program.id,
+        status: "scheduled",
+        session_date: ~D[2026-01-03]
+      )
+
+      {:ok, results} = ParticipationSessionStatsACL.list_completed_session_counts()
+
+      assert [result] = results
+      assert result.provider_id == provider.id
+      assert result.program_id == program.id
+      assert result.program_title == program.title
+      assert result.sessions_completed_count == 2
+    end
+
+    test "groups by program across multiple providers" do
+      provider_a = insert(:provider_profile_schema)
+      provider_b = insert(:provider_profile_schema)
+      program_a = insert(:program_schema, provider_id: provider_a.id, title: "Art Class")
+      program_b = insert(:program_schema, provider_id: provider_b.id, title: "Music Class")
+
+      insert(:program_session_schema,
+        program_id: program_a.id,
+        status: "completed",
+        session_date: ~D[2026-02-01]
+      )
+
+      insert(:program_session_schema,
+        program_id: program_b.id,
+        status: "completed",
+        session_date: ~D[2026-02-01]
+      )
+
+      insert(:program_session_schema,
+        program_id: program_b.id,
+        status: "completed",
+        session_date: ~D[2026-02-02]
+      )
+
+      {:ok, results} = ParticipationSessionStatsACL.list_completed_session_counts()
+
+      by_provider = Map.new(results, &{&1.provider_id, &1})
+      assert by_provider[provider_a.id].sessions_completed_count == 1
+      assert by_provider[provider_b.id].sessions_completed_count == 2
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/repositories/session_stats_repository_test.exs
@@ -1,0 +1,60 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepositoryTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepository
+  alias KlassHero.Provider.Domain.ReadModels.SessionStats
+
+  describe "list_for_provider/1" do
+    test "returns empty list when no stats exist" do
+      assert [] == SessionStatsRepository.list_for_provider(Ecto.UUID.generate())
+    end
+
+    test "returns stats for the given provider ordered by count descending" do
+      provider_id = Ecto.UUID.generate()
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        program_title: "Art",
+        sessions_completed_count: 3
+      )
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        program_title: "Music",
+        sessions_completed_count: 7
+      )
+
+      # Different provider — should not appear
+      insert(:session_stats_schema, sessions_completed_count: 10)
+
+      result = SessionStatsRepository.list_for_provider(provider_id)
+
+      assert [%SessionStats{program_title: "Music"}, %SessionStats{program_title: "Art"}] = result
+      assert length(result) == 2
+    end
+  end
+
+  describe "get_total_count/1" do
+    test "returns 0 when no stats exist" do
+      assert 0 == SessionStatsRepository.get_total_count(Ecto.UUID.generate())
+    end
+
+    test "returns sum of all session counts for the provider" do
+      provider_id = Ecto.UUID.generate()
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        sessions_completed_count: 3
+      )
+
+      insert(:session_stats_schema,
+        provider_id: provider_id,
+        sessions_completed_count: 7
+      )
+
+      assert 10 == SessionStatsRepository.get_total_count(provider_id)
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
@@ -3,6 +3,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTes
 
   import Ecto.Query
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
   alias KlassHero.Repo
@@ -34,7 +35,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTes
         skip_bootstrap: true
       )
 
-    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), pid)
+    Sandbox.allow(Repo, self(), pid)
     pid
   end
 

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
@@ -1,0 +1,139 @@
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTest do
+  use KlassHero.DataCase, async: true
+
+  import Ecto.Query
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  defp build_session_completed_event(attrs) do
+    %IntegrationEvent{
+      event_id: Ecto.UUID.generate(),
+      event_type: :session_completed,
+      source_context: :participation,
+      entity_type: :session,
+      entity_id: attrs[:session_id] || Ecto.UUID.generate(),
+      occurred_at: DateTime.utc_now(),
+      payload: %{
+        session_id: attrs[:session_id] || Ecto.UUID.generate(),
+        program_id: attrs[:program_id] || Ecto.UUID.generate(),
+        provider_id: attrs[:provider_id] || Ecto.UUID.generate(),
+        program_title: attrs[:program_title] || "Test Program"
+      },
+      metadata: %{},
+      version: 1
+    }
+  end
+
+  defp start_projection! do
+    {:ok, pid} =
+      ProviderSessionStats.start_link(
+        name: :"test_proj_#{System.unique_integer([:positive])}",
+        skip_bootstrap: true
+      )
+
+    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), pid)
+    pid
+  end
+
+  describe "handle_info/2 session_completed event" do
+    test "inserts a new row on first event for a provider+program" do
+      pid = start_projection!()
+
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      event =
+        build_session_completed_event(
+          provider_id: provider_id,
+          program_id: program_id,
+          program_title: "Art Class"
+        )
+
+      send(pid, {:integration_event, event})
+      # Synchronize -- :sys.get_state blocks until all messages in the mailbox are processed
+      :sys.get_state(pid)
+
+      stats = Repo.all(from(s in SessionStatsSchema, where: s.provider_id == ^provider_id))
+
+      assert [stat] = stats
+      assert stat.program_id == program_id
+      assert stat.program_title == "Art Class"
+      assert stat.sessions_completed_count == 1
+    end
+
+    test "increments count on subsequent events for same provider+program" do
+      pid = start_projection!()
+
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      event =
+        build_session_completed_event(
+          provider_id: provider_id,
+          program_id: program_id,
+          program_title: "Art Class"
+        )
+
+      # Send 3 events
+      for _ <- 1..3 do
+        send(pid, {:integration_event, event})
+      end
+
+      :sys.get_state(pid)
+
+      stat =
+        Repo.one!(
+          from(s in SessionStatsSchema,
+            where: s.provider_id == ^provider_id and s.program_id == ^program_id
+          )
+        )
+
+      assert stat.sessions_completed_count == 3
+    end
+
+    test "tracks separate counts per program" do
+      pid = start_projection!()
+
+      provider_id = Ecto.UUID.generate()
+      program_a = Ecto.UUID.generate()
+      program_b = Ecto.UUID.generate()
+
+      send(
+        pid,
+        {:integration_event,
+         build_session_completed_event(
+           provider_id: provider_id,
+           program_id: program_a,
+           program_title: "Art"
+         )}
+      )
+
+      for _ <- 1..2 do
+        send(
+          pid,
+          {:integration_event,
+           build_session_completed_event(
+             provider_id: provider_id,
+             program_id: program_b,
+             program_title: "Music"
+           )}
+        )
+      end
+
+      :sys.get_state(pid)
+
+      stats =
+        SessionStatsSchema
+        |> where([s], s.provider_id == ^provider_id)
+        |> order_by([s], asc: s.program_title)
+        |> Repo.all()
+
+      assert [art, music] = stats
+      assert art.sessions_completed_count == 1
+      assert music.sessions_completed_count == 2
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -56,6 +56,7 @@ defmodule KlassHero.Factory do
   alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramSchema
   alias KlassHero.ProgramCatalog.Domain.Models.Program
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProfileSchema
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSchema
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.VerificationDocumentSchema
   alias KlassHero.Provider.Domain.Models.ProviderProfile
@@ -454,6 +455,30 @@ defmodule KlassHero.Factory do
       active: true,
       tags: [],
       qualifications: []
+    }
+  end
+
+  # =============================================================================
+  # Provider Context - Session Stats Factories
+  # =============================================================================
+
+  @doc """
+  Factory for creating SessionStatsSchema Ecto schemas (read model, no FK constraints).
+
+  Used in repository tests for the denormalized provider_session_stats table.
+
+  ## Examples
+
+      schema = insert(:session_stats_schema)
+      schema = insert(:session_stats_schema, sessions_completed_count: 5)
+  """
+  def session_stats_schema_factory do
+    %SessionStatsSchema{
+      id: Ecto.UUID.generate(),
+      provider_id: Ecto.UUID.generate(),
+      program_id: Ecto.UUID.generate(),
+      program_title: sequence(:session_stats_title, &"Program #{&1}"),
+      sessions_completed_count: 0
     }
   end
 


### PR DESCRIPTION
## Summary

- Added `session_completed` integration event enrichment with `provider_id` and `program_title` in Participation context (`complete_session.ex`, `participation_integration_events.ex`)
- Created CQRS projection infrastructure: `provider_session_stats` read table, `ProviderSessionStats` GenServer with atomic SQL increment, `ParticipationSessionStatsACL` for bootstrap, `SessionStatsRepository` for reads
- Wired session count into Provider dashboard overview tab with real-time PubSub updates (`dashboard_live.ex`)
- Switched `ProjectionSupervisor` from `:rest_for_one` to `:one_for_one` strategy for independent projection supervision
- Standardized Participation ACL directories from `{context}_context/` to `acl/` naming, consistent with all other bounded contexts
- Renamed all 9 Participation DI config keys to `for_<verb>_<noun>` convention (e.g., `session_repository` to `for_storing_sessions`)

## Review Focus

- **Event enrichment fallback** -- when `ProgramProviderResolver.resolve_provider_details/1` fails, `CompleteSession` uses sentinel values (`provider_id: "unknown"`) instead of empty map to satisfy the integration event builder's mandatory keys (`complete_session.ex:91-104`)
- **Atomic SQL increment** -- the projection upsert uses `fragment("? + 1", s.sessions_completed_count)` with `conflict_target: [:provider_id, :program_id]` to avoid race conditions (`provider_session_stats.ex:191-217`)
- **Cross-context bootstrap ACL** -- uses raw table names (`"program_sessions"`, `"programs"`) instead of schema imports to avoid compile-time coupling between Provider and Participation/ProgramCatalog contexts (`participation_session_stats_acl.ex:31-43`)
- **Dashboard tab guard** -- `handle_info(:session_stats_updated)` only re-fetches when `live_action == :overview` and skips re-assign when count is unchanged (`dashboard_live.ex:231-239`)
- **Config key rename scope** -- 22 files touched for the `for_` convention rename; purely mechanical atom substitutions with zero logic changes (`config/config.exs:260-269`, all files under `participation/application/`)

## Test Plan

- [x] `mix precommit` (4084 passed, 0 failures)
- [x] `mix credo --strict` (0 issues)
- [x] Backend: projection table schema, indices, supervisor children verified via Tidewave
- [x] Backend: end-to-end event flow (PubSub -> projection -> read repo) verified with simulated events
- [x] UI: session counter card renders on desktop and mobile
- [x] UI: real-time counter increment via PubSub verified
- [x] Manual: complete a real session via the attendance flow and verify the counter increments
- [x] CI: all pipeline checks pass

Closes #372