### PR TITLE
fix: allow provider staff to send follow-ups in broadcasts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -42,6 +42,7 @@ alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.InboundEmailR
 alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.MessageRepository
 alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ParticipantRepository
 alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ProgramStaffParticipantRepository
+alias KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver
 alias KlassHero.Messaging.Adapters.Driven.ResendEmailContentAdapter
 alias KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler
 alias KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker
@@ -243,6 +244,7 @@ config :klass_hero, :messaging,
   for_resolving_users: UserResolver,
   for_querying_enrollments: EnrollmentResolver,
   for_resolving_program_staff: ProgramStaffParticipantRepository,
+  for_resolving_provider_staff: ProviderStaffResolver,
   for_managing_conversation_summaries: ConversationSummariesRepository,
   for_querying_conversation_summaries: ConversationSummariesRepository,
   for_managing_inbound_emails: InboundEmailRepository,

--- a/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
+++ b/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
@@ -20,10 +20,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver do
         operation: "active_staff_for_provider?"
       )
 
-      case KlassHero.Provider.get_active_staff_member_by_user(user_id) do
-        {:ok, %{provider_id: ^provider_id}} -> true
-        _ -> false
-      end
+      KlassHero.Provider.active_staff_for_provider?(provider_id, user_id)
     end
   end
 end

--- a/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
+++ b/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
@@ -1,0 +1,29 @@
+defmodule KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver do
+  @moduledoc """
+  Adapter for resolving provider-staff relationships in the Messaging context.
+
+  Delegates to the Provider facade to respect bounded context boundaries —
+  Messaging is not allowed to query Provider schemas directly.
+  """
+
+  @behaviour KlassHero.Messaging.Domain.Ports.ForResolvingProviderStaff
+
+  use KlassHero.Shared.Tracing
+
+  @impl true
+  @spec active_staff_for_provider?(String.t(), String.t()) :: boolean()
+  def active_staff_for_provider?(provider_id, user_id) do
+    span do
+      set_attributes("acl",
+        source: "messaging",
+        target: "provider",
+        operation: "active_staff_for_provider?"
+      )
+
+      case KlassHero.Provider.get_active_staff_member_by_user(user_id) do
+        {:ok, %{provider_id: ^provider_id}} -> true
+        _ -> false
+      end
+    end
+  end
+end

--- a/lib/klass_hero/messaging/application/commands/send_message.ex
+++ b/lib/klass_hero/messaging/application/commands/send_message.ex
@@ -35,6 +35,10 @@ defmodule KlassHero.Messaging.Application.Commands.SendMessage do
   @attachment_repo Application.compile_env!(:klass_hero, [:messaging, :for_managing_attachments])
   @user_resolver Application.compile_env!(:klass_hero, [:messaging, :for_resolving_users])
   @staff_resolver Application.compile_env!(:klass_hero, [:messaging, :for_resolving_program_staff])
+  @provider_staff_resolver Application.compile_env!(:klass_hero, [
+                             :messaging,
+                             :for_resolving_provider_staff
+                           ])
 
   @doc """
   Sends a message to a conversation.
@@ -278,6 +282,7 @@ defmodule KlassHero.Messaging.Application.Commands.SendMessage do
         cond do
           provider_owner?(provider_id, sender_id) -> :ok
           staff_assigned?(program_id, sender_id) -> :ok
+          active_staff_for_provider?(provider_id, sender_id) -> :ok
           true -> {:error, :broadcast_reply_not_allowed}
         end
 
@@ -301,6 +306,19 @@ defmodule KlassHero.Messaging.Application.Commands.SendMessage do
   defp staff_assigned?(program_id, sender_id) do
     staff_user_ids = @staff_resolver.get_active_staff_user_ids(program_id)
     sender_id in staff_user_ids
+  end
+
+  # Trigger: program-staff projection check above returned false
+  # Why: any active staff member of the broadcast's provider should be able to
+  #      post follow-ups, even if they aren't assigned to the specific program.
+  #      The `program_staff_participants` projection only covers explicit
+  #      program assignments, but staff are authorised to broadcast for any
+  #      program of their provider (see `StaffBroadcastLive.mount/3`); the two
+  #      permission checks must agree to avoid bug #669.
+  # Outcome: staff of the provider can send; everyone else still falls through
+  #          to `:broadcast_reply_not_allowed`.
+  defp active_staff_for_provider?(provider_id, sender_id) do
+    @provider_staff_resolver.active_staff_for_provider?(provider_id, sender_id)
   end
 
   # --- Read status ---

--- a/lib/klass_hero/messaging/domain/ports/for_resolving_provider_staff.ex
+++ b/lib/klass_hero/messaging/domain/ports/for_resolving_provider_staff.ex
@@ -1,0 +1,23 @@
+defmodule KlassHero.Messaging.Domain.Ports.ForResolvingProviderStaff do
+  @moduledoc """
+  Port for querying provider-staff relationships from the Provider context.
+
+  Distinct from `ForResolvingProgramStaff` (which queries the per-program
+  `program_staff_participants` projection): this port answers the broader
+  question of whether a user is an active staff member of a given provider,
+  regardless of program assignment.
+
+  Used by broadcast permission checks so that any active staff of the
+  provider — not just program-assigned staff — can post follow-up messages
+  in broadcasts for that provider.
+  """
+
+  @doc """
+  Checks whether the given user is an active staff member of the given provider.
+
+  Returns `true` if the user has an active `staff_member` record whose
+  `provider_id` matches the given provider, `false` otherwise.
+  """
+  @callback active_staff_for_provider?(provider_id :: String.t(), user_id :: String.t()) ::
+              boolean()
+end

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -423,6 +423,18 @@ defmodule KlassHero.Provider do
   end
 
   @doc """
+  Returns true if the given user has any active staff_member row for the given provider.
+
+  Use this for permission checks scoped to a specific provider — unlike
+  `get_active_staff_member_by_user/1`, this correctly identifies users who are
+  active staff at multiple providers.
+  """
+  @spec active_staff_for_provider?(String.t(), String.t()) :: boolean()
+  def active_staff_for_provider?(provider_id, user_id) when is_binary(provider_id) and is_binary(user_id) do
+    StaffMemberQueries.active_for_provider_and_user?(provider_id, user_id)
+  end
+
+  @doc """
   Returns the staff member matching the given invitation token hash,
   only if invitation_status is :sent. Used by the invitation registration flow.
   """

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository.ex
@@ -156,4 +156,16 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMembe
       end
     end
   end
+
+  @impl true
+  def active_for_provider_and_user?(provider_id, user_id) when is_binary(provider_id) and is_binary(user_id) do
+    span do
+      set_attributes("db", operation: "exists", entity: "staff_member")
+
+      from(s in StaffMemberSchema,
+        where: s.provider_id == ^provider_id and s.user_id == ^user_id and s.active == true
+      )
+      |> Repo.exists?()
+    end
+  end
 end

--- a/lib/klass_hero/provider/application/queries/staff_member_queries.ex
+++ b/lib/klass_hero/provider/application/queries/staff_member_queries.ex
@@ -47,6 +47,19 @@ defmodule KlassHero.Provider.Application.Queries.StaffMemberQueries do
   end
 
   @doc """
+  Returns true if the given user has any active staff_member row for the given provider.
+
+  Used by Messaging to authorise broadcast follow-ups for staff who work for
+  the broadcast's provider, without depending on the per-program staff
+  projection. Filters by both `provider_id` and `user_id` so a user with
+  active staff_members at multiple providers is correctly identified for each.
+  """
+  @spec active_for_provider_and_user?(String.t(), String.t()) :: boolean()
+  def active_for_provider_and_user?(provider_id, user_id) when is_binary(provider_id) and is_binary(user_id) do
+    @staff_repository.active_for_provider_and_user?(provider_id, user_id)
+  end
+
+  @doc """
   Returns the staff member matching the given invitation token hash,
   only if invitation_status is :sent. Used by the invitation registration flow.
   """

--- a/lib/klass_hero/provider/domain/ports/for_querying_staff_members.ex
+++ b/lib/klass_hero/provider/domain/ports/for_querying_staff_members.ex
@@ -22,4 +22,7 @@ defmodule KlassHero.Provider.Domain.Ports.ForQueryingStaffMembers do
 
   @callback get_active_by_user(user_id :: String.t()) ::
               {:ok, StaffMember.t()} | {:error, :not_found}
+
+  @callback active_for_provider_and_user?(provider_id :: String.t(), user_id :: String.t()) ::
+              boolean()
 end

--- a/test/klass_hero/messaging/application/commands/send_message_test.exs
+++ b/test/klass_hero/messaging/application/commands/send_message_test.exs
@@ -266,6 +266,42 @@ defmodule KlassHero.Messaging.Application.Commands.SendMessageTest do
       assert {:error, :broadcast_reply_not_allowed} =
                SendMessage.execute(broadcast.id, non_staff_user.id, "Sneaky reply")
     end
+
+    # Bug #669: a staff_member of the provider should be able to follow up in a
+    # broadcast even if their staff record is not in the per-program
+    # `program_staff_participants` projection. The projection is only populated
+    # when staff is explicitly assigned to a program, but staff are still
+    # authorised to broadcast for any program owned by their provider, so the
+    # follow-up permission must be aligned with that.
+    test "allows active staff_member of provider to send in broadcast even without program assignment" do
+      staff_user = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      insert(:staff_member_schema,
+        provider_id: provider.id,
+        user_id: staff_user.id,
+        active: true
+      )
+
+      broadcast =
+        insert(:conversation_schema,
+          type: "program_broadcast",
+          provider_id: provider.id,
+          program_id: program.id,
+          subject: "Announcement"
+        )
+
+      insert(:participant_schema, conversation_id: broadcast.id, user_id: staff_user.id)
+
+      # Note: NO call to ProgramStaffParticipantRepository.upsert_active/1 — the
+      # projection is intentionally empty for this staff/program combo.
+
+      assert {:ok, message} =
+               SendMessage.execute(broadcast.id, staff_user.id, "Hello from provider staff!")
+
+      assert message.content == "Hello from provider staff!"
+    end
   end
 
   describe "execute/4 with attachments" do

--- a/test/klass_hero/messaging/application/commands/send_message_test.exs
+++ b/test/klass_hero/messaging/application/commands/send_message_test.exs
@@ -302,6 +302,54 @@ defmodule KlassHero.Messaging.Application.Commands.SendMessageTest do
 
       assert message.content == "Hello from provider staff!"
     end
+
+    # Regression for PR #678 review: a user with active staff_member rows at
+    # multiple providers must be authorised for *each* provider's broadcasts —
+    # not just the most recently inserted one. The pre-fix adapter delegated to
+    # `Provider.get_active_staff_member_by_user/1`, which returns the latest
+    # row only and would wrongly deny posts in older providers' broadcasts.
+    test "allows staff active at multiple providers to send in non-latest provider's broadcast" do
+      staff_user = AccountsFixtures.user_fixture()
+
+      # Older active staff_member at provider A
+      provider_a = insert(:provider_profile_schema)
+      program_a = insert(:program_schema, provider_id: provider_a.id)
+
+      insert(:staff_member_schema,
+        provider_id: provider_a.id,
+        user_id: staff_user.id,
+        active: true
+      )
+
+      # Newer active staff_member at provider B (will be returned first by
+      # `get_active_staff_member_by_user/1` due to `order_by: desc(inserted_at)`)
+      provider_b = insert(:provider_profile_schema)
+
+      insert(:staff_member_schema,
+        provider_id: provider_b.id,
+        user_id: staff_user.id,
+        active: true
+      )
+
+      broadcast =
+        insert(:conversation_schema,
+          type: "program_broadcast",
+          provider_id: provider_a.id,
+          program_id: program_a.id,
+          subject: "Announcement"
+        )
+
+      insert(:participant_schema, conversation_id: broadcast.id, user_id: staff_user.id)
+
+      assert {:ok, message} =
+               SendMessage.execute(
+                 broadcast.id,
+                 staff_user.id,
+                 "Hello from staff of provider A"
+               )
+
+      assert message.content == "Hello from staff of provider A"
+    end
   end
 
   describe "execute/4 with attachments" do


### PR DESCRIPTION
## Summary

- Adds a new `ForResolvingProviderStaff` ACL port + `ProviderStaffResolver` adapter (delegates to `Provider.get_active_staff_member_by_user/1`).
- Extends `verify_broadcast_send_permission/3` in `SendMessage` with a third permission branch: any active staff member of the broadcast's provider may post follow-ups.
- Wires the new adapter under `:messaging, :for_resolving_provider_staff` in `config/config.exs`.

## Why

Staff members who could initiate a broadcast couldn't send follow-ups in the conversation they just created. The runtime check only consulted the per-program `program_staff_participants` projection, while the staff broadcast LiveView's mount-time check (`StaffBroadcastLive.staff_assigned?/2`) permitted any active staff of the provider. The two checks must agree — otherwise staff get redirected into a broadcast view with a "Type a message" input that immediately fails.

## Review Focus

- `lib/klass_hero/messaging/application/commands/send_message.ex` — new `cond` branch and `active_staff_for_provider?/2` helper. The order matters: provider-owner check is cheapest, then projection lookup, then ACL call.
- `lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex` — pattern-matches `provider_id` to ensure the staff record is for *this* provider.
- Whether a new dedicated port is the right granularity vs. extending `ForResolvingProgramStaff` (kept separate because that port's docstring scopes it to the projection).

## Test Plan

- [x] Failing test added to `send_message_test.exs` confirming the bug
- [x] Test passes after the fix (`mix test test/klass_hero/messaging/application/commands/send_message_test.exs`)
- [x] Full messaging suite passes (`457` tests)
- [x] Full project suite passes (`mix precommit` — 4085 passed)
- [x] End-to-end UI verification via Playwright: staff user sent broadcast, then sent a follow-up message in the broadcast conversation without error

Closes #669