### PR TITLE
feat: show provider business name in hero on program detail page

### DIFF
--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -197,11 +197,15 @@ defmodule KlassHeroWeb.ProgramDetailLive do
 
   attr :program, :map, required: true
   attr :wrapper_class, :string, required: true
+  attr :business_name, :string, default: nil
 
   defp hero_info_overlay(assigns) do
     ~H"""
     <div class={@wrapper_class}>
       <div class="max-w-4xl mx-auto text-center text-white">
+        <p :if={@business_name} id="hero-business-name" class="text-sm text-white/90 mb-1">
+          {@business_name}
+        </p>
         <h1 class={[Theme.typography(:page_title), "mb-3"]}>
           {@program.title}
         </h1>
@@ -272,6 +276,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
 
           <.hero_info_overlay
             program={@program}
+            business_name={@provider_profile && @provider_profile.business_name}
             wrapper_class="absolute bottom-0 left-0 right-0 pb-8 px-4"
           />
         </div>
@@ -298,6 +303,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
 
           <.hero_info_overlay
             program={@program}
+            business_name={@provider_profile && @provider_profile.business_name}
             wrapper_class="relative pb-12 px-4"
           />
         </div>

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -174,6 +174,29 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       assert has_element?(view, "#program-hero")
       assert has_element?(view, "[phx-click='back_to_programs']")
     end
+
+    test "renders provider business name above the program title", %{conn: conn} do
+      provider = provider_profile_fixture(business_name: "Starlight Coaching")
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "#hero-business-name", "Starlight Coaching")
+    end
+
+    test "omits business name when provider profile is draft", %{conn: conn} do
+      provider =
+        provider_profile_fixture(
+          business_name: "Not Ready Yet",
+          profile_status: "draft"
+        )
+
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      refute has_element?(view, "#hero-business-name")
+    end
   end
 
   describe "staff member display" do


### PR DESCRIPTION
## Summary

- Added an optional `:business_name` attr to the private `hero_info_overlay/1` component on the program detail page
- Rendered an "eyebrow" `<p id="hero-business-name">` above the existing `<h1>` title, styled to match the adjacent location line (`text-sm text-white/90`)
- Wired both call sites (image-hero and gradient-fallback branches) to pass `@provider_profile && @provider_profile.business_name`
- Added two LiveView tests covering the positive case (active provider renders the name) and the suppression case (draft provider hides it)
- No DB/migration/port work — builds entirely on the `@provider_profile` assign already populated by #680

Closes #549

## Review Focus

- **Nil-safety at the call sites** — `@provider_profile` is already filtered to active-only by `load_provider_profile/1` (`lib/klass_hero_web/live/program_detail_live.ex:137-148`, which returns `nil` for `:draft` or missing). The short-circuit `@provider_profile && @provider_profile.business_name` at lines 279 and 307 returns `nil` without dereferencing — worth a sanity check that this HEEx attr usage feels natural to you vs. extracting a helper.
- **Narrow component contract** — The component takes only the `business_name` string, not the full profile map (contrast with `<.provider_profile_card provider={@provider_profile} />` lower on the page). This keeps the hero overlay focused on what it needs and avoids leaking the public-view map shape into a second component.
- **Typography choice** — Used raw Tailwind `text-sm text-white/90` (line 204) instead of a `Theme.typography/1` variant. This matches the existing location line in the same overlay and `mix lint_typography` only forbids raw `font-display`/`font-sans`. Happy to add a new `:hero_kicker` variant if you'd prefer to centralize this going forward.
- **Test placement and idiom** — Both new tests (`test/klass_hero_web/live/program_detail_live_test.exs:178-201`) sit inside the existing `describe "hero info overlay"` block and follow the assertion idiom from the #680 provider-card tests (`has_element?/3` with a scoped id selector, `profile_status: "draft"` to exercise suppression).

## Test Plan

- [x] `mix precommit` passes — compile (warnings-as-errors), format, `lint_typography`, full suite (4096 passed, 12 skipped, 18 excluded)
- [x] New tests pass — `mix test test/klass_hero_web/live/program_detail_live_test.exs --only describe:"hero info overlay"` (4/4)
- [x] Existing `program_detail_live_test.exs` tests still pass (25/25)
- [x] Manual: navigate to `/programs/<id>` for an active provider — business name appears above the program title on both image-hero and gradient-fallback variants
- [x] Manual: navigate to a program whose provider is `:draft` (or has no provider) — no business name renders and no broken layout/extra whitespace
- [x] Manual: verify mobile (375×667) and desktop (1280×800) — typography reads correctly above the title without crowding