### PR TITLE
feat: add provider business profile card to program detail page

### DIFF
--- a/lib/klass_hero_web/components/composite_components.ex
+++ b/lib/klass_hero_web/components/composite_components.ex
@@ -814,4 +814,74 @@ defmodule KlassHeroWeb.CompositeComponents do
     </div>
     """
   end
+
+  @doc """
+  Renders a public, read-only provider business profile card.
+
+  Used on parent-facing pages (e.g. program detail) to surface the provider's
+  business identity. Takes a plain view map so the component stays decoupled
+  from any domain struct.
+
+  ## Examples
+
+      <.provider_profile_card provider={%{
+        business_name: "Starlight Coaching",
+        description: "Empowering kids through play-based learning.",
+        logo_url: nil,
+        initials: "SC"
+      }} />
+  """
+  attr :provider, :map,
+    required: true,
+    doc: "Public provider view: %{business_name, description, logo_url, initials}"
+
+  def provider_profile_card(assigns) do
+    ~H"""
+    <section
+      id="provider-profile-card"
+      class={[
+        Theme.bg(:surface),
+        Theme.rounded(:xl),
+        "shadow-sm border overflow-hidden",
+        Theme.border_color(:light)
+      ]}
+    >
+      <div class={["p-4 border-b", Theme.border_color(:light)]}>
+        <h3 class={["font-semibold flex items-center gap-2", Theme.text_color(:heading)]}>
+          <.icon name="hero-building-storefront" class="w-5 h-5 text-hero-blue-500" />
+          {gettext("About the Provider")}
+        </h3>
+      </div>
+      <div class="p-6 flex items-start gap-4">
+        <img
+          :if={@provider.logo_url}
+          src={@provider.logo_url}
+          alt={@provider.business_name}
+          class={["w-16 h-16 object-cover flex-shrink-0", Theme.rounded(:full)]}
+        />
+        <div
+          :if={!@provider.logo_url}
+          class={[
+            "w-16 h-16 flex items-center justify-center text-white text-xl font-bold flex-shrink-0",
+            Theme.rounded(:full),
+            Theme.gradient(:primary)
+          ]}
+        >
+          {@provider.initials}
+        </div>
+        <div class="flex-1">
+          <h4 class={[Theme.typography(:card_title), Theme.text_color(:heading)]}>
+            {@provider.business_name}
+          </h4>
+          <p
+            :if={@provider.description}
+            class={["text-sm leading-relaxed mt-1", Theme.text_color(:secondary)]}
+          >
+            {@provider.description}
+          </p>
+        </div>
+      </div>
+    </section>
+    """
+  end
 end

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -1,6 +1,7 @@
 defmodule KlassHeroWeb.ProgramDetailLive do
   use KlassHeroWeb, :live_view
 
+  import KlassHeroWeb.CompositeComponents
   import KlassHeroWeb.ProgramComponents
   import KlassHeroWeb.UIComponents
 
@@ -10,6 +11,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   alias KlassHeroWeb.Helpers.TaskHelpers
   alias KlassHeroWeb.Presenters.ParticipantPolicyPresenter
   alias KlassHeroWeb.Presenters.ProgramPresenter
+  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Theme
 
@@ -27,7 +29,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
           )
         end
 
-        # Run two independent DB queries in parallel to reduce total mount latency.
+        # Run independent DB queries in parallel to reduce total mount latency.
         team_task =
           Task.Supervisor.async_nolink(KlassHero.TaskSupervisor, fn ->
             load_team_members(program.provider_id)
@@ -38,11 +40,19 @@ defmodule KlassHeroWeb.ProgramDetailLive do
             load_participant_policy(program.id)
           end)
 
+        provider_task =
+          Task.Supervisor.async_nolink(KlassHero.TaskSupervisor, fn ->
+            load_provider_profile(program.provider_id)
+          end)
+
         team_members =
           TaskHelpers.safe_await(team_task, [], label: "ProgramDetailLive.team_members")
 
         participant_policy =
           TaskHelpers.safe_await(policy_task, nil, label: "ProgramDetailLive.participant_policy")
+
+        provider_profile =
+          TaskHelpers.safe_await(provider_task, nil, label: "ProgramDetailLive.provider_profile")
 
         socket =
           socket
@@ -52,6 +62,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
           |> assign(team_members: team_members)
           |> assign(registration_status: ProgramCatalog.registration_status(program))
           |> assign(participant_policy: participant_policy)
+          |> assign(provider_profile: provider_profile)
 
         {:ok, socket}
 
@@ -118,6 +129,21 @@ defmodule KlassHeroWeb.ProgramDetailLive do
     case Provider.list_staff_members(provider_id) do
       {:ok, members} -> StaffMemberPresenter.to_card_view_list(members)
       {:error, _} -> []
+    end
+  end
+
+  defp load_provider_profile(nil), do: nil
+
+  defp load_provider_profile(provider_id) do
+    case Provider.get_provider_profile(provider_id) do
+      # Trigger: provider exists and is publicly visible
+      # Why: only :active providers should be surfaced to parents; drafts are incomplete
+      # Outcome: presenter view returned for the template
+      {:ok, %{profile_status: :active} = provider} -> ProviderPresenter.to_public_view(provider)
+      # Trigger: provider is :draft, missing, or in any other non-public state
+      # Why: nil lets the :if guard in the template suppress the card
+      # Outcome: no card is rendered
+      _ -> nil
     end
   end
 
@@ -467,6 +493,9 @@ defmodule KlassHeroWeb.ProgramDetailLive do
             </div>
           </div>
         </section>
+
+        <%!-- Provider Profile Card — rendered only when an active provider profile is available --%>
+        <.provider_profile_card :if={@provider_profile} provider={@provider_profile} />
 
         <%!-- TODO: "What Other Parents Say" reviews section — re-enable when review data is available.
              Dependencies: <.review_card> component import (removed), @reviews assign. --%>

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -52,6 +52,25 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   end
 
   @doc """
+  Transforms a Provider domain model to a slim, public-facing view.
+
+  Used for surfaces shown to parents (e.g. the program detail page) where
+  tier/verification/slot data is not relevant — only the business identity.
+
+  Returns a map with: id, business_name, description, logo_url, initials.
+  """
+  @spec to_public_view(ProviderProfile.t()) :: map()
+  def to_public_view(%ProviderProfile{} = provider) do
+    %{
+      id: provider.id,
+      business_name: provider.business_name,
+      description: provider.description,
+      logo_url: provider.logo_url,
+      initials: build_initials(provider.business_name)
+    }
+  end
+
+  @doc """
   Derives the aggregate verification status from a list of verification documents.
 
   Status priority:

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -253,6 +253,64 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
     end
   end
 
+  describe "provider profile card" do
+    test "renders business name and description for an active provider", %{conn: conn} do
+      provider =
+        provider_profile_fixture(
+          business_name: "Starlight Coaching",
+          description: "Empowering kids through play-based learning."
+        )
+
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "#provider-profile-card h4", "Starlight Coaching")
+      assert render(view) =~ "Empowering kids through play-based learning."
+    end
+
+    test "renders logo image when logo_url is present", %{conn: conn} do
+      provider =
+        provider_profile_fixture(
+          business_name: "Starlight Coaching",
+          logo_url: "https://cdn.example.com/starlight.png"
+        )
+
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(
+               view,
+               "#provider-profile-card img[src='https://cdn.example.com/starlight.png']"
+             )
+    end
+
+    test "renders initials avatar when logo_url is missing", %{conn: conn} do
+      provider = provider_profile_fixture(business_name: "Tiger Academy", logo_url: nil)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      refute has_element?(view, "#provider-profile-card img")
+      assert html =~ "TA"
+    end
+
+    test "does not render the card when the provider is in draft status", %{conn: conn} do
+      provider =
+        provider_profile_fixture(
+          business_name: "Not Ready Yet",
+          profile_status: "draft"
+        )
+
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      refute has_element?(view, "#provider-profile-card")
+    end
+  end
+
   describe "pricing display" do
     test "renders formatted program price", %{conn: conn} do
       program = insert(:program_schema, price: Decimal.new("149.99"))

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -290,10 +290,10 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       provider = provider_profile_fixture(business_name: "Tiger Academy", logo_url: nil)
       program = insert(:program_schema, provider_id: provider.id)
 
-      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
 
       refute has_element?(view, "#provider-profile-card img")
-      assert html =~ "TA"
+      assert has_element?(view, "#provider-profile-card", "TA")
     end
 
     test "does not render the card when the provider is in draft status", %{conn: conn} do

--- a/test/klass_hero_web/presenters/provider_presenter_test.exs
+++ b/test/klass_hero_web/presenters/provider_presenter_test.exs
@@ -78,6 +78,59 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenterTest do
     end
   end
 
+  describe "to_public_view/1" do
+    test "maps business_name, description, and logo_url through to the view" do
+      provider = %ProviderProfile{
+        id: "p-1",
+        identity_id: "i-1",
+        business_name: "Starlight Coaching",
+        description: "Empowering kids through play-based learning.",
+        logo_url: "https://cdn.example.com/starlight.png"
+      }
+
+      view = ProviderPresenter.to_public_view(provider)
+
+      assert view.id == "p-1"
+      assert view.business_name == "Starlight Coaching"
+      assert view.description == "Empowering kids through play-based learning."
+      assert view.logo_url == "https://cdn.example.com/starlight.png"
+    end
+
+    test "derives two-letter initials from a multi-word business name" do
+      provider = %ProviderProfile{
+        id: "p-2",
+        identity_id: "i-2",
+        business_name: "Tiger Academy"
+      }
+
+      assert ProviderPresenter.to_public_view(provider).initials == "TA"
+    end
+
+    test "derives a single-letter initial from a one-word business name" do
+      provider = %ProviderProfile{
+        id: "p-3",
+        identity_id: "i-3",
+        business_name: "Starlight"
+      }
+
+      assert ProviderPresenter.to_public_view(provider).initials == "S"
+    end
+
+    test "passes through nil description and logo_url" do
+      provider = %ProviderProfile{
+        id: "p-4",
+        identity_id: "i-4",
+        business_name: "Minimal Biz"
+      }
+
+      view = ProviderPresenter.to_public_view(provider)
+
+      assert view.description == nil
+      assert view.logo_url == nil
+      assert view.initials == "MB"
+    end
+  end
+
   describe "tier_label/1" do
     test "returns label for each valid tier" do
       assert ProviderPresenter.tier_label(:starter) == "Starter Plan"


### PR DESCRIPTION
## Summary
- Adds a public-facing **About the Provider** card on the program detail page — business name, description, and logo (or gradient initials fallback) — positioned between the team section and the bottom CTA.
- Introduces a new decoupled component (`provider_profile_card/1` in `CompositeComponents`) with a plain-map contract, keeping it separate from the dashboard-scoped `business_profile_card`. Data flows through a new `ProviderPresenter.to_public_view/1` projection so the component has no dependency on `ProviderProfile`.
- Suppresses the card for providers whose profile is still `:draft` via a `profile_status: :active` pattern match in the LiveView loader — the extra fetch runs in parallel with the existing team/policy tasks so page latency is unchanged.

Closes #550

## Review focus
- `lib/klass_hero_web/components/composite_components.ex` — new component; check whether you'd rather it live in a dedicated public-provider module instead of `CompositeComponents`.
- `lib/klass_hero_web/live/program_detail_live.ex` — `load_provider_profile/1` deliberately returns `nil` for draft/missing/error paths so the template `:if` guard is the single suppression point; confirm that matches the product intent.
- `lib/klass_hero_web/presenters/provider_presenter.ex` — the new `to_public_view/1` is deliberately slim (no tier/verification/slot data). If you anticipate needing those on the public surface, flag it.

## Test plan
- [x] `mix test test/klass_hero_web/presenters/provider_presenter_test.exs` — presenter unit tests (initials derivation, passthrough, nil handling) pass.
- [x] `mix test test/klass_hero_web/live/program_detail_live_test.exs` — LiveView tests cover: active provider renders, logo-vs-initials branches, draft provider suppressed.
- [x] `mix precommit` — full pipeline green (compile --warnings-as-errors, deps.unlock, format, lint_typography, 4094-test suite).
- [x] Manual: browsed `/programs/<id>` on desktop (1024×720) and mobile (390×844) — card placement and layout verified on both viewports; sticky mobile CTA footer unaffected.
- [x] Tidewave round-trip: `Provider.get_provider_profile/1` → `ProviderPresenter.to_public_view/1` produces the expected view map for a real active provider; draft providers correctly return `nil` through the loader.