### PR TITLE
feat: show enrolled child names in conversation cards and titles

### DIFF
--- a/docs/superpowers/plans/2026-04-17-enrolled-children-projection.md
+++ b/docs/superpowers/plans/2026-04-17-enrolled-children-projection.md
@@ -1,0 +1,2007 @@
+# Enrolled Children Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **REQUIRED SKILLS:** Use `superpowers:test-driven-development` for all implementation. Use `idiomatic-elixir` when writing `.ex`/`.exs` files. Use `phoenix-pubsub` for event publishing/subscription patterns.
+>
+> **TIDEWAVE MCP PRIORITY:** ALWAYS prefer Tidewave MCP tools over bash for Elixir evaluation (`project_eval`), documentation lookup (`get_docs`), SQL queries (`execute_sql_query`), schema inspection (`get_ecto_schemas`), and log checking (`get_logs`). Alert immediately if Tidewave is unavailable.
+
+**Goal:** Show parent name and enrolled child names in conversation headers by building an event-driven projection that resolves enrollment data within the Messaging context.
+
+**Architecture:** Create missing integration events in Enrollment and Family contexts. Build an `EnrolledChildren` projection GenServer within Messaging that subscribes to cross-context events, maintains a local lookup table, and emits internal `enrolled_children_changed` domain events. Extend the existing `ConversationSummaries` projection to react to that internal event. Update the web layer to display the resolved names.
+
+**Tech Stack:** Elixir 1.20, Phoenix 1.8, Phoenix PubSub, Ecto, PostgreSQL, GenServer, Gettext
+
+**Spec:** `docs/superpowers/specs/2026-04-17-enrolled-children-projection-design.md`
+
+---
+
+## File Map
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `priv/repo/migrations/TIMESTAMP_create_messaging_enrolled_children.exs` | Migration: `messaging_enrolled_children` table |
+| `priv/repo/migrations/TIMESTAMP_add_enrolled_child_names_to_conversation_summaries.exs` | Migration: add `enrolled_child_names` column |
+| `lib/klass_hero/messaging/adapters/driven/persistence/schemas/enrolled_children_schema.ex` | Ecto schema for `messaging_enrolled_children` |
+| `lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex` | GenServer projection for enrolled children lookup |
+| `test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs` | Tests for `enrollment_created` domain event |
+| `test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs` | Tests for `enrollment_created` integration event |
+| `test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs` | Tests for `child_created`/`child_updated` domain events |
+| `test/klass_hero/family/domain/events/family_integration_events_child_lifecycle_test.exs` | Tests for `child_created`/`child_updated` integration events |
+| `test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs` | Tests for EnrolledChildren projection |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `lib/klass_hero/enrollment/domain/events/enrollment_events.ex` | Add `enrollment_created/3` |
+| `lib/klass_hero/enrollment/domain/events/enrollment_integration_events.ex` | Add `enrollment_created/3` |
+| `lib/klass_hero/enrollment/adapters/driving/events/event_handlers/promote_integration_events.ex` | Add `:enrollment_created` clause |
+| `lib/klass_hero/enrollment/application/commands/create_enrollment.ex` | Dispatch `enrollment_created` domain event |
+| `lib/klass_hero/messaging/application/queries/list_conversations.ex` | Add `enrolled_child_names` to `to_enriched_map/1` |
+| `lib/klass_hero/family/domain/events/family_events.ex` | Add `child_created/3`, `child_updated/3` |
+| `lib/klass_hero/family/domain/events/family_integration_events.ex` | Add `child_created/3`, `child_updated/3` |
+| `lib/klass_hero/family/adapters/driving/events/event_handlers/promote_integration_events.ex` | Add `:child_created`, `:child_updated` clauses |
+| `lib/klass_hero/family/application/commands/children/create_child.ex` | Dispatch `child_created` domain event |
+| `lib/klass_hero/family/application/commands/children/update_child.ex` | Dispatch `child_updated` domain event |
+| `lib/klass_hero/messaging/domain/events/messaging_events.ex` | Add `program_id` param to `conversation_created` |
+| `lib/klass_hero/messaging/application/commands/create_direct_conversation.ex` | Pass `program_id` to event |
+| `lib/klass_hero/messaging/adapters/driven/persistence/schemas/conversation_summary_schema.ex` | Add `enrolled_child_names` field |
+| `lib/klass_hero/messaging/domain/read_models/conversation_summary.ex` | Add `enrolled_child_names` field |
+| `lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex` | Map `enrolled_child_names` in `to_dto/1` |
+| `lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex` | Subscribe to new topic, handle `enrolled_children_changed`, update bootstrap |
+| `lib/klass_hero/projection_supervisor.ex` | Add `EnrolledChildren` before `ConversationSummaries` |
+| `lib/klass_hero/application.ex` | Register new event bus handlers and event subscribers |
+| `lib/klass_hero_web/live/messaging_live_helper.ex` | Change `get_conversation_title` to arity 3, add `fetch_enrolled_child_names/2` |
+| `lib/klass_hero_web/components/messaging_components.ex` | Add child names subtitle to provider conversation card |
+| `test/klass_hero_web/live/messaging_live_helper_test.exs` | Update tests for `get_conversation_title/3` |
+
+---
+
+### Task 1: `enrollment_created` Domain + Integration Events
+
+**Files:**
+- Create: `test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs`
+- Create: `test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs`
+- Modify: `lib/klass_hero/enrollment/domain/events/enrollment_events.ex`
+- Modify: `lib/klass_hero/enrollment/domain/events/enrollment_integration_events.ex`
+
+- [ ] **Step 1: Write failing test for `enrollment_created` domain event**
+
+```elixir
+# test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs
+defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEventsEnrollmentCreatedTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  describe "enrollment_created/3" do
+    test "creates event with correct type and aggregate" do
+      enrollment_id = Ecto.UUID.generate()
+
+      payload = %{
+        enrollment_id: enrollment_id,
+        child_id: Ecto.UUID.generate(),
+        parent_id: Ecto.UUID.generate(),
+        parent_user_id: Ecto.UUID.generate(),
+        program_id: Ecto.UUID.generate(),
+        status: "pending"
+      }
+
+      event = EnrollmentEvents.enrollment_created(enrollment_id, payload)
+
+      assert %DomainEvent{} = event
+      assert event.event_type == :enrollment_created
+      assert event.aggregate_id == enrollment_id
+      assert event.aggregate_type == :enrollment
+      assert event.payload.enrollment_id == enrollment_id
+      assert event.payload.child_id == payload.child_id
+      assert event.payload.parent_user_id == payload.parent_user_id
+      assert event.payload.program_id == payload.program_id
+    end
+
+    test "base_payload enrollment_id wins over caller-supplied enrollment_id" do
+      real_id = Ecto.UUID.generate()
+      conflicting_payload = %{enrollment_id: "should-be-overridden", extra: "data"}
+
+      event = EnrollmentEvents.enrollment_created(real_id, conflicting_payload)
+
+      assert event.payload.enrollment_id == real_id
+      assert event.payload.extra == "data"
+    end
+
+    test "raises for nil enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentEvents.enrollment_created(nil) end
+    end
+
+    test "raises for empty string enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentEvents.enrollment_created("") end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs --max-failures 1`
+Expected: FAIL — `EnrollmentEvents.enrollment_created/2` is undefined
+
+- [ ] **Step 3: Implement `enrollment_created` domain event factory**
+
+Add to `lib/klass_hero/enrollment/domain/events/enrollment_events.ex`, after the `enrollment_cancelled` function (before the final `end`):
+
+```elixir
+  @doc """
+  Creates an `:enrollment_created` event when a new enrollment is persisted.
+
+  ## Parameters
+
+  - `enrollment_id` — the new enrollment's ID
+  - `payload` — event data including child_id, parent_id, parent_user_id, program_id, status
+  - `opts` — forwarded to `DomainEvent.new/5` (e.g. `:correlation_id`)
+  """
+  def enrollment_created(enrollment_id, payload \\ %{}, opts \\ [])
+
+  def enrollment_created(enrollment_id, payload, opts)
+      when is_binary(enrollment_id) and byte_size(enrollment_id) > 0 do
+    base_payload = %{enrollment_id: enrollment_id}
+
+    DomainEvent.new(
+      :enrollment_created,
+      enrollment_id,
+      @aggregate_type,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def enrollment_created(enrollment_id, _payload, _opts) do
+    raise ArgumentError,
+          "enrollment_created/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
+  end
+```
+
+Also update the `@moduledoc` events list to include:
+```
+  - `:enrollment_created` - Emitted when a new enrollment is successfully created.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs`
+Expected: 4 tests, 0 failures
+
+- [ ] **Step 5: Write failing test for `enrollment_created` integration event**
+
+```elixir
+# test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs
+defmodule KlassHero.Enrollment.Domain.Events.EnrollmentIntegrationEventsEnrollmentCreatedTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentIntegrationEvents
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  describe "enrollment_created/3" do
+    test "creates integration event with correct structure" do
+      enrollment_id = Ecto.UUID.generate()
+
+      payload = %{
+        enrollment_id: enrollment_id,
+        child_id: Ecto.UUID.generate(),
+        parent_id: Ecto.UUID.generate(),
+        parent_user_id: Ecto.UUID.generate(),
+        program_id: Ecto.UUID.generate(),
+        status: "pending"
+      }
+
+      event = EnrollmentIntegrationEvents.enrollment_created(enrollment_id, payload)
+
+      assert %IntegrationEvent{} = event
+      assert event.event_type == :enrollment_created
+      assert event.source_context == :enrollment
+      assert event.entity_type == :enrollment
+      assert event.entity_id == enrollment_id
+      assert event.payload.parent_user_id == payload.parent_user_id
+    end
+
+    test "base_payload enrollment_id wins over caller-supplied enrollment_id" do
+      real_id = Ecto.UUID.generate()
+      conflicting_payload = %{enrollment_id: "should-be-overridden", extra: "data"}
+
+      event = EnrollmentIntegrationEvents.enrollment_created(real_id, conflicting_payload)
+
+      assert event.payload.enrollment_id == real_id
+      assert event.payload.extra == "data"
+    end
+
+    test "raises for nil enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentIntegrationEvents.enrollment_created(nil) end
+    end
+
+    test "raises for empty string enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentIntegrationEvents.enrollment_created("") end
+    end
+  end
+end
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `mix test test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs --max-failures 1`
+Expected: FAIL — `enrollment_created/2` is undefined
+
+- [ ] **Step 7: Implement `enrollment_created` integration event factory**
+
+Add to `lib/klass_hero/enrollment/domain/events/enrollment_integration_events.ex`, after the `enrollment_cancelled` function:
+
+```elixir
+  @typedoc "Payload for `:enrollment_created` events."
+  @type enrollment_created_payload :: %{
+          required(:enrollment_id) => String.t(),
+          optional(atom()) => term()
+        }
+
+  @doc """
+  Creates an `:enrollment_created` integration event.
+
+  ## Parameters
+
+  - `enrollment_id` - the new enrollment's ID
+  - `payload` - event data including child_id, parent_id, parent_user_id, program_id, status
+  - `opts` - metadata options (correlation_id, causation_id)
+
+  ## Raises
+
+  - `ArgumentError` if `enrollment_id` is nil or empty
+  """
+  def enrollment_created(enrollment_id, payload \\ %{}, opts \\ [])
+
+  def enrollment_created(enrollment_id, payload, opts)
+      when is_binary(enrollment_id) and byte_size(enrollment_id) > 0 do
+    base_payload = %{enrollment_id: enrollment_id}
+
+    IntegrationEvent.new(
+      :enrollment_created,
+      @source_context,
+      :enrollment,
+      enrollment_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def enrollment_created(enrollment_id, _payload, _opts) do
+    raise ArgumentError,
+          "enrollment_created/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
+  end
+```
+
+Also update the `@moduledoc` events list to include:
+```
+  - `:enrollment_created` - Emitted when a new enrollment is successfully created.
+    Downstream contexts can react to update projections or trigger workflows.
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `mix test test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs`
+Expected: 4 tests, 0 failures
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs \
+        test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs \
+        lib/klass_hero/enrollment/domain/events/enrollment_events.ex \
+        lib/klass_hero/enrollment/domain/events/enrollment_integration_events.ex
+git commit -m "feat: add enrollment_created domain and integration events"
+```
+
+---
+
+### Task 2: Wire `enrollment_created` — Promotion, Dispatch, and `enrollment_cancelled` Fix
+
+**Files:**
+- Modify: `lib/klass_hero/enrollment/adapters/driving/events/event_handlers/promote_integration_events.ex`
+- Modify: `lib/klass_hero/enrollment/application/commands/create_enrollment.ex`
+- Modify: `lib/klass_hero/enrollment/application/commands/cancel_enrollment_by_admin.ex`
+- Modify: `lib/klass_hero/application.ex`
+
+- [ ] **Step 1: Add `enrollment_created` promotion handler**
+
+Add to `lib/klass_hero/enrollment/adapters/driving/events/event_handlers/promote_integration_events.ex`, after the `enrollment_cancelled` clause:
+
+```elixir
+  def handle(%DomainEvent{event_type: :enrollment_created} = event) do
+    # Trigger: enrollment_created domain event dispatched from CreateEnrollment use case
+    # Why: downstream contexts (e.g., Messaging) need to react to new enrollments
+    # Outcome: publish integration event on topic integration:enrollment:enrollment_created
+    event.payload.enrollment_id
+    |> EnrollmentIntegrationEvents.enrollment_created(event.payload)
+    |> IntegrationEventPublishing.publish_critical("enrollment_created",
+      enrollment_id: event.payload.enrollment_id
+    )
+  end
+```
+
+- [ ] **Step 2: Register `enrollment_created` on the Enrollment DomainEventBus**
+
+In `lib/klass_hero/application.ex`, find the `:enrollment_domain_event_bus` child spec (around line 123). Add the new handler after the `enrollment_cancelled` entry:
+
+```elixir
+           {:enrollment_created,
+            {KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10}
+```
+
+- [ ] **Step 3: Dispatch `enrollment_created` from `CreateEnrollment`**
+
+In `lib/klass_hero/enrollment/application/commands/create_enrollment.ex`:
+
+Add at the top, below the existing aliases:
+```elixir
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Shared.EventDispatchHelper
+```
+
+Add a module attribute for the context:
+```elixir
+  @context KlassHero.Enrollment
+```
+
+Replace the `create_enrollment_with_validation` function to dispatch the event after successful creation:
+
+```elixir
+  defp create_enrollment_with_validation(identity_id, params) do
+    with {:ok, parent} <- validate_parent_profile(identity_id),
+         :ok <- validate_booking_entitlement(parent),
+         :ok <- validate_participant_eligibility(params[:program_id], params[:child_id]),
+         {:ok, enrollment} <-
+           build_enrollment_attrs(params, parent.id)
+           |> then(&@enrollment_repository.create_with_capacity_check(&1, params[:program_id])) do
+      dispatch_enrollment_created(enrollment, identity_id)
+      {:ok, enrollment}
+    end
+  end
+```
+
+Replace the `create_enrollment_direct` function:
+
+```elixir
+  defp create_enrollment_direct(params) do
+    attrs = build_enrollment_attrs(params, params[:parent_id])
+
+    Logger.info("[Enrollment.CreateEnrollment] Creating enrollment (direct)",
+      program_id: attrs[:program_id],
+      child_id: attrs[:child_id],
+      parent_id: attrs[:parent_id]
+    )
+
+    case @enrollment_repository.create_with_capacity_check(attrs, params[:program_id]) do
+      {:ok, enrollment} ->
+        dispatch_enrollment_created(enrollment, params[:identity_id])
+        {:ok, enrollment}
+
+      error ->
+        error
+    end
+  end
+```
+
+Add the private dispatch helper:
+
+```elixir
+  defp dispatch_enrollment_created(enrollment, identity_id) do
+    EnrollmentEvents.enrollment_created(enrollment.id, %{
+      enrollment_id: enrollment.id,
+      child_id: enrollment.child_id,
+      parent_id: enrollment.parent_id,
+      parent_user_id: identity_id,
+      program_id: enrollment.program_id,
+      status: enrollment.status
+    })
+    |> EventDispatchHelper.dispatch(@context)
+  end
+```
+
+- [ ] **Step 4: Add `parent_user_id` to `enrollment_cancelled` payload**
+
+In `lib/klass_hero/enrollment/application/commands/cancel_enrollment_by_admin.ex`, the event dispatch at line 56–64 currently doesn't include `parent_user_id`. We need to resolve it. The simplest approach: the `enrollment_cancelled` event already carries `parent_id` — the Messaging handler can look up `identity_id` from its own `messaging_enrolled_children` table (which stores `parent_user_id`). No change needed to this command.
+
+**Verify via Tidewave:** Use `get_ecto_schemas` to confirm the `enrollments` table doesn't store `identity_id` directly. The `parent_user_id` mapping lives in the `messaging_enrolled_children` projection, so the EnrolledChildren handler can use its own data to find affected conversations when processing `enrollment_cancelled`.
+
+- [ ] **Step 5: Run all Enrollment event tests**
+
+Run: `mix test test/klass_hero/enrollment/domain/events/ --max-failures 3`
+Expected: All tests pass
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `mix compile --warnings-as-errors`
+Expected: Clean compilation with no warnings
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/klass_hero/enrollment/adapters/driving/events/event_handlers/promote_integration_events.ex \
+        lib/klass_hero/enrollment/application/commands/create_enrollment.ex \
+        lib/klass_hero/application.ex
+git commit -m "feat: wire enrollment_created event promotion and dispatch"
+```
+
+---
+
+### Task 3: Family `child_created` and `child_updated` Events
+
+**Files:**
+- Create: `test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs`
+- Create: `test/klass_hero/family/domain/events/family_integration_events_child_lifecycle_test.exs`
+- Modify: `lib/klass_hero/family/domain/events/family_events.ex`
+- Modify: `lib/klass_hero/family/domain/events/family_integration_events.ex`
+- Modify: `lib/klass_hero/family/adapters/driving/events/event_handlers/promote_integration_events.ex`
+- Modify: `lib/klass_hero/family/application/commands/children/create_child.ex`
+- Modify: `lib/klass_hero/family/application/commands/children/update_child.ex`
+- Modify: `lib/klass_hero/application.ex`
+
+- [ ] **Step 1: Write failing tests for `child_created` and `child_updated` domain events**
+
+```elixir
+# test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs
+defmodule KlassHero.Family.Domain.Events.FamilyEventsChildLifecycleTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Family.Domain.Events.FamilyEvents
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  describe "child_created/3" do
+    test "creates event with correct type and aggregate" do
+      child_id = Ecto.UUID.generate()
+
+      payload = %{
+        child_id: child_id,
+        parent_id: Ecto.UUID.generate(),
+        first_name: "Emma",
+        last_name: "Johnson"
+      }
+
+      event = FamilyEvents.child_created(child_id, payload)
+
+      assert %DomainEvent{} = event
+      assert event.event_type == :child_created
+      assert event.aggregate_id == child_id
+      assert event.aggregate_type == :child
+      assert event.payload.child_id == child_id
+      assert event.payload.first_name == "Emma"
+    end
+
+    test "base_payload child_id wins over caller-supplied child_id" do
+      real_id = Ecto.UUID.generate()
+      payload = %{child_id: "should-be-overridden", first_name: "Emma"}
+
+      event = FamilyEvents.child_created(real_id, payload)
+
+      assert event.payload.child_id == real_id
+      assert event.payload.first_name == "Emma"
+    end
+
+    test "raises for nil child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/,
+        fn -> FamilyEvents.child_created(nil) end
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/,
+        fn -> FamilyEvents.child_created("") end
+    end
+  end
+
+  describe "child_updated/3" do
+    test "creates event with correct type and aggregate" do
+      child_id = Ecto.UUID.generate()
+
+      payload = %{
+        child_id: child_id,
+        parent_id: Ecto.UUID.generate(),
+        first_name: "Emily",
+        last_name: "Johnson"
+      }
+
+      event = FamilyEvents.child_updated(child_id, payload)
+
+      assert %DomainEvent{} = event
+      assert event.event_type == :child_updated
+      assert event.aggregate_id == child_id
+      assert event.aggregate_type == :child
+      assert event.payload.first_name == "Emily"
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/,
+        fn -> FamilyEvents.child_updated("") end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs --max-failures 1`
+Expected: FAIL — `child_created/2` is undefined
+
+- [ ] **Step 3: Implement `child_created` and `child_updated` domain event factories**
+
+Add to `lib/klass_hero/family/domain/events/family_events.ex`, after the `invite_family_ready` function:
+
+```elixir
+  @doc """
+  Creates a `child_created` event.
+
+  Emitted after the Family context creates a new child record.
+  Downstream contexts can react to this event to populate projections.
+
+  ## Parameters
+
+  - `child_id` - The ID of the newly created child
+  - `payload` - Event data including parent_id, first_name, last_name
+  - `opts` - Metadata options (correlation_id, causation_id, user_id)
+  """
+  def child_created(child_id, payload \\ %{}, opts \\ [])
+
+  def child_created(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    DomainEvent.new(
+      :child_created,
+      child_id,
+      @aggregate_type,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_created(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_created/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
+
+  @doc """
+  Creates a `child_updated` event.
+
+  Emitted after the Family context updates an existing child record.
+  Downstream contexts can react to name changes.
+
+  ## Parameters
+
+  - `child_id` - The ID of the updated child
+  - `payload` - Event data including parent_id, first_name, last_name
+  - `opts` - Metadata options (correlation_id, causation_id, user_id)
+  """
+  def child_updated(child_id, payload \\ %{}, opts \\ [])
+
+  def child_updated(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    DomainEvent.new(
+      :child_updated,
+      child_id,
+      @aggregate_type,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_updated(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_updated/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
+```
+
+Update the `@moduledoc` to include:
+```
+  - `:child_created` - Emitted when a new child record is created.
+  - `:child_updated` - Emitted when a child record is updated.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mix test test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs`
+Expected: 6 tests, 0 failures
+
+- [ ] **Step 5: Write failing test for integration events**
+
+```elixir
+# test/klass_hero/family/domain/events/family_integration_events_child_lifecycle_test.exs
+defmodule KlassHero.Family.Domain.Events.FamilyIntegrationEventsChildLifecycleTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Family.Domain.Events.FamilyIntegrationEvents
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  describe "child_created/3" do
+    test "creates integration event with correct structure" do
+      child_id = Ecto.UUID.generate()
+      payload = %{child_id: child_id, parent_id: Ecto.UUID.generate(), first_name: "Emma", last_name: "Johnson"}
+
+      event = FamilyIntegrationEvents.child_created(child_id, payload)
+
+      assert %IntegrationEvent{} = event
+      assert event.event_type == :child_created
+      assert event.source_context == :family
+      assert event.entity_type == :child
+      assert event.entity_id == child_id
+      assert event.payload.first_name == "Emma"
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/,
+        fn -> FamilyIntegrationEvents.child_created("") end
+    end
+  end
+
+  describe "child_updated/3" do
+    test "creates integration event with correct structure" do
+      child_id = Ecto.UUID.generate()
+      payload = %{child_id: child_id, parent_id: Ecto.UUID.generate(), first_name: "Emily", last_name: "Johnson"}
+
+      event = FamilyIntegrationEvents.child_updated(child_id, payload)
+
+      assert %IntegrationEvent{} = event
+      assert event.event_type == :child_updated
+      assert event.source_context == :family
+      assert event.entity_type == :child
+      assert event.entity_id == child_id
+      assert event.payload.first_name == "Emily"
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/,
+        fn -> FamilyIntegrationEvents.child_updated("") end
+    end
+  end
+end
+```
+
+- [ ] **Step 6: Implement integration event factories + promotion handlers + command dispatch + DomainEventBus wiring**
+
+**Integration events** — add to `lib/klass_hero/family/domain/events/family_integration_events.ex`:
+
+```elixir
+  @typedoc "Payload for `:child_created` events."
+  @type child_created_payload :: %{
+          required(:child_id) => String.t(),
+          optional(atom()) => term()
+        }
+
+  @typedoc "Payload for `:child_updated` events."
+  @type child_updated_payload :: %{
+          required(:child_id) => String.t(),
+          optional(atom()) => term()
+        }
+
+  def child_created(child_id, payload \\ %{}, opts \\ [])
+
+  def child_created(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    IntegrationEvent.new(
+      :child_created,
+      @source_context,
+      @entity_type,
+      child_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_created(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_created/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
+
+  def child_updated(child_id, payload \\ %{}, opts \\ [])
+
+  def child_updated(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    IntegrationEvent.new(
+      :child_updated,
+      @source_context,
+      @entity_type,
+      child_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_updated(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_updated/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
+```
+
+**Promotion handlers** — add to `lib/klass_hero/family/adapters/driving/events/event_handlers/promote_integration_events.ex`:
+
+```elixir
+  def handle(%DomainEvent{event_type: :child_created} = event) do
+    # Trigger: child_created domain event dispatched from CreateChild use case
+    # Why: downstream contexts (e.g., Messaging) need child names for projections
+    # Outcome: publish integration event on topic integration:family:child_created
+    event.payload.child_id
+    |> FamilyIntegrationEvents.child_created(event.payload)
+    |> IntegrationEventPublishing.publish()
+  end
+
+  def handle(%DomainEvent{event_type: :child_updated} = event) do
+    # Trigger: child_updated domain event dispatched from UpdateChild use case
+    # Why: downstream contexts need updated child names for projections
+    # Outcome: publish integration event on topic integration:family:child_updated
+    event.payload.child_id
+    |> FamilyIntegrationEvents.child_updated(event.payload)
+    |> IntegrationEventPublishing.publish()
+  end
+```
+
+**DomainEventBus wiring** — in `lib/klass_hero/application.ex`, find the `:family_domain_event_bus` child spec (around line 84). Add after the `invite_family_ready` entry:
+
+```elixir
+           {:child_created,
+            {KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}, priority: 10},
+           {:child_updated,
+            {KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}, priority: 10}
+```
+
+**Dispatch from CreateChild** — in `lib/klass_hero/family/application/commands/children/create_child.ex`, add aliases and dispatch:
+
+```elixir
+  alias KlassHero.Family.Domain.Events.FamilyEvents
+  alias KlassHero.Shared.EventDispatchHelper
+
+  @context KlassHero.Family
+```
+
+Update `execute/1` to dispatch after successful creation:
+
+```elixir
+  def execute(attrs) when is_map(attrs) do
+    {parent_id, child_attrs} = Map.pop(attrs, :parent_id)
+    child_attrs = Map.put_new(child_attrs, :id, Ecto.UUID.generate())
+
+    with {:ok, _validated} <- Child.new(child_attrs),
+         {:ok, persisted} <- persist_child(child_attrs, parent_id) do
+      dispatch_child_created(persisted, parent_id)
+      {:ok, persisted}
+    else
+      {:error, errors} when is_list(errors) -> {:error, {:validation_error, errors}}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp dispatch_child_created(child, parent_id) do
+    FamilyEvents.child_created(child.id, %{
+      child_id: child.id,
+      parent_id: parent_id,
+      first_name: child.first_name,
+      last_name: child.last_name
+    })
+    |> EventDispatchHelper.dispatch(@context)
+  end
+```
+
+**Dispatch from UpdateChild** — in `lib/klass_hero/family/application/commands/children/update_child.ex`:
+
+```elixir
+  alias KlassHero.Family.Domain.Events.FamilyEvents
+  alias KlassHero.Shared.EventDispatchHelper
+
+  @context KlassHero.Family
+```
+
+Update `execute/2`:
+
+```elixir
+  def execute(child_id, attrs) when is_binary(child_id) and is_map(attrs) do
+    with {:ok, existing} <- @repository.get_by_id(child_id),
+         merged = Map.merge(Map.from_struct(existing), attrs),
+         {:ok, _validated} <- Child.new(merged),
+         {:ok, updated} <- @repository.update(child_id, attrs) do
+      dispatch_child_updated(updated)
+      {:ok, updated}
+    else
+      {:error, errors} when is_list(errors) -> {:error, {:validation_error, errors}}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp dispatch_child_updated(child) do
+    FamilyEvents.child_updated(child.id, %{
+      child_id: child.id,
+      first_name: child.first_name,
+      last_name: child.last_name
+    })
+    |> EventDispatchHelper.dispatch(@context)
+  end
+```
+
+Note: `parent_id` is not on the child struct directly (it's in the join table). The `UpdateChild` dispatch omits `parent_id`. The Messaging handler can look up the parent via its own `messaging_enrolled_children` table using `child_id`.
+
+- [ ] **Step 7: Run all Family event tests + verify compilation**
+
+Run: `mix test test/klass_hero/family/domain/events/ && mix compile --warnings-as-errors`
+Expected: All tests pass, no compilation warnings
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/klass_hero/family/ lib/klass_hero/application.ex \
+        test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs \
+        test/klass_hero/family/domain/events/family_integration_events_child_lifecycle_test.exs
+git commit -m "feat: add child_created and child_updated domain and integration events"
+```
+
+---
+
+### Task 4: Fix `conversation_created` Event to Include `program_id`
+
+**Files:**
+- Modify: `lib/klass_hero/messaging/domain/events/messaging_events.ex`
+- Modify: `lib/klass_hero/messaging/application/commands/create_direct_conversation.ex`
+- Modify: `test/klass_hero_web/live/messaging_live_helper_test.exs` (verify existing tests still pass)
+
+- [ ] **Step 1: Update `conversation_created` domain event to accept `program_id`**
+
+In `lib/klass_hero/messaging/domain/events/messaging_events.ex`, change the `conversation_created` function (around line 28):
+
+```elixir
+  @spec conversation_created(
+          conversation_id :: String.t(),
+          type :: :direct | :program_broadcast,
+          provider_id :: String.t(),
+          participant_ids :: [String.t()],
+          program_id :: String.t() | nil
+        ) :: DomainEvent.t()
+  def conversation_created(conversation_id, type, provider_id, participant_ids, program_id \\ nil) do
+    DomainEvent.new(
+      :conversation_created,
+      conversation_id,
+      @aggregate_type,
+      %{
+        conversation_id: conversation_id,
+        type: type,
+        provider_id: provider_id,
+        participant_ids: participant_ids,
+        program_id: program_id
+      }
+    )
+  end
+```
+
+- [ ] **Step 2: Update `CreateDirectConversation` to pass `program_id`**
+
+In `lib/klass_hero/messaging/application/commands/create_direct_conversation.ex`, update `publish_event/3` (around line 113) to accept and pass `program_id`:
+
+```elixir
+  defp publish_event(conversation, participant_ids, provider_id) do
+    event =
+      MessagingEvents.conversation_created(
+        conversation.id,
+        conversation.type,
+        provider_id,
+        participant_ids,
+        conversation.program_id
+      )
+
+    DomainEventBus.dispatch(@context, event)
+    :ok
+  end
+```
+
+- [ ] **Step 3: Verify compilation and existing tests**
+
+Run: `mix compile --warnings-as-errors && mix test test/klass_hero_web/live/messaging_live_helper_test.exs`
+Expected: Clean compile, existing tests pass
+
+- [ ] **Step 4: Verify via Tidewave that the event carries program_id**
+
+Use Tidewave `project_eval` to verify:
+```elixir
+alias KlassHero.Messaging.Domain.Events.MessagingEvents
+event = MessagingEvents.conversation_created("conv-1", :direct, "prov-1", ["u1", "u2"], "prog-1")
+event.payload.program_id
+```
+Expected: `"prog-1"`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/klass_hero/messaging/domain/events/messaging_events.ex \
+        lib/klass_hero/messaging/application/commands/create_direct_conversation.ex
+git commit -m "fix: include program_id in conversation_created event payload"
+```
+
+---
+
+### Task 5: Database Migrations
+
+**Files:**
+- Create: `priv/repo/migrations/TIMESTAMP_create_messaging_enrolled_children.exs`
+- Create: `priv/repo/migrations/TIMESTAMP_add_enrolled_child_names_to_conversation_summaries.exs`
+
+- [ ] **Step 1: Generate the messaging_enrolled_children migration**
+
+Run: `mix ecto.gen.migration create_messaging_enrolled_children`
+
+Then replace the generated content with:
+
+```elixir
+defmodule KlassHero.Repo.Migrations.CreateMessagingEnrolledChildren do
+  use Ecto.Migration
+
+  def change do
+    create table(:messaging_enrolled_children, primary_key: false) do
+      add :id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()")
+      add :parent_user_id, :binary_id, null: false
+      add :program_id, :binary_id, null: false
+      add :child_id, :binary_id, null: false
+      add :child_first_name, :string
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:messaging_enrolled_children, [:parent_user_id, :program_id, :child_id])
+    create index(:messaging_enrolled_children, [:parent_user_id, :program_id])
+    create index(:messaging_enrolled_children, [:child_id])
+  end
+end
+```
+
+- [ ] **Step 2: Generate the conversation_summaries migration**
+
+Run: `mix ecto.gen.migration add_enrolled_child_names_to_conversation_summaries`
+
+Then replace the generated content with:
+
+```elixir
+defmodule KlassHero.Repo.Migrations.AddEnrolledChildNamesToConversationSummaries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversation_summaries) do
+      add :enrolled_child_names, {:array, :string}, default: []
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run migrations**
+
+Run: `mix ecto.migrate`
+Expected: Both migrations applied successfully
+
+- [ ] **Step 4: Verify via Tidewave**
+
+Use Tidewave `execute_sql_query`:
+```sql
+SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'messaging_enrolled_children' ORDER BY ordinal_position;
+```
+Expected: columns include `parent_user_id`, `program_id`, `child_id`, `child_first_name`
+
+Use Tidewave `execute_sql_query`:
+```sql
+SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'conversation_summaries' AND column_name = 'enrolled_child_names';
+```
+Expected: one row with `data_type = 'ARRAY'`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add priv/repo/migrations/
+git commit -m "feat: add messaging_enrolled_children table and enrolled_child_names column"
+```
+
+---
+
+### Task 6: EnrolledChildren Schema + Projection GenServer
+
+**Files:**
+- Create: `lib/klass_hero/messaging/adapters/driven/persistence/schemas/enrolled_children_schema.ex`
+- Create: `lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex`
+- Create: `test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs`
+
+- [ ] **Step 1: Write failing test for EnrolledChildren projection bootstrap**
+
+```elixir
+# test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
+defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest do
+  use KlassHero.DataCase, async: false
+
+  import Ecto.Query
+  import KlassHero.Factory
+
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
+  alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
+  alias KlassHero.Repo
+
+  @test_server_name :enrolled_children_projection_test
+
+  setup do
+    pid = start_supervised!({EnrolledChildren, name: @test_server_name})
+    {:ok, pid: pid}
+  end
+
+  describe "bootstrap" do
+    test "projects existing enrollments into messaging_enrolled_children on startup" do
+      # Create a parent with a child enrolled in a program
+      user = user_fixture(name: "Sarah Johnson")
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      child = insert(:child_schema, first_name: "Emma", last_name: "Johnson")
+      insert(:child_guardian_schema, child_id: child.id, guardian_id: parent.id)
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      insert(:enrollment_schema,
+        parent_id: parent.id,
+        child_id: child.id,
+        program_id: program.id,
+        status: "confirmed"
+      )
+
+      # Trigger a rebuild to pick up the test data
+      EnrolledChildren.rebuild(@test_server_name)
+
+      # Verify the projection populated
+      rows =
+        from(e in EnrolledChildrenSchema,
+          where: e.parent_user_id == ^user.id and e.program_id == ^program.id
+        )
+        |> Repo.all()
+
+      assert length(rows) == 1
+      [row] = rows
+      assert row.child_id == child.id
+      assert row.child_first_name == "Emma"
+    end
+
+    test "ignores cancelled enrollments during bootstrap" do
+      user = user_fixture(name: "Bob Smith")
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      child = insert(:child_schema, first_name: "Max")
+      insert(:child_guardian_schema, child_id: child.id, guardian_id: parent.id)
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      insert(:enrollment_schema,
+        parent_id: parent.id,
+        child_id: child.id,
+        program_id: program.id,
+        status: "cancelled"
+      )
+
+      EnrolledChildren.rebuild(@test_server_name)
+
+      count =
+        from(e in EnrolledChildrenSchema,
+          where: e.parent_user_id == ^user.id
+        )
+        |> Repo.aggregate(:count)
+
+      assert count == 0
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs --max-failures 1`
+Expected: FAIL — `EnrolledChildrenSchema` and `EnrolledChildren` modules don't exist
+
+- [ ] **Step 3: Implement the Ecto schema**
+
+```elixir
+# lib/klass_hero/messaging/adapters/driven/persistence/schemas/enrolled_children_schema.ex
+defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema do
+  @moduledoc """
+  Ecto schema for the messaging_enrolled_children projection table.
+
+  Write-only from the EnrolledChildren projection's perspective.
+  Read-only for handlers that need to derive child names for conversations.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:id, :binary_id, autogenerate: false}
+  @timestamps_opts [type: :utc_datetime]
+
+  schema "messaging_enrolled_children" do
+    field :parent_user_id, :binary_id
+    field :program_id, :binary_id
+    field :child_id, :binary_id
+    field :child_first_name, :string
+
+    timestamps()
+  end
+end
+```
+
+- [ ] **Step 4: Implement the EnrolledChildren GenServer**
+
+```elixir
+# lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
+  @moduledoc """
+  Event-driven projection maintaining the `messaging_enrolled_children` lookup table.
+
+  This GenServer subscribes to cross-context integration events from
+  Enrollment and Family, plus Messaging's own `conversation_created` event.
+  It maintains a local lookup of enrolled children per parent+program,
+  then emits `enrolled_children_changed` domain events that the
+  `ConversationSummaries` projection consumes.
+
+  ## Event Subscriptions
+
+  - `integration:enrollment:enrollment_created` — upserts a lookup row
+  - `integration:enrollment:enrollment_cancelled` — deletes a lookup row
+  - `integration:family:child_created` — updates child_first_name
+  - `integration:family:child_updated` — updates child_first_name
+  - `integration:messaging:conversation_created` — triggers name resolution for new conversations
+  """
+
+  use GenServer
+
+  import Ecto.Query
+
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSummarySchema
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  require Logger
+
+  @enrollment_created_topic "integration:enrollment:enrollment_created"
+  @enrollment_cancelled_topic "integration:enrollment:enrollment_cancelled"
+  @child_created_topic "integration:family:child_created"
+  @child_updated_topic "integration:family:child_updated"
+  @conversation_created_topic "integration:messaging:conversation_created"
+
+  @enrolled_children_changed_topic "messaging:enrolled_children_changed"
+
+  # Client API
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec rebuild(GenServer.name()) :: :ok
+  def rebuild(name \\ __MODULE__) do
+    GenServer.call(name, :rebuild, :infinity)
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(_opts) do
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrollment_created_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrollment_cancelled_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @child_created_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @child_updated_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversation_created_topic)
+
+    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+  end
+
+  @impl true
+  def handle_continue(:bootstrap, state) do
+    attempt_bootstrap(state)
+  end
+
+  @impl true
+  def handle_call(:rebuild, _from, state) do
+    count = bootstrap_from_write_tables()
+    Logger.info("EnrolledChildren rebuilt", count: count)
+    {:reply, :ok, %{state | bootstrapped: true}}
+  end
+
+  @impl true
+  def handle_info(:retry_bootstrap, state) do
+    {:noreply, state, {:continue, :bootstrap}}
+  end
+
+  # Trigger: enrollment_created integration event
+  # Why: new enrollment means a child is now enrolled in a program
+  # Outcome: upsert row in lookup table, re-derive child names
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :enrollment_created} = event}, state) do
+    Logger.debug("EnrolledChildren projecting enrollment_created",
+      enrollment_id: event.entity_id
+    )
+
+    project_enrollment_created(event)
+    {:noreply, state}
+  end
+
+  # Trigger: enrollment_cancelled integration event
+  # Why: child is no longer enrolled, remove from lookup
+  # Outcome: delete row from lookup table, re-derive child names
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :enrollment_cancelled} = event}, state) do
+    Logger.debug("EnrolledChildren projecting enrollment_cancelled",
+      enrollment_id: event.entity_id
+    )
+
+    project_enrollment_cancelled(event)
+    {:noreply, state}
+  end
+
+  # Trigger: child_created integration event
+  # Why: fills in child_first_name for rows that may have nil
+  # Outcome: update child_first_name, re-derive child names
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_created} = event}, state) do
+    Logger.debug("EnrolledChildren projecting child_created",
+      child_id: event.entity_id
+    )
+
+    project_child_name_change(event)
+    {:noreply, state}
+  end
+
+  # Trigger: child_updated integration event
+  # Why: child name may have changed, update in lookup
+  # Outcome: update child_first_name, re-derive child names
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_updated} = event}, state) do
+    Logger.debug("EnrolledChildren projecting child_updated",
+      child_id: event.entity_id
+    )
+
+    project_child_name_change(event)
+    {:noreply, state}
+  end
+
+  # Trigger: conversation_created integration event
+  # Why: new direct conversation with program_id needs enrolled child names
+  # Outcome: look up names from table, emit enrolled_children_changed
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :conversation_created} = event}, state) do
+    project_conversation_created(event)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    Logger.warning("EnrolledChildren received unexpected message",
+      message: inspect(msg, limit: 200)
+    )
+
+    {:noreply, state}
+  end
+
+  # Private Functions — Bootstrap
+
+  defp attempt_bootstrap(state) do
+    count = bootstrap_from_write_tables()
+    Logger.info("EnrolledChildren projection started", count: count)
+    {:noreply, %{state | bootstrapped: true}}
+  rescue
+    error ->
+      retry_count = Map.get(state, :retry_count, 0) + 1
+
+      if retry_count > 3 do
+        reraise error, __STACKTRACE__
+      else
+        Logger.error("EnrolledChildren: bootstrap failed, scheduling retry",
+          error: Exception.message(error),
+          retry_count: retry_count
+        )
+
+        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
+        {:noreply, Map.put(state, :retry_count, retry_count)}
+      end
+  end
+
+  defp bootstrap_from_write_tables do
+    entries =
+      from(e in "enrollments",
+        join: c in "children", on: c.id == e.child_id,
+        join: pp in "parent_profiles", on: pp.id == e.parent_id,
+        where: e.status in ["pending", "confirmed"],
+        select: %{
+          parent_user_id: type(pp.identity_id, :binary_id),
+          program_id: type(e.program_id, :binary_id),
+          child_id: type(e.child_id, :binary_id),
+          child_first_name: c.first_name
+        }
+      )
+      |> Repo.all()
+
+    if entries == [] do
+      0
+    else
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      rows =
+        Enum.map(entries, fn entry ->
+          Map.merge(entry, %{id: Ecto.UUID.generate(), inserted_at: now, updated_at: now})
+        end)
+
+      {count, _} =
+        Repo.insert_all(EnrolledChildrenSchema, rows,
+          on_conflict: {:replace, [:child_first_name, :updated_at]},
+          conflict_target: [:parent_user_id, :program_id, :child_id]
+        )
+
+      count
+    end
+  end
+
+  # Private Functions — Event Projections
+
+  defp project_enrollment_created(event) do
+    payload = event.payload
+    parent_user_id = payload.parent_user_id
+    program_id = payload.program_id
+    child_id = payload.child_id
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %EnrolledChildrenSchema{}
+    |> Ecto.Changeset.change(%{
+      id: Ecto.UUID.generate(),
+      parent_user_id: parent_user_id,
+      program_id: program_id,
+      child_id: child_id,
+      child_first_name: nil,
+      inserted_at: now,
+      updated_at: now
+    })
+    |> Repo.insert!(
+      on_conflict: {:replace, [:updated_at]},
+      conflict_target: [:parent_user_id, :program_id, :child_id]
+    )
+
+    re_derive_and_emit(parent_user_id, program_id)
+  end
+
+  defp project_enrollment_cancelled(event) do
+    payload = event.payload
+    child_id = payload.child_id
+    program_id = payload.program_id
+
+    # Trigger: find the lookup row via child_id + program_id
+    # Why: enrollment_cancelled doesn't carry parent_user_id
+    # Outcome: delete the row and re-derive for the affected parent+program
+    rows =
+      from(e in EnrolledChildrenSchema,
+        where: e.child_id == ^child_id and e.program_id == ^program_id,
+        select: e
+      )
+      |> Repo.all()
+
+    case rows do
+      [row | _] ->
+        from(e in EnrolledChildrenSchema,
+          where: e.child_id == ^child_id and e.program_id == ^program_id
+        )
+        |> Repo.delete_all()
+
+        re_derive_and_emit(row.parent_user_id, program_id)
+
+      [] ->
+        :ok
+    end
+  end
+
+  defp project_child_name_change(event) do
+    payload = event.payload
+    child_id = payload.child_id
+    first_name = payload.first_name
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    # Trigger: child name changed (created or updated)
+    # Why: update all lookup rows for this child_id
+    # Outcome: child_first_name updated, then re-derive for each affected parent+program
+    affected =
+      from(e in EnrolledChildrenSchema,
+        where: e.child_id == ^child_id,
+        select: {e.parent_user_id, e.program_id}
+      )
+      |> Repo.all()
+
+    if affected != [] do
+      from(e in EnrolledChildrenSchema,
+        where: e.child_id == ^child_id
+      )
+      |> Repo.update_all(set: [child_first_name: first_name, updated_at: now])
+
+      affected
+      |> Enum.uniq()
+      |> Enum.each(fn {parent_user_id, program_id} ->
+        re_derive_and_emit(parent_user_id, program_id)
+      end)
+    end
+  end
+
+  defp project_conversation_created(event) do
+    payload = event.payload
+    program_id = Map.get(payload, :program_id)
+    conversation_type = payload |> Map.get(:type, "direct") |> to_string()
+
+    # Trigger: only direct conversations with a program_id need child names
+    # Why: broadcast conversations don't show per-parent child context
+    # Outcome: skip if not direct or no program_id
+    if conversation_type == "direct" and program_id do
+      participant_ids = Map.get(payload, :participant_ids, [])
+      conversation_id = payload.conversation_id
+
+      # Trigger: check each participant for enrolled children
+      # Why: one of the participants is the parent, the other is the provider
+      # Outcome: emit enrolled_children_changed for any participant with enrolled children
+      Enum.each(participant_ids, fn user_id ->
+        child_names = get_child_names(user_id, program_id)
+
+        if child_names != [] do
+          emit_enrolled_children_changed(conversation_id, child_names)
+        end
+      end)
+    end
+  end
+
+  # Private Functions — Re-derivation
+
+  defp re_derive_and_emit(parent_user_id, program_id) do
+    child_names = get_child_names(parent_user_id, program_id)
+
+    # Trigger: find all direct conversations for this parent+program
+    # Why: each conversation needs its enrolled_child_names updated
+    # Outcome: emit enrolled_children_changed for each affected conversation
+    conversation_ids =
+      from(s in ConversationSummarySchema,
+        where:
+          s.user_id == ^parent_user_id and
+            s.program_id == ^program_id and
+            s.conversation_type == "direct",
+        select: s.conversation_id,
+        distinct: true
+      )
+      |> Repo.all()
+
+    Enum.each(conversation_ids, fn conversation_id ->
+      emit_enrolled_children_changed(conversation_id, child_names)
+    end)
+  end
+
+  defp get_child_names(parent_user_id, program_id) do
+    from(e in EnrolledChildrenSchema,
+      where:
+        e.parent_user_id == ^parent_user_id and
+          e.program_id == ^program_id and
+          not is_nil(e.child_first_name),
+      select: e.child_first_name,
+      order_by: e.child_first_name
+    )
+    |> Repo.all()
+  end
+
+  defp emit_enrolled_children_changed(conversation_id, child_names) do
+    event =
+      DomainEvent.new(
+        :enrolled_children_changed,
+        conversation_id,
+        :conversation,
+        %{
+          conversation_id: conversation_id,
+          enrolled_child_names: child_names
+        }
+      )
+
+    Phoenix.PubSub.broadcast(
+      KlassHero.PubSub,
+      @enrolled_children_changed_topic,
+      {:domain_event, event}
+    )
+  end
+end
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `mix test test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs`
+Expected: 2 tests, 0 failures
+
+**Verify via Tidewave:** Use `get_ecto_schemas` to confirm the `EnrolledChildrenSchema` is correctly loaded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/klass_hero/messaging/adapters/driven/persistence/schemas/enrolled_children_schema.ex \
+        lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex \
+        test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
+git commit -m "feat: add EnrolledChildren projection with schema and bootstrap"
+```
+
+---
+
+### Task 7: Extend ConversationSummaries — Schema, Read Model, and Event Handler
+
+**Files:**
+- Modify: `lib/klass_hero/messaging/adapters/driven/persistence/schemas/conversation_summary_schema.ex`
+- Modify: `lib/klass_hero/messaging/domain/read_models/conversation_summary.ex`
+- Modify: `lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex`
+- Modify: `lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex`
+
+- [ ] **Step 1: Add `enrolled_child_names` to ConversationSummarySchema**
+
+In `lib/klass_hero/messaging/adapters/driven/persistence/schemas/conversation_summary_schema.ex`, add after the `system_notes` field:
+
+```elixir
+    field :enrolled_child_names, {:array, :string}, default: []
+```
+
+- [ ] **Step 2: Add `enrolled_child_names` to ConversationSummary read model**
+
+In `lib/klass_hero/messaging/domain/read_models/conversation_summary.ex`:
+
+Add to the `@type` spec (after `archived_at`):
+```elixir
+          enrolled_child_names: [String.t()],
+```
+
+Add to `defstruct` (after `unread_count: 0`):
+```elixir
+    enrolled_child_names: [],
+```
+
+- [ ] **Step 3: Map `enrolled_child_names` in `to_dto/1`**
+
+In `lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex`, add to the `to_dto/1` function (around line 235, after `archived_at`):
+
+```elixir
+      enrolled_child_names: schema.enrolled_child_names || [],
+```
+
+- [ ] **Step 4: Subscribe ConversationSummaries to the new PubSub topic and handle the event**
+
+In `lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex`:
+
+Add the topic module attribute near the top (after line 57):
+```elixir
+  @enrolled_children_changed_topic "messaging:enrolled_children_changed"
+```
+
+Subscribe in `init/1` (after the existing subscribes, around line 98):
+```elixir
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrolled_children_changed_topic)
+```
+
+Add a new `handle_info` clause (after the `message_data_anonymized` clause, before the catch-all):
+
+```elixir
+  # Trigger: Received an enrolled_children_changed domain event from EnrolledChildren projection
+  # Why: conversation summary needs updated child names for display
+  # Outcome: enrolled_child_names column updated for all rows of the conversation
+  @impl true
+  def handle_info({:domain_event, %DomainEvent{event_type: :enrolled_children_changed} = event}, state) do
+    Logger.debug("ConversationSummaries projecting enrolled_children_changed",
+      conversation_id: event.aggregate_id
+    )
+
+    project_enrolled_children_changed(event)
+    {:noreply, state}
+  end
+```
+
+Add the alias at the top (after `IntegrationEvent`):
+```elixir
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+```
+
+Add the private function (before the `# Private Functions — System Note Projection` section):
+
+```elixir
+  # Trigger: enrolled_children_changed domain event received
+  # Why: update the enrolled_child_names for all participant rows of this conversation
+  # Outcome: simple field update — projection stays dumb
+  defp project_enrolled_children_changed(event) do
+    conversation_id = event.payload.conversation_id
+    child_names = Map.get(event.payload, :enrolled_child_names, [])
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(s in ConversationSummarySchema,
+      where: s.conversation_id == ^conversation_id
+    )
+    |> Repo.update_all(
+      set: [
+        enrolled_child_names: child_names,
+        updated_at: now
+      ]
+    )
+  end
+```
+
+- [ ] **Step 5: Update bootstrap to include `enrolled_child_names`**
+
+In the `build_summary_entry/3` function, add `enrolled_child_names` to the returned map (after `system_notes`):
+
+```elixir
+      enrolled_child_names: resolve_enrolled_child_names(conversation, participant.user_id),
+```
+
+Add the helper function:
+
+```elixir
+  # Trigger: bootstrap needs enrolled child names from the EnrolledChildren projection table
+  # Why: direct conversations with a program_id should display child context
+  # Outcome: list of child first names or empty list
+  defp resolve_enrolled_child_names(%{type: type, program_id: program_id}, user_id)
+       when type in ["direct", :direct] and not is_nil(program_id) do
+    from(e in KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema,
+      where:
+        e.parent_user_id == ^user_id and
+          e.program_id == ^program_id and
+          not is_nil(e.child_first_name),
+      select: e.child_first_name,
+      order_by: e.child_first_name
+    )
+    |> Repo.all()
+  end
+
+  defp resolve_enrolled_child_names(_, _), do: []
+```
+
+- [ ] **Step 6: Run ConversationSummaries tests**
+
+Run: `mix test test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs`
+Expected: All existing tests pass (new field has default `[]`)
+
+- [ ] **Step 7: Verify compilation**
+
+Run: `mix compile --warnings-as-errors`
+Expected: Clean compilation
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/klass_hero/messaging/adapters/driven/persistence/schemas/conversation_summary_schema.ex \
+        lib/klass_hero/messaging/domain/read_models/conversation_summary.ex \
+        lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex \
+        lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+git commit -m "feat: extend ConversationSummaries with enrolled_child_names"
+```
+
+---
+
+### Task 8: Supervision Wiring
+
+**Files:**
+- Modify: `lib/klass_hero/projection_supervisor.ex`
+
+- [ ] **Step 1: Add EnrolledChildren to ProjectionSupervisor**
+
+In `lib/klass_hero/projection_supervisor.ex`, add the alias:
+```elixir
+  alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
+```
+
+Add `EnrolledChildren` to the children list **before** `ConversationSummaries` (so it bootstraps first):
+
+```elixir
+    children = [
+      VerifiedProviders,
+      ProgramListings,
+      EnrolledChildren,
+      ConversationSummaries,
+      ProviderSessionStats
+    ]
+```
+
+- [ ] **Step 2: Verify compilation and server startup**
+
+Run: `mix compile --warnings-as-errors`
+Expected: Clean compilation
+
+Use Tidewave `project_eval`:
+```elixir
+Process.whereis(KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren) |> is_pid()
+```
+Expected: `true` (if server is running)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/klass_hero/projection_supervisor.ex
+git commit -m "feat: add EnrolledChildren to ProjectionSupervisor"
+```
+
+---
+
+### Task 9: Web Layer — `get_conversation_title/3`
+
+**Files:**
+- Modify: `test/klass_hero_web/live/messaging_live_helper_test.exs`
+- Modify: `lib/klass_hero_web/live/messaging_live_helper.ex`
+
+- [ ] **Step 1: Write failing tests for `get_conversation_title/3`**
+
+Replace the existing `describe "get_conversation_title/1"` block in `test/klass_hero_web/live/messaging_live_helper_test.exs`:
+
+```elixir
+  describe "get_conversation_title/3" do
+    test "returns parent name with child names for direct conversation with enrolled children" do
+      conversation = %{type: :direct}
+      child_names = ["Emma", "Liam"]
+      other_name = "Sarah Johnson"
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, child_names, other_name) ==
+               "Sarah Johnson for Emma, Liam"
+    end
+
+    test "returns parent name with single child for direct conversation" do
+      conversation = %{type: :direct}
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, ["Emma"], "Sarah Johnson") ==
+               "Sarah Johnson for Emma"
+    end
+
+    test "returns other participant name when no enrolled children" do
+      conversation = %{type: :direct}
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, [], "Sarah Johnson") ==
+               "Sarah Johnson"
+    end
+
+    test "returns subject for program_broadcast with subject" do
+      conversation = %{type: :program_broadcast, subject: "Summer Camp Update"}
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, [], nil) ==
+               "Summer Camp Update"
+    end
+
+    test "returns 'Program Broadcast' for broadcast without subject" do
+      conversation = %{type: :program_broadcast, subject: nil}
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, [], nil) ==
+               "Program Broadcast"
+    end
+
+    test "returns 'Conversation' as fallback" do
+      assert MessagingLiveHelper.get_conversation_title(%{type: :direct}, [], nil) ==
+               "Conversation"
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mix test test/klass_hero_web/live/messaging_live_helper_test.exs --max-failures 1`
+Expected: FAIL — `get_conversation_title/3` is undefined (only `/1` exists)
+
+- [ ] **Step 3: Implement `get_conversation_title/3`**
+
+In `lib/klass_hero_web/live/messaging_live_helper.ex`, replace the existing three `get_conversation_title/1` clauses (around lines 326–336) with:
+
+```elixir
+  @doc """
+  Returns the title for a conversation.
+
+  For direct conversations with enrolled children (provider view):
+  "Sarah Johnson for Emma, Liam"
+  """
+  def get_conversation_title(conversation, enrolled_child_names \\ [], other_participant_name \\ nil)
+
+  def get_conversation_title(%{type: :direct}, child_names, other_name)
+      when child_names != [] and not is_nil(other_name) do
+    formatted = Enum.join(child_names, ", ")
+    "#{other_name} #{gettext("for")} #{formatted}"
+  end
+
+  def get_conversation_title(%{type: :direct}, _child_names, other_name)
+      when not is_nil(other_name) do
+    other_name
+  end
+
+  def get_conversation_title(%{type: :program_broadcast, subject: subject}, _, _)
+      when not is_nil(subject) do
+    subject
+  end
+
+  def get_conversation_title(%{type: :program_broadcast}, _, _) do
+    gettext("Program Broadcast")
+  end
+
+  def get_conversation_title(_conversation, _, _) do
+    gettext("Conversation")
+  end
+```
+
+- [ ] **Step 4: Update the caller in `mount_conversation_show`**
+
+In the same file, update the socket assignment block (the part that sets `page_title` around line 139):
+
+Replace:
+```elixir
+          |> assign(:page_title, get_conversation_title(conversation))
+```
+
+With:
+```elixir
+          |> assign(:page_title, build_page_title(conversation, user_id))
+```
+
+Add the helper function that reads from the projection (avoids relying on `conversation.participants` which may not be loaded):
+
+```elixir
+  defp build_page_title(conversation, user_id) do
+    context = fetch_conversation_context(conversation.id, user_id)
+    get_conversation_title(conversation, context.enrolled_child_names, context.other_participant_name)
+  end
+
+  defp fetch_conversation_context(conversation_id, user_id) do
+    import Ecto.Query
+
+    alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSummarySchema
+
+    case KlassHero.Repo.one(
+           from(s in ConversationSummarySchema,
+             where: s.conversation_id == ^conversation_id and s.user_id == ^user_id,
+             select: %{
+               enrolled_child_names: s.enrolled_child_names,
+               other_participant_name: s.other_participant_name
+             }
+           )
+         ) do
+      nil -> %{enrolled_child_names: [], other_participant_name: nil}
+      result -> %{enrolled_child_names: result.enrolled_child_names || [], other_participant_name: result.other_participant_name}
+    end
+  end
+```
+
+Remove the separate `fetch_enrolled_child_names/2` helper — `fetch_conversation_context/2` replaces it.
+
+- [ ] **Step 5: Run tests**
+
+Run: `mix test test/klass_hero_web/live/messaging_live_helper_test.exs`
+Expected: All tests pass
+
+- [ ] **Step 6: Run full precommit**
+
+Run: `mix precommit`
+Expected: All checks pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/klass_hero_web/live/messaging_live_helper.ex \
+        test/klass_hero_web/live/messaging_live_helper_test.exs
+git commit -m "feat: update get_conversation_title to show parent name with child names"
+```
+
+---
+
+### Task 10: Web Layer — Conversation Card Subtitle (Index View)
+
+**Files:**
+- Modify: `lib/klass_hero_web/components/messaging_components.ex`
+
+- [ ] **Step 1: Add `enrolled_child_names` to conversation_card data flow**
+
+First, check how `conversation_card` receives its data. The `conversation_list` component (around line 464) passes `conv_data.other_participant_name`. We need to also pass `enrolled_child_names`.
+
+In `lib/klass_hero_web/components/messaging_components.ex`, find the `conversation_card` component call inside `conversation_list` (around line 467). Add the new attribute:
+
+```elixir
+        enrolled_child_names={Map.get(conv_data, :enrolled_child_names, [])}
+```
+
+- [ ] **Step 2: Add `enrolled_child_names` attr to `conversation_card` and render subtitle**
+
+Find the `conversation_card` component definition and add the attr:
+
+```elixir
+  attr :enrolled_child_names, :list, default: []
+```
+
+Inside the card template, below the `other_participant_name` display, add the child names subtitle (only when non-empty):
+
+```heex
+<p :if={@enrolled_child_names != []} class={["text-xs mt-0.5", Theme.text_color(:muted)]}>
+  {gettext("for")} {Enum.join(@enrolled_child_names, ", ")}
+</p>
+```
+
+The exact placement depends on the existing card layout — insert it as a subtitle under the name display area. Only show on the provider side.
+
+- [ ] **Step 3: Update `ListConversations.to_enriched_map/1` to include `enrolled_child_names`**
+
+In `lib/klass_hero/messaging/application/queries/list_conversations.ex`, add `enrolled_child_names` to the `to_enriched_map/1` function (after the `other_participant_name` line):
+
+```elixir
+      enrolled_child_names: summary.enrolled_child_names
+```
+
+The `ConversationSummary` struct already has this field from Task 7. This ensures the data flows through to the template.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `mix compile --warnings-as-errors`
+Expected: Clean compilation
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/klass_hero_web/components/messaging_components.ex
+git commit -m "feat: show enrolled child names in conversation card subtitle"
+```
+
+---
+
+### Task 11: Final Verification and Follow-up Issue
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `mix precommit`
+Expected: All checks pass — compile, format, test
+
+- [ ] **Step 2: Verify projection works end-to-end via Tidewave**
+
+Use Tidewave `project_eval` to simulate the flow:
+```elixir
+# Check if EnrolledChildren projection is running
+Process.whereis(KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren) |> is_pid()
+```
+
+Use Tidewave `execute_sql_query`:
+```sql
+SELECT * FROM messaging_enrolled_children LIMIT 5;
+```
+
+Use Tidewave `execute_sql_query`:
+```sql
+SELECT conversation_id, enrolled_child_names FROM conversation_summaries WHERE enrolled_child_names != '{}' LIMIT 5;
+```
+
+- [ ] **Step 3: File follow-up issue for CQRS show-view migration**
+
+```bash
+gh issue create --title "refactor: migrate conversation show view to read from projection" \
+  --body "$(cat <<'EOF'
+## Context
+
+As part of #551, the conversation show view now reads from two sources:
+- Write model (via `GetConversation`) for messages, participants, sender names
+- Projection (via `conversation_summaries`) for `enrolled_child_names`
+
+## Goal
+
+Design a dedicated conversation-detail read model/projection that replaces the write-model dependency entirely. This would make the projection layer the single source of truth for the show view.
+
+## Notes
+
+- The current `conversation_summaries` projection is inbox-optimized (one row per user per conversation with latest message only)
+- A detail projection would need: full message history (paginated), all sender names, participant identities, mark-as-read capability
+- This is a larger CQRS evolution — scope carefully
+
+## Related
+
+- Closes no issue (follow-up from #551)
+- Spec: `docs/superpowers/specs/2026-04-17-enrolled-children-projection-design.md` (Follow-up Issue section)
+EOF
+)"
+```
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin feat/551-show-parent-and-enrolled-child-names-in-conversation
+```

--- a/docs/superpowers/specs/2026-04-17-enrolled-children-projection-design.md
+++ b/docs/superpowers/specs/2026-04-17-enrolled-children-projection-design.md
@@ -1,0 +1,366 @@
+# Enrolled Children in Conversation Headers
+
+**Issue:** #551 — Show parent name and enrolled child names in conversation header
+**Date:** 2026-04-17
+**Status:** Approved
+
+## Problem
+
+When a provider opens a direct conversation, the header shows a generic "Conversation" title. There is no context about which children the conversation relates to. The provider must remember or scroll through messages to figure out who they are talking to and why.
+
+## Solution
+
+Extend the Messaging context's projection infrastructure to resolve and display enrolled child names alongside the parent name in conversation headers.
+
+**Target format:** `Sarah Johnson for Emma, Liam`
+
+- Single child: `Sarah Johnson for Emma`
+- Multiple children: `Sarah Johnson for Emma, Liam`
+- No enrolled children resolvable: fall back to parent name or generic "Conversation"
+- Provider-side only — parents already know their own context
+
+## Architecture Overview
+
+The solution follows the event-driven projection pattern established by `ConversationSummaries`. Instead of adding ACL adapters for cross-context data resolution, we:
+
+1. Create missing integration events in Enrollment and Family contexts
+2. Build a new `EnrolledChildren` projection within Messaging that maintains a local lookup table populated from those events
+3. Have a driving event handler translate cross-context events into an internal `enrolled_children_changed` domain event
+4. Extend `ConversationSummaries` to react to that internal event with a simple field update
+
+This avoids direct cross-context coupling — Messaging never queries Enrollment or Family at runtime. All data flows through events.
+
+### Event Flow Diagram
+
+```
+Enrollment Context                Family Context
+      |                                 |
+  enrollment_created              child_created
+  enrollment_cancelled            child_updated
+      |                                 |
+      +---------- PubSub --------------+
+                    |
+    Messaging: EnrolledChildren Projection (GenServer)
+        - maintains messaging_enrolled_children table
+        - re-derives child names on any change
+        - emits enrolled_children_changed domain event
+                    |
+              DomainEventBus
+                    |
+    Messaging: ConversationSummaries Projection
+        - updates enrolled_child_names column
+                    |
+            conversation_summaries table
+                    |
+        +----------+-----------+
+        |                      |
+    Show View              Index View
+    (secondary read)    (already reads projection)
+```
+
+## New Integration Events
+
+### Enrollment Context
+
+**`enrollment_created`** (new domain event + integration promotion)
+
+- Published from: `CreateEnrollment` command after successful persistence
+- Topic: `integration:enrollment:enrollment_created`
+- Payload:
+
+```elixir
+%{
+  enrollment_id: String.t(),
+  child_id: String.t(),
+  parent_id: String.t(),
+  parent_user_id: String.t(),  # identity_id — what Messaging uses
+  program_id: String.t(),
+  status: String.t()
+}
+```
+
+Note: `parent_user_id` (identity_id) is included because Messaging identifies participants by user_id, not parent_id. The `CreateEnrollment` command already receives `identity_id` as a parameter.
+
+**`enrollment_cancelled`** (existing — verify payload includes needed fields)
+
+- Verify payload includes: `child_id`, `parent_id`, `program_id`
+- Add `parent_user_id` if missing
+
+### Family Context
+
+**`child_created`** (new domain event + integration promotion)
+
+- Published from: `CreateChild` command after successful persistence
+- Topic: `integration:family:child_created`
+- Payload:
+
+```elixir
+%{
+  child_id: String.t(),
+  parent_id: String.t(),
+  first_name: String.t(),
+  last_name: String.t()
+}
+```
+
+**`child_updated`** (new domain event + integration promotion)
+
+- Published from: `UpdateChild` command after successful persistence
+- Topic: `integration:family:child_updated`
+- Payload: same as `child_created`
+
+### Messaging Context (fix)
+
+**`conversation_created`** (existing — fix missing `program_id`)
+
+The domain event currently carries `%{conversation_id, type, provider_id, participant_ids}` but omits `program_id`. This means the `ConversationSummaries` projection gets `program_id: nil` for direct conversations via the event path (only correct after bootstrap).
+
+Fix: Add `program_id` to the domain event payload in `MessagingEvents.conversation_created/4` and propagate through the integration event.
+
+### Messaging Internal
+
+**`enrolled_children_changed`** (new domain event — internal to Messaging, not promoted to integration)
+
+- Emitted by: `EnrolledChildren` projection handler
+- Delivered via: PubSub topic `"messaging:enrolled_children_changed"` (consumed by `ConversationSummaries`)
+- Payload:
+
+```elixir
+%{
+  conversation_id: String.t(),
+  enrolled_child_names: [String.t()]  # e.g. ["Emma", "Liam"] — sorted alphabetically
+}
+```
+
+## EnrolledChildren Projection
+
+### Table: `messaging_enrolled_children`
+
+```sql
+CREATE TABLE messaging_enrolled_children (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_user_id uuid NOT NULL,
+  program_id uuid NOT NULL,
+  child_id uuid NOT NULL,
+  child_first_name text,
+  inserted_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT messaging_enrolled_children_unique
+    UNIQUE(parent_user_id, program_id, child_id)
+);
+
+CREATE INDEX idx_enrolled_children_parent_program
+  ON messaging_enrolled_children(parent_user_id, program_id);
+
+CREATE INDEX idx_enrolled_children_child_id
+  ON messaging_enrolled_children(child_id);
+```
+
+`child_first_name` is nullable — handles the timing edge case where `enrollment_created` arrives before `child_created`. Bootstrap fills gaps on restart.
+
+### GenServer: `Messaging.Adapters.Driven.Projections.EnrolledChildren`
+
+Follows the exact pattern of `ConversationSummaries`:
+
+- Subscribes to 5 event topics on init
+- `handle_continue(:bootstrap)` populates from write tables
+- Each event handler updates the lookup table, then triggers re-derivation
+- Retry logic on bootstrap failure (same as ConversationSummaries)
+
+**Event subscriptions:**
+
+| Topic | Source |
+|---|---|
+| `integration:enrollment:enrollment_created` | Enrollment (new) |
+| `integration:enrollment:enrollment_cancelled` | Enrollment (existing) |
+| `integration:family:child_created` | Family (new) |
+| `integration:family:child_updated` | Family (new) |
+| `integration:messaging:conversation_created` | Messaging (existing) |
+
+**Event handling:**
+
+| Event | Lookup table action | Downstream |
+|---|---|---|
+| `enrollment_created` | Upsert row (name may be nil) | Re-derive and emit `enrolled_children_changed` |
+| `enrollment_cancelled` | Delete row | Re-derive and emit `enrolled_children_changed` |
+| `child_created` | Update `child_first_name` where `child_id` matches | Re-derive and emit `enrolled_children_changed` |
+| `child_updated` | Update `child_first_name` where `child_id` matches | Re-derive and emit `enrolled_children_changed` |
+| `conversation_created` | No table change | Look up names from table using event payload (not summary query — row may not exist yet), emit `enrolled_children_changed` |
+
+**Re-derivation flow** (shared helper used by all handlers):
+
+1. Query `messaging_enrolled_children` for `{parent_user_id, program_id}` — get list of non-nil `child_first_name` values, sorted alphabetically
+2. Find affected conversation IDs:
+   - For `enrollment_*` and `child_*` events: query `conversation_summaries` for `conversation_type = 'direct' AND program_id = X AND user_id = parent_user_id`
+   - For `conversation_created`: extract `conversation_id` directly from the event payload (the summary row may not exist yet due to projection ordering)
+3. For each `conversation_id`, publish `enrolled_children_changed` to PubSub topic `"messaging:enrolled_children_changed"` as a domain event
+
+**Bootstrap:**
+
+```sql
+SELECT pp.identity_id AS parent_user_id,
+       e.program_id,
+       e.child_id,
+       c.first_name AS child_first_name
+FROM enrollments e
+JOIN children c ON c.id = e.child_id
+JOIN parent_profiles pp ON pp.id = e.parent_id
+WHERE e.status IN ('pending', 'confirmed')
+```
+
+Upserted into `messaging_enrolled_children` with conflict handling on the unique constraint.
+
+**Supervision:** Added to the application supervisor, started before `ConversationSummaries` so the lookup table is populated before ConversationSummaries bootstrap reads from it.
+
+## ConversationSummaries Extension
+
+### Migration
+
+```sql
+ALTER TABLE conversation_summaries
+ADD COLUMN enrolled_child_names text[] DEFAULT '{}';
+```
+
+### Schema + Read Model
+
+- `ConversationSummarySchema`: add `field :enrolled_child_names, {:array, :string}, default: []`
+- `ConversationSummary` read model: add `enrolled_child_names: [String.t()]` with default `[]`
+
+### New Event Handler
+
+The projection subscribes to the `"messaging:enrolled_children_changed"` PubSub topic on init and handles incoming events:
+
+```elixir
+def handle_info({:domain_event, %DomainEvent{event_type: :enrolled_children_changed} = event}, state) do
+  project_enrolled_children_changed(event)
+  {:noreply, state}
+end
+```
+
+Update is a simple bulk set on all rows for the conversation:
+
+```sql
+UPDATE conversation_summaries
+SET enrolled_child_names = $names, updated_at = $now
+WHERE conversation_id = $id
+```
+
+### Bootstrap Integration
+
+During `ConversationSummaries.bootstrap_from_write_tables/0`, for each direct conversation with a `program_id`, query `messaging_enrolled_children` (within-context table) to populate the `enrolled_child_names` field.
+
+## Web Layer
+
+### Show View (`messaging_live_helper.ex`)
+
+In `mount_conversation_show`, after loading the conversation from the write model, make a secondary read from `conversation_summaries` to get `enrolled_child_names`:
+
+```elixir
+enrolled_child_names = fetch_enrolled_child_names(conversation.id, user_id)
+page_title = get_conversation_title(conversation, enrolled_child_names, other_participant_name)
+```
+
+**New `get_conversation_title` clauses:**
+
+```elixir
+# Direct conversation with enrolled children — provider sees "Sarah Johnson for Emma, Liam"
+def get_conversation_title(%{type: :direct}, child_names, other_name)
+    when child_names != [] and not is_nil(other_name) do
+  formatted = Enum.join(child_names, ", ")
+  "#{other_name} #{gettext("for")} #{formatted}"
+end
+
+# Direct conversation without children — fall back to other participant name
+def get_conversation_title(%{type: :direct}, _child_names, other_name)
+    when not is_nil(other_name) do
+  other_name
+end
+
+# Existing clauses for broadcasts and fallback
+def get_conversation_title(%{type: :program_broadcast, subject: subject}, _, _)
+    when not is_nil(subject), do: subject
+
+def get_conversation_title(%{type: :program_broadcast}, _, _),
+    do: gettext("Program Broadcast")
+
+def get_conversation_title(_conversation, _, _),
+    do: gettext("Conversation")
+```
+
+The function signature changes from arity 1 to arity 3. Callers updated accordingly.
+
+### Index View (conversation card)
+
+The `conversation_card` component already receives `ConversationSummary` data including `enrolled_child_names`. For provider-variant conversation cards:
+
+- Show child names as a subtitle below the parent name in smaller, muted text
+- Format: `for Emma, Liam`
+- Only render when `enrolled_child_names` is non-empty
+- Parent variant does not display child names
+
+### Internationalization
+
+The "for" separator uses `gettext("for")` for English/German translation. Child names are proper nouns — no translation needed.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Conversation created before any enrollment | `enrolled_child_names` stays `[]`, title falls back to parent name or "Conversation" |
+| Enrollment created after conversation exists | `enrollment_created` event triggers re-derivation, projection updates, title changes on next page load |
+| `child_first_name` nil (enrollment before child event) | Row stored with nil name, excluded from derived list. Bootstrap or next `child_created` event fills the gap |
+| Child deleted (enrollments cancelled) | `enrollment_cancelled` event removes the row, child drops from list naturally |
+| GDPR anonymization | No special handling — `enrolled_child_names` is derived from active enrollments, not persistent child data. Existing `message_data_anonymized` handles `other_participant_name` separately |
+| Conversation has no `program_id` | Handler ignores — no program means no enrollment context to resolve |
+| Multiple children in same program | All names appear in the list |
+
+## Config and Supervision
+
+**No new port/adapter DI needed** — the `EnrolledChildren` projection is a GenServer that queries its own table and uses `DomainEventBus` directly.
+
+**Application supervisor (`application.ex`):** Add `EnrolledChildren` GenServer, started before `ConversationSummaries`.
+
+**Boundary config (`messaging.ex`):** Already declares `deps: [KlassHero.Enrollment, KlassHero.Family]` — no change needed.
+
+## Follow-up Issue
+
+File a separate issue to migrate the conversation show view from the write model to a dedicated conversation-detail read model. This would make the projection layer the single source of truth for the show view, eliminating the current two-source read pattern. This is a larger CQRS evolution outside the scope of issue #551.
+
+## Testing Strategy
+
+### Unit Tests
+
+- `EnrolledChildren` projection: bootstrap populates correctly, each event type updates the lookup table, re-derivation emits correct events
+- `ConversationSummaries`: `enrolled_children_changed` event updates the field correctly
+- `get_conversation_title/3`: all clause combinations (with children, without, broadcast, fallback)
+
+### Integration Tests
+
+- End-to-end: enrollment created → lookup updated → domain event emitted → summary updated
+- End-to-end: child name updated → lookup updated → domain event emitted → summary updated
+- Bootstrap ordering: `EnrolledChildren` bootstraps before `ConversationSummaries`
+
+### LiveView Tests
+
+- Provider show view: `<h1>` contains "Sarah Johnson for Emma" format
+- Provider index view: conversation card subtitle shows child names
+- Parent views: child names not displayed
+- Fallback: no children → title shows parent name only
+
+## Scope Summary
+
+### In scope (this issue)
+
+- New `enrollment_created` domain + integration event (Enrollment context)
+- New `child_created` and `child_updated` domain + integration events (Family context)
+- Fix `conversation_created` event to include `program_id` (Messaging context)
+- New `messaging_enrolled_children` table + `EnrolledChildren` projection GenServer
+- Extend `conversation_summaries` with `enrolled_child_names` column
+- Update show view title composition
+- Update index view conversation card (provider variant)
+- Tests for all layers
+
+### Out of scope (follow-up)
+
+- Migrate show view to read entirely from projections (CQRS evolution)
+- Real-time title updates via PubSub (title updates on next page load, not live)

--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -88,7 +88,11 @@ defmodule KlassHero.Application do
            {:child_data_anonymized,
             {KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}, priority: 10},
            {:invite_family_ready,
-            {KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}, priority: 10}
+            {KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}, priority: 10},
+           {:child_created, {KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10},
+           {:child_updated, {KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10}
          ]},
         id: :family_domain_event_bus
       ),

--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -136,6 +136,9 @@ defmodule KlassHero.Application do
             priority: 10},
            {:enrollment_cancelled,
             {KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10},
+           {:enrollment_created,
+            {KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
             priority: 10}
          ]},
         id: :enrollment_domain_event_bus

--- a/lib/klass_hero/enrollment/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -42,4 +42,15 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.PromoteInte
       enrollment_id: event.payload.enrollment_id
     )
   end
+
+  def handle(%DomainEvent{event_type: :enrollment_created} = event) do
+    # Trigger: enrollment_created domain event dispatched from CreateEnrollment use case
+    # Why: downstream contexts (e.g., Messaging) need to react to new enrollments
+    # Outcome: publish integration event on topic integration:enrollment:enrollment_created
+    event.payload.enrollment_id
+    |> EnrollmentIntegrationEvents.enrollment_created(event.payload)
+    |> IntegrationEventPublishing.publish_critical("enrollment_created",
+      enrollment_id: event.payload.enrollment_id
+    )
+  end
 end

--- a/lib/klass_hero/enrollment/application/commands/create_enrollment.ex
+++ b/lib/klass_hero/enrollment/application/commands/create_enrollment.ex
@@ -33,11 +33,15 @@ defmodule KlassHero.Enrollment.Application.Commands.CreateEnrollment do
 
   alias KlassHero.Enrollment
   alias KlassHero.Enrollment.Application.Queries.CheckParticipantEligibility
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
   alias KlassHero.Enrollment.Domain.Models.Enrollment, as: EnrollmentModel
   alias KlassHero.Family
   alias KlassHero.Shared.Entitlements
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
+
+  @context KlassHero.Enrollment
 
   @enrollment_repository Application.compile_env!(:klass_hero, [
                            :enrollment,
@@ -69,19 +73,11 @@ defmodule KlassHero.Enrollment.Application.Commands.CreateEnrollment do
   defp create_enrollment_with_validation(identity_id, params) do
     with {:ok, parent} <- validate_parent_profile(identity_id),
          :ok <- validate_booking_entitlement(parent),
-         :ok <- validate_participant_eligibility(params[:program_id], params[:child_id]) do
-      attrs = build_enrollment_attrs(params, parent.id)
-
-      Logger.info("[Enrollment.CreateEnrollment] Creating enrollment with validation",
-        program_id: attrs[:program_id],
-        child_id: attrs[:child_id],
-        parent_id: attrs[:parent_id]
-      )
-
-      # Trigger: capacity check and enrollment creation happen atomically
-      # Why: prevents TOCTOU race where concurrent requests both pass check
-      # Outcome: SELECT FOR UPDATE on policy row serializes concurrent attempts
-      @enrollment_repository.create_with_capacity_check(attrs, params[:program_id])
+         :ok <- validate_participant_eligibility(params[:program_id], params[:child_id]),
+         attrs = build_enrollment_attrs(params, parent.id),
+         {:ok, enrollment} <- @enrollment_repository.create_with_capacity_check(attrs, params[:program_id]) do
+      dispatch_enrollment_created(enrollment, identity_id)
+      {:ok, enrollment}
     end
   end
 
@@ -94,7 +90,14 @@ defmodule KlassHero.Enrollment.Application.Commands.CreateEnrollment do
       parent_id: attrs[:parent_id]
     )
 
-    @enrollment_repository.create_with_capacity_check(attrs, params[:program_id])
+    case @enrollment_repository.create_with_capacity_check(attrs, params[:program_id]) do
+      {:ok, enrollment} ->
+        dispatch_enrollment_created(enrollment, params[:identity_id])
+        {:ok, enrollment}
+
+      error ->
+        error
+    end
   end
 
   defp validate_parent_profile(identity_id) do
@@ -159,5 +162,17 @@ defmodule KlassHero.Enrollment.Application.Commands.CreateEnrollment do
       payment_method: params[:payment_method],
       special_requirements: params[:special_requirements]
     }
+  end
+
+  defp dispatch_enrollment_created(enrollment, identity_id) do
+    EnrollmentEvents.enrollment_created(enrollment.id, %{
+      enrollment_id: enrollment.id,
+      child_id: enrollment.child_id,
+      parent_id: enrollment.parent_id,
+      parent_user_id: identity_id,
+      program_id: enrollment.program_id,
+      status: Atom.to_string(enrollment.status)
+    })
+    |> EventDispatchHelper.dispatch(@context)
   end
 end

--- a/lib/klass_hero/enrollment/domain/events/enrollment_events.ex
+++ b/lib/klass_hero/enrollment/domain/events/enrollment_events.ex
@@ -17,6 +17,7 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEvents do
   - `:invite_resend_requested` - Emitted when a provider requests resending
     an enrollment invite email.
   - `:enrollment_cancelled` - Emitted when an admin cancels an enrollment.
+  - `:enrollment_created` - Emitted when a new enrollment is persisted.
   """
 
   alias KlassHero.Shared.Domain.Events.DomainEvent
@@ -156,5 +157,33 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEvents do
   def enrollment_cancelled(enrollment_id, _payload, _opts) do
     raise ArgumentError,
           "enrollment_cancelled/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
+  end
+
+  @doc """
+  Creates an `:enrollment_created` event when a new enrollment is persisted.
+
+  ## Parameters
+
+  - `enrollment_id` — the new enrollment's ID
+  - `payload` — event data including child_id, parent_id, parent_user_id, program_id, status
+  - `opts` — forwarded to `DomainEvent.new/5` (e.g. `:correlation_id`)
+  """
+  def enrollment_created(enrollment_id, payload \\ %{}, opts \\ [])
+
+  def enrollment_created(enrollment_id, payload, opts) when is_binary(enrollment_id) and byte_size(enrollment_id) > 0 do
+    base_payload = %{enrollment_id: enrollment_id}
+
+    DomainEvent.new(
+      :enrollment_created,
+      enrollment_id,
+      @aggregate_type,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def enrollment_created(enrollment_id, _payload, _opts) do
+    raise ArgumentError,
+          "enrollment_created/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
   end
 end

--- a/lib/klass_hero/enrollment/domain/events/enrollment_integration_events.ex
+++ b/lib/klass_hero/enrollment/domain/events/enrollment_integration_events.ex
@@ -16,6 +16,9 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentIntegrationEvents do
   - `:enrollment_cancelled` - Emitted when an admin cancels an enrollment.
     Downstream contexts can react to notify affected parties or
     update reporting data.
+  - `:enrollment_created` - Emitted when a new enrollment is persisted.
+    Downstream contexts can react to link enrolled children or
+    update conversation participant data.
   """
 
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
@@ -134,5 +137,44 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentIntegrationEvents do
   def enrollment_cancelled(enrollment_id, _payload, _opts) do
     raise ArgumentError,
           "enrollment_cancelled/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
+  end
+
+  @typedoc "Payload for `:enrollment_created` events."
+  @type enrollment_created_payload :: %{
+          required(:enrollment_id) => String.t(),
+          optional(atom()) => term()
+        }
+
+  @doc """
+  Creates an `:enrollment_created` integration event.
+
+  ## Parameters
+
+  - `enrollment_id` - the new enrollment's ID
+  - `payload` - event data including child_id, parent_id, parent_user_id, program_id, status
+  - `opts` - metadata options (correlation_id, causation_id)
+
+  ## Raises
+
+  - `ArgumentError` if `enrollment_id` is nil or empty
+  """
+  def enrollment_created(enrollment_id, payload \\ %{}, opts \\ [])
+
+  def enrollment_created(enrollment_id, payload, opts) when is_binary(enrollment_id) and byte_size(enrollment_id) > 0 do
+    base_payload = %{enrollment_id: enrollment_id}
+
+    IntegrationEvent.new(
+      :enrollment_created,
+      @source_context,
+      :enrollment,
+      enrollment_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def enrollment_created(enrollment_id, _payload, _opts) do
+    raise ArgumentError,
+          "enrollment_created/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
   end
 end

--- a/lib/klass_hero/family/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/family/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -40,4 +40,22 @@ defmodule KlassHero.Family.Adapters.Driving.Events.EventHandlers.PromoteIntegrat
     |> FamilyIntegrationEvents.invite_family_ready(event.payload)
     |> IntegrationEventPublishing.publish()
   end
+
+  def handle(%DomainEvent{event_type: :child_created} = event) do
+    # Trigger: child record created in Family context
+    # Why: downstream contexts (e.g. Messaging) need to maintain local child name lookups
+    # Outcome: publish integration event on topic integration:family:child_created
+    event.payload.child_id
+    |> FamilyIntegrationEvents.child_created(event.payload)
+    |> IntegrationEventPublishing.publish()
+  end
+
+  def handle(%DomainEvent{event_type: :child_updated} = event) do
+    # Trigger: child record updated in Family context
+    # Why: downstream contexts (e.g. Messaging) need to refresh local child name lookups
+    # Outcome: publish integration event on topic integration:family:child_updated
+    event.payload.child_id
+    |> FamilyIntegrationEvents.child_updated(event.payload)
+    |> IntegrationEventPublishing.publish()
+  end
 end

--- a/lib/klass_hero/family/application/commands/children/create_child.ex
+++ b/lib/klass_hero/family/application/commands/children/create_child.ex
@@ -6,8 +6,11 @@ defmodule KlassHero.Family.Application.Commands.Children.CreateChild do
   When a parent_id is provided, the child is atomically linked to the guardian.
   """
 
+  alias KlassHero.Family.Domain.Events.FamilyEvents
   alias KlassHero.Family.Domain.Models.Child
+  alias KlassHero.Shared.EventDispatchHelper
 
+  @context KlassHero.Family
   @repository Application.compile_env!(:klass_hero, [:family, :for_storing_children])
 
   @doc """
@@ -31,11 +34,22 @@ defmodule KlassHero.Family.Application.Commands.Children.CreateChild do
 
     with {:ok, _validated} <- Child.new(child_attrs),
          {:ok, persisted} <- persist_child(child_attrs, parent_id) do
+      dispatch_child_created(persisted, parent_id)
       {:ok, persisted}
     else
       {:error, errors} when is_list(errors) -> {:error, {:validation_error, errors}}
       {:error, _} = error -> error
     end
+  end
+
+  defp dispatch_child_created(child, parent_id) do
+    FamilyEvents.child_created(child.id, %{
+      child_id: child.id,
+      parent_id: parent_id,
+      first_name: child.first_name,
+      last_name: child.last_name
+    })
+    |> EventDispatchHelper.dispatch(@context)
   end
 
   # Trigger: no guardian specified

--- a/lib/klass_hero/family/application/commands/children/update_child.ex
+++ b/lib/klass_hero/family/application/commands/children/update_child.ex
@@ -6,8 +6,11 @@ defmodule KlassHero.Family.Application.Commands.Children.UpdateChild do
   then persists via the repository port.
   """
 
+  alias KlassHero.Family.Domain.Events.FamilyEvents
   alias KlassHero.Family.Domain.Models.Child
+  alias KlassHero.Shared.EventDispatchHelper
 
+  @context KlassHero.Family
   @repository Application.compile_env!(:klass_hero, [:family, :for_storing_children])
 
   @doc """
@@ -24,10 +27,23 @@ defmodule KlassHero.Family.Application.Commands.Children.UpdateChild do
          merged = Map.merge(Map.from_struct(existing), attrs),
          {:ok, _validated} <- Child.new(merged),
          {:ok, updated} <- @repository.update(child_id, attrs) do
+      dispatch_child_updated(updated)
       {:ok, updated}
     else
       {:error, errors} when is_list(errors) -> {:error, {:validation_error, errors}}
       {:error, _} = error -> error
     end
+  end
+
+  defp dispatch_child_updated(child) do
+    # Trigger: child record successfully updated
+    # Why: downstream contexts (e.g. Messaging) need to refresh local child name lookups
+    # Outcome: fire-and-forget dispatch; parent_id omitted (not on child struct)
+    FamilyEvents.child_updated(child.id, %{
+      child_id: child.id,
+      first_name: child.first_name,
+      last_name: child.last_name
+    })
+    |> EventDispatchHelper.dispatch(@context)
   end
 end

--- a/lib/klass_hero/family/domain/events/family_events.ex
+++ b/lib/klass_hero/family/domain/events/family_events.ex
@@ -7,6 +7,10 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
 
   ## Events
 
+  - `:child_created` - Emitted when a new child record is created. Downstream
+    contexts (e.g. Messaging) react to maintain local child name lookups.
+  - `:child_updated` - Emitted when an existing child record is updated.
+    Downstream contexts (e.g. Messaging) react to refresh local child name lookups.
   - `:child_data_anonymized` - Emitted when a child's PII is anonymized during
     GDPR account deletion (critical). Downstream contexts (e.g. Participation)
     react to this event to anonymize their own child-related data.
@@ -18,6 +22,94 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
   alias KlassHero.Shared.Domain.Events.DomainEvent
 
   @aggregate_type :child
+
+  @doc """
+  Creates a `child_created` event.
+
+  Emitted when a new child record is created. Downstream contexts (e.g.
+  Messaging) react to maintain a local lookup of child names.
+
+  ## Parameters
+
+  - `child_id` - The ID of the newly created child
+  - `payload` - Additional event-specific data (child_id, parent_id, first_name, last_name)
+  - `opts` - Metadata options (correlation_id, causation_id, user_id)
+
+  ## Raises
+
+  - `ArgumentError` if `child_id` is nil or empty
+
+  ## Examples
+
+      iex> event = FamilyEvents.child_created("child-uuid", %{first_name: "Emma"})
+      iex> event.event_type
+      :child_created
+  """
+  def child_created(child_id, payload \\ %{}, opts \\ [])
+
+  def child_created(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    DomainEvent.new(
+      :child_created,
+      child_id,
+      @aggregate_type,
+      # Trigger: caller may pass a conflicting :child_id in payload
+      # Why: base_payload contains the canonical child_id from the function argument
+      # Outcome: base_payload keys always win, preventing accidental overwrite
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_created(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_created/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
+
+  @doc """
+  Creates a `child_updated` event.
+
+  Emitted when an existing child record is updated. Downstream contexts (e.g.
+  Messaging) react to refresh their local lookup of child names.
+
+  ## Parameters
+
+  - `child_id` - The ID of the updated child
+  - `payload` - Additional event-specific data (child_id, first_name, last_name)
+  - `opts` - Metadata options (correlation_id, causation_id, user_id)
+
+  ## Raises
+
+  - `ArgumentError` if `child_id` is nil or empty
+
+  ## Examples
+
+      iex> event = FamilyEvents.child_updated("child-uuid", %{first_name: "Emily"})
+      iex> event.event_type
+      :child_updated
+  """
+  def child_updated(child_id, payload \\ %{}, opts \\ [])
+
+  def child_updated(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    DomainEvent.new(
+      :child_updated,
+      child_id,
+      @aggregate_type,
+      # Trigger: caller may pass a conflicting :child_id in payload
+      # Why: base_payload contains the canonical child_id from the function argument
+      # Outcome: base_payload keys always win, preventing accidental overwrite
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_updated(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_updated/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
 
   @doc """
   Creates a `child_data_anonymized` event.

--- a/lib/klass_hero/family/domain/events/family_integration_events.ex
+++ b/lib/klass_hero/family/domain/events/family_integration_events.ex
@@ -7,6 +7,12 @@ defmodule KlassHero.Family.Domain.Events.FamilyIntegrationEvents do
 
   ## Events
 
+  - `:child_created` - Emitted when a new child record is created. Downstream
+    contexts (e.g. Messaging) react to maintain local child name lookups.
+    Topic: `integration:family:child_created`
+  - `:child_updated` - Emitted when an existing child record is updated.
+    Downstream contexts (e.g. Messaging) react to refresh local child name lookups.
+    Topic: `integration:family:child_updated`
   - `:child_data_anonymized` - Emitted when a child's PII is anonymized during
     GDPR account deletion (critical). Downstream contexts (e.g. Participation)
     react to this event to anonymize their own child-related data.
@@ -16,6 +22,23 @@ defmodule KlassHero.Family.Domain.Events.FamilyIntegrationEvents do
   """
 
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  @typedoc "Payload for `:child_created` events."
+  @type child_created_payload :: %{
+          required(:child_id) => String.t(),
+          optional(:parent_id) => String.t(),
+          optional(:first_name) => String.t(),
+          optional(:last_name) => String.t(),
+          optional(atom()) => term()
+        }
+
+  @typedoc "Payload for `:child_updated` events."
+  @type child_updated_payload :: %{
+          required(:child_id) => String.t(),
+          optional(:first_name) => String.t(),
+          optional(:last_name) => String.t(),
+          optional(atom()) => term()
+        }
 
   @typedoc "Payload for `:child_data_anonymized` events."
   @type child_data_anonymized_payload :: %{
@@ -31,6 +54,104 @@ defmodule KlassHero.Family.Domain.Events.FamilyIntegrationEvents do
 
   @source_context :family
   @entity_type :child
+
+  @doc """
+  Creates a `child_created` integration event.
+
+  Emitted when a new child record is created. Published on topic
+  `integration:family:child_created`.
+
+  ## Parameters
+
+  - `child_id` - The ID of the newly created child
+  - `payload` - Event-specific data (child_id, parent_id, first_name, last_name)
+  - `opts` - Metadata options (correlation_id, causation_id)
+
+  ## Raises
+
+  - `ArgumentError` if `child_id` is nil or empty
+
+  ## Examples
+
+      iex> event = FamilyIntegrationEvents.child_created("child-uuid", %{first_name: "Emma"})
+      iex> event.event_type
+      :child_created
+      iex> event.source_context
+      :family
+      iex> event.entity_type
+      :child
+  """
+  def child_created(child_id, payload \\ %{}, opts \\ [])
+
+  def child_created(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    IntegrationEvent.new(
+      :child_created,
+      @source_context,
+      @entity_type,
+      child_id,
+      # Trigger: caller may pass a conflicting :child_id in payload
+      # Why: base_payload contains the canonical child_id from the function argument
+      # Outcome: base_payload keys always win, preventing accidental overwrite
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_created(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_created/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
+
+  @doc """
+  Creates a `child_updated` integration event.
+
+  Emitted when an existing child record is updated. Published on topic
+  `integration:family:child_updated`.
+
+  ## Parameters
+
+  - `child_id` - The ID of the updated child
+  - `payload` - Event-specific data (child_id, first_name, last_name)
+  - `opts` - Metadata options (correlation_id, causation_id)
+
+  ## Raises
+
+  - `ArgumentError` if `child_id` is nil or empty
+
+  ## Examples
+
+      iex> event = FamilyIntegrationEvents.child_updated("child-uuid", %{first_name: "Emily"})
+      iex> event.event_type
+      :child_updated
+      iex> event.source_context
+      :family
+      iex> event.entity_type
+      :child
+  """
+  def child_updated(child_id, payload \\ %{}, opts \\ [])
+
+  def child_updated(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
+    base_payload = %{child_id: child_id}
+
+    IntegrationEvent.new(
+      :child_updated,
+      @source_context,
+      @entity_type,
+      child_id,
+      # Trigger: caller may pass a conflicting :child_id in payload
+      # Why: base_payload contains the canonical child_id from the function argument
+      # Outcome: base_payload keys always win, preventing accidental overwrite
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def child_updated(child_id, _payload, _opts) do
+    raise ArgumentError,
+          "child_updated/3 requires a non-empty child_id string, got: #{inspect(child_id)}"
+  end
 
   @doc """
   Creates a `child_data_anonymized` integration event.

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -63,6 +63,7 @@ defmodule KlassHero.Messaging do
 
   alias KlassHero.Messaging.Application.Queries.{
     GetConversation,
+    GetConversationContext,
     GetInboundEmail,
     GetTotalUnreadCount,
     InboundEmailQueries,
@@ -433,6 +434,25 @@ defmodule KlassHero.Messaging do
   @spec get_total_unread_count(String.t()) :: non_neg_integer()
   defdelegate get_total_unread_count(user_id),
     to: GetTotalUnreadCount,
+    as: :execute
+
+  @doc """
+  Returns enrolled child names and other participant name for a conversation/user pair.
+
+  Used by the web layer to build enriched conversation titles, e.g. "Sarah for Emma, Liam".
+  Reads from the denormalized conversation_summaries read model.
+
+  ## Parameters
+  - conversation_id: The conversation to look up
+  - user_id: The requesting user's ID
+
+  ## Returns
+  - Map with `:enrolled_child_names` (list) and `:other_participant_name` (string or nil)
+  """
+  @spec get_conversation_context(String.t(), String.t()) ::
+          %{enrolled_child_names: [String.t()], other_participant_name: String.t() | nil}
+  defdelegate get_conversation_context(conversation_id, user_id),
+    to: GetConversationContext,
     as: :execute
 
   @doc """

--- a/lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex
@@ -213,6 +213,31 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Conversat
     end
   end
 
+  @impl true
+  def get_conversation_context(conversation_id, user_id) do
+    span do
+      set_attributes("db", operation: "select", entity: "conversation_summary")
+
+      result =
+        from(s in ConversationSummarySchema,
+          where: s.conversation_id == ^conversation_id and s.user_id == ^user_id,
+          select: %{
+            enrolled_child_names: s.enrolled_child_names,
+            other_participant_name: s.other_participant_name
+          }
+        )
+        |> Repo.one()
+
+      case result do
+        nil ->
+          %{enrolled_child_names: [], other_participant_name: nil}
+
+        %{enrolled_child_names: names, other_participant_name: other} ->
+          %{enrolled_child_names: names || [], other_participant_name: other}
+      end
+    end
+  end
+
   defp to_dto(%ConversationSummarySchema{} = schema) do
     ConversationSummary.new(%{
       id: schema.id,

--- a/lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_summaries_repository.ex
@@ -231,6 +231,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Conversat
       unread_count: schema.unread_count,
       last_read_at: schema.last_read_at,
       archived_at: schema.archived_at,
+      enrolled_child_names: schema.enrolled_child_names || [],
       inserted_at: schema.inserted_at,
       updated_at: schema.updated_at
     })

--- a/lib/klass_hero/messaging/adapters/driven/persistence/schemas/conversation_summary_schema.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/schemas/conversation_summary_schema.ex
@@ -29,6 +29,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSu
     field :archived_at, :utc_datetime
     field :has_attachments, :boolean, default: false
     field :system_notes, :map, default: %{}
+    field :enrolled_child_names, {:array, :string}, default: []
 
     timestamps()
   end

--- a/lib/klass_hero/messaging/adapters/driven/persistence/schemas/enrolled_children_schema.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/schemas/enrolled_children_schema.ex
@@ -1,0 +1,22 @@
+defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema do
+  @moduledoc """
+  Ecto schema for the messaging_enrolled_children projection table.
+
+  Write-only from the EnrolledChildren projection's perspective.
+  Read-only for handlers that need to derive child names for conversations.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:id, :binary_id, autogenerate: false}
+  @timestamps_opts [type: :utc_datetime]
+
+  schema "messaging_enrolled_children" do
+    field :parent_user_id, :binary_id
+    field :program_id, :binary_id
+    field :child_id, :binary_id
+    field :child_first_name, :string
+
+    timestamps()
+  end
+end

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -41,8 +41,10 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.AttachmentSchema
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSchema
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSummarySchema
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.MessageSchema
   alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
 
   require Logger
@@ -55,6 +57,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   @conversation_archived_topic "integration:messaging:conversation_archived"
   @conversations_archived_topic "integration:messaging:conversations_archived"
   @message_data_anonymized_topic "integration:messaging:message_data_anonymized"
+  @enrolled_children_changed_topic "messaging:enrolled_children_changed"
   @broadcast_token_regex ~r/\[broadcast:[^\]]+\]/
 
   # Client API
@@ -96,6 +99,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversation_archived_topic)
     Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversations_archived_topic)
     Phoenix.PubSub.subscribe(KlassHero.PubSub, @message_data_anonymized_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrolled_children_changed_topic)
 
     {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
   end
@@ -203,6 +207,19 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     )
 
     project_message_data_anonymized(event)
+    {:noreply, state}
+  end
+
+  # Trigger: Received an enrolled_children_changed domain event from EnrolledChildren projection
+  # Why: conversation summary needs updated child names for display
+  # Outcome: enrolled_child_names column updated for all rows of the conversation
+  @impl true
+  def handle_info({:domain_event, %DomainEvent{event_type: :enrolled_children_changed} = event}, state) do
+    Logger.debug("ConversationSummaries projecting enrolled_children_changed",
+      conversation_id: event.aggregate_id
+    )
+
+    project_enrolled_children_changed(event)
     {:noreply, state}
   end
 
@@ -391,6 +408,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
       last_read_at: participant.last_read_at,
       archived_at: conversation.archived_at,
       system_notes: conv_system_notes,
+      enrolled_child_names: resolve_enrolled_child_names(conversation, participant.user_id),
       inserted_at: now,
       updated_at: now
     }
@@ -595,6 +613,25 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     end
   end
 
+  # Trigger: enrolled_children_changed domain event received
+  # Why: update the enrolled_child_names for all participant rows of this conversation
+  # Outcome: simple field update — projection stays dumb
+  defp project_enrolled_children_changed(event) do
+    conversation_id = event.payload.conversation_id
+    child_names = Map.get(event.payload, :enrolled_child_names, [])
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(s in ConversationSummarySchema,
+      where: s.conversation_id == ^conversation_id
+    )
+    |> Repo.update_all(
+      set: [
+        enrolled_child_names: child_names,
+        updated_at: now
+      ]
+    )
+  end
+
   # Private Functions — System Note Projection
 
   # Trigger: a message_sent event was received
@@ -634,6 +671,24 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   end
 
   defp maybe_project_system_note(_payload), do: :ok
+
+  # Trigger: bootstrap needs enrolled child names from the EnrolledChildren projection table
+  # Why: direct conversations with a program_id should display child context
+  # Outcome: list of child first names or empty list
+  defp resolve_enrolled_child_names(%{type: type, program_id: program_id}, user_id)
+       when type in ["direct", :direct] and not is_nil(program_id) do
+    from(e in EnrolledChildrenSchema,
+      where:
+        e.parent_user_id == ^user_id and
+          e.program_id == ^program_id and
+          not is_nil(e.child_first_name),
+      select: e.child_first_name,
+      order_by: e.child_first_name
+    )
+    |> Repo.all()
+  end
+
+  defp resolve_enrolled_child_names(_, _), do: []
 
   # Private Functions — Helpers
 

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -408,7 +408,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
       last_read_at: participant.last_read_at,
       archived_at: conversation.archived_at,
       system_notes: conv_system_notes,
-      enrolled_child_names: resolve_enrolled_child_names(conversation, participant.user_id),
+      enrolled_child_names: resolve_enrolled_child_names(conversation, Enum.map(active_participants, & &1.user_id)),
       inserted_at: now,
       updated_at: now
     }
@@ -673,16 +673,19 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   defp maybe_project_system_note(_payload), do: :ok
 
   # Trigger: bootstrap needs enrolled child names from the EnrolledChildren projection table
-  # Why: direct conversations with a program_id should display child context
-  # Outcome: list of child first names or empty list
-  defp resolve_enrolled_child_names(%{type: type, program_id: program_id}, user_id)
-       when type in ["direct", :direct] and not is_nil(program_id) do
+  # Why: direct conversations with a program_id should display child context — query across
+  #      all participant user_ids (not just the current row's) so provider-side summary rows
+  #      receive the same list as parent-side rows, matching the event-driven path's semantics
+  # Outcome: list of child first names (deduped + sorted) or empty list
+  defp resolve_enrolled_child_names(%{type: type, program_id: program_id}, participant_user_ids)
+       when type in ["direct", :direct] and not is_nil(program_id) and participant_user_ids != [] do
     from(e in EnrolledChildrenSchema,
       where:
-        e.parent_user_id == ^user_id and
+        e.parent_user_id in ^participant_user_ids and
           e.program_id == ^program_id and
           not is_nil(e.child_first_name),
       select: e.child_first_name,
+      distinct: true,
       order_by: e.child_first_name
     )
     |> Repo.all()

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -277,24 +277,21 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
     child_id = payload.child_id
     program_id = payload.program_id
 
-    rows =
+    parent_user_id =
       from(e in EnrolledChildrenSchema,
         where: e.child_id == ^child_id and e.program_id == ^program_id,
-        select: e
+        select: e.parent_user_id,
+        limit: 1
       )
-      |> Repo.all()
+      |> Repo.one()
 
-    case rows do
-      [row | _] ->
-        from(e in EnrolledChildrenSchema,
-          where: e.child_id == ^child_id and e.program_id == ^program_id
-        )
-        |> Repo.delete_all()
+    if parent_user_id do
+      from(e in EnrolledChildrenSchema,
+        where: e.child_id == ^child_id and e.program_id == ^program_id
+      )
+      |> Repo.delete_all()
 
-        re_derive_and_emit(row.parent_user_id, program_id)
-
-      [] ->
-        :ok
+      re_derive_and_emit(parent_user_id, program_id)
     end
   end
 
@@ -357,8 +354,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
   # Why: downstream consumers (ConversationSummaries) need the updated child name list
   # Outcome: enrolled_children_changed domain event emitted for each affected conversation
   defp re_derive_and_emit(parent_user_id, program_id) do
-    child_names = get_child_names(parent_user_id, program_id)
-
     conversation_ids =
       from(s in ConversationSummarySchema,
         where:
@@ -370,9 +365,13 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
       )
       |> Repo.all()
 
-    Enum.each(conversation_ids, fn conversation_id ->
-      emit_enrolled_children_changed(conversation_id, child_names)
-    end)
+    if conversation_ids != [] do
+      child_names = get_child_names(parent_user_id, program_id)
+
+      Enum.each(conversation_ids, fn conversation_id ->
+        emit_enrolled_children_changed(conversation_id, child_names)
+      end)
+    end
   end
 
   # Trigger: need sorted child names for a (parent_user, program) pair

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -1,0 +1,414 @@
+defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
+  @moduledoc """
+  Event-driven projection maintaining the `messaging_enrolled_children` lookup table.
+
+  This GenServer subscribes to cross-context integration events from
+  Enrollment and Family, plus Messaging's own `conversation_created` event.
+  It maintains a local lookup of enrolled children per parent+program,
+  then emits `enrolled_children_changed` domain events that the
+  `ConversationSummaries` projection consumes.
+
+  ## Event Subscriptions
+
+  - `integration:enrollment:enrollment_created` — upserts a lookup row
+  - `integration:enrollment:enrollment_cancelled` — deletes a lookup row
+  - `integration:family:child_created` — updates child_first_name
+  - `integration:family:child_updated` — updates child_first_name
+  - `integration:messaging:conversation_created` — triggers name resolution for new conversations
+  """
+
+  use GenServer
+
+  import Ecto.Query
+
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSummarySchema
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  require Logger
+
+  @enrollment_created_topic "integration:enrollment:enrollment_created"
+  @enrollment_cancelled_topic "integration:enrollment:enrollment_cancelled"
+  @child_created_topic "integration:family:child_created"
+  @child_updated_topic "integration:family:child_updated"
+  @conversation_created_topic "integration:messaging:conversation_created"
+
+  @enrolled_children_changed_topic "messaging:enrolled_children_changed"
+
+  # Client API
+
+  @doc """
+  Starts the EnrolledChildren projection GenServer.
+
+  ## Options
+
+  - `:name` - Process name (defaults to `__MODULE__`)
+  """
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Rebuilds the messaging_enrolled_children read table from the write tables.
+
+  Useful after seeding write tables directly (bypassing integration events).
+  Blocks until the rebuild is complete.
+  """
+  @spec rebuild(GenServer.name()) :: :ok
+  def rebuild(name \\ __MODULE__) do
+    GenServer.call(name, :rebuild, :infinity)
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(_opts) do
+    # Trigger: GenServer is starting
+    # Why: subscribe to events before bootstrapping to avoid missing events
+    #      that arrive between bootstrap completion and subscription
+    # Outcome: subscribed to all five relevant topics
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrollment_created_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrollment_cancelled_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @child_created_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @child_updated_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversation_created_topic)
+
+    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+  end
+
+  @impl true
+  def handle_continue(:bootstrap, state) do
+    # Trigger: GenServer initialization complete
+    # Why: project all existing enrollments from write tables into read table
+    # Outcome: messaging_enrolled_children table populated with current data
+    attempt_bootstrap(state)
+  end
+
+  # Trigger: external caller requests a full rebuild (e.g. after seeding)
+  # Why: seeds insert into write tables without emitting integration events
+  # Outcome: messaging_enrolled_children read table refreshed from write tables
+  @impl true
+  def handle_call(:rebuild, _from, state) do
+    count = bootstrap_from_write_tables()
+    Logger.info("EnrolledChildren rebuilt", count: count)
+    {:reply, :ok, %{state | bootstrapped: true}}
+  end
+
+  @impl true
+  def handle_info(:retry_bootstrap, state) do
+    {:noreply, state, {:continue, :bootstrap}}
+  end
+
+  # Trigger: Received an enrollment_created integration event
+  # Why: a new enrollment was created, upsert a lookup row
+  # Outcome: one row inserted/updated in messaging_enrolled_children
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :enrollment_created} = event}, state) do
+    Logger.debug("EnrolledChildren projecting enrollment_created",
+      enrollment_id: event.entity_id
+    )
+
+    project_enrollment_created(event)
+    {:noreply, state}
+  end
+
+  # Trigger: Received an enrollment_cancelled integration event
+  # Why: enrollment cancelled, remove the lookup row
+  # Outcome: row deleted from messaging_enrolled_children
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :enrollment_cancelled} = event}, state) do
+    Logger.debug("EnrolledChildren projecting enrollment_cancelled",
+      enrollment_id: event.entity_id
+    )
+
+    project_enrollment_cancelled(event)
+    {:noreply, state}
+  end
+
+  # Trigger: Received a child_created integration event
+  # Why: new child may need first_name populated in existing lookup rows
+  # Outcome: child_first_name updated for matching rows
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_created} = event}, state) do
+    Logger.debug("EnrolledChildren projecting child_created", child_id: event.entity_id)
+    project_child_name_change(event)
+    {:noreply, state}
+  end
+
+  # Trigger: Received a child_updated integration event
+  # Why: child name may have changed, update lookup rows
+  # Outcome: child_first_name updated for matching rows
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_updated} = event}, state) do
+    Logger.debug("EnrolledChildren projecting child_updated", child_id: event.entity_id)
+    project_child_name_change(event)
+    {:noreply, state}
+  end
+
+  # Trigger: Received a conversation_created integration event
+  # Why: new conversation may need child names resolved for its participants
+  # Outcome: enrolled_children_changed emitted if any participant has enrolled children
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :conversation_created} = event}, state) do
+    project_conversation_created(event)
+    {:noreply, state}
+  end
+
+  # Catch-all for unhandled messages — logged so misrouted events are traceable
+  @impl true
+  def handle_info(msg, state) do
+    Logger.warning("EnrolledChildren received unexpected message",
+      message: inspect(msg, limit: 200)
+    )
+
+    {:noreply, state}
+  end
+
+  # Private — Bootstrap
+
+  # Trigger: bootstrap attempt with retry logic
+  # Why: transient DB failures shouldn't crash the GenServer immediately
+  # Outcome: successful bootstrap or scheduled retry (up to 3 times before crashing)
+  defp attempt_bootstrap(state) do
+    count = bootstrap_from_write_tables()
+    Logger.info("EnrolledChildren projection started", count: count)
+    {:noreply, %{state | bootstrapped: true}}
+  rescue
+    error ->
+      retry_count = Map.get(state, :retry_count, 0) + 1
+
+      if retry_count > 3 do
+        # Trigger: exhausted retries
+        # Why: persistent failure indicates real infrastructure issue
+        # Outcome: crash to let supervisor handle with its own restart strategy
+        reraise error, __STACKTRACE__
+      else
+        Logger.error("EnrolledChildren: bootstrap failed, scheduling retry",
+          error: Exception.message(error),
+          retry_count: retry_count
+        )
+
+        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
+        {:noreply, Map.put(state, :retry_count, retry_count)}
+      end
+  end
+
+  # Trigger: bootstrap phase — read table may be empty or stale
+  # Why: cold start recovery — populate read table from authoritative write tables
+  # Outcome: messaging_enrolled_children contains one row per (parent_user, program, child)
+  defp bootstrap_from_write_tables do
+    entries =
+      from(e in "enrollments",
+        join: c in "children",
+        on: c.id == e.child_id,
+        join: pp in "parents",
+        on: pp.id == e.parent_id,
+        where: e.status in ["pending", "confirmed"],
+        select: %{
+          parent_user_id: type(pp.identity_id, :binary_id),
+          program_id: type(e.program_id, :binary_id),
+          child_id: type(e.child_id, :binary_id),
+          child_first_name: c.first_name
+        }
+      )
+      |> Repo.all()
+
+    if entries == [] do
+      0
+    else
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      rows =
+        Enum.map(entries, fn entry ->
+          Map.merge(entry, %{id: Ecto.UUID.generate(), inserted_at: now, updated_at: now})
+        end)
+
+      {count, _} =
+        Repo.insert_all(EnrolledChildrenSchema, rows,
+          on_conflict: {:replace, [:child_first_name, :updated_at]},
+          conflict_target: [:parent_user_id, :program_id, :child_id]
+        )
+
+      count
+    end
+  end
+
+  # Private — Event Projections
+
+  # Trigger: enrollment_created event received
+  # Why: a new enrollment needs a lookup row so child names can be resolved
+  # Outcome: one row upserted, then re-derivation emits enrolled_children_changed
+  defp project_enrollment_created(event) do
+    payload = event.payload
+    parent_user_id = payload.parent_user_id
+    program_id = payload.program_id
+    child_id = payload.child_id
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %EnrolledChildrenSchema{}
+    |> Ecto.Changeset.change(%{
+      id: Ecto.UUID.generate(),
+      parent_user_id: parent_user_id,
+      program_id: program_id,
+      child_id: child_id,
+      child_first_name: nil,
+      inserted_at: now,
+      updated_at: now
+    })
+    |> Repo.insert!(
+      on_conflict: {:replace, [:updated_at]},
+      conflict_target: [:parent_user_id, :program_id, :child_id]
+    )
+
+    re_derive_and_emit(parent_user_id, program_id)
+  end
+
+  # Trigger: enrollment_cancelled event received
+  # Why: cancelled enrollments should not appear in child name lists
+  # Outcome: row deleted, then re-derivation emits enrolled_children_changed
+  #
+  # Special: the event doesn't carry parent_user_id, so we look it up from
+  # the existing row before deleting it
+  defp project_enrollment_cancelled(event) do
+    payload = event.payload
+    child_id = payload.child_id
+    program_id = payload.program_id
+
+    rows =
+      from(e in EnrolledChildrenSchema,
+        where: e.child_id == ^child_id and e.program_id == ^program_id,
+        select: e
+      )
+      |> Repo.all()
+
+    case rows do
+      [row | _] ->
+        from(e in EnrolledChildrenSchema,
+          where: e.child_id == ^child_id and e.program_id == ^program_id
+        )
+        |> Repo.delete_all()
+
+        re_derive_and_emit(row.parent_user_id, program_id)
+
+      [] ->
+        :ok
+    end
+  end
+
+  # Trigger: child_created or child_updated event received
+  # Why: child's first_name may have changed, update all matching lookup rows
+  # Outcome: child_first_name updated, then re-derivation for each affected (parent, program)
+  defp project_child_name_change(event) do
+    payload = event.payload
+    child_id = payload.child_id
+    first_name = payload.first_name
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    affected =
+      from(e in EnrolledChildrenSchema,
+        where: e.child_id == ^child_id,
+        select: {e.parent_user_id, e.program_id}
+      )
+      |> Repo.all()
+
+    if affected != [] do
+      from(e in EnrolledChildrenSchema, where: e.child_id == ^child_id)
+      |> Repo.update_all(set: [child_first_name: first_name, updated_at: now])
+
+      affected
+      |> Enum.uniq()
+      |> Enum.each(fn {parent_user_id, program_id} ->
+        re_derive_and_emit(parent_user_id, program_id)
+      end)
+    end
+  end
+
+  # Trigger: conversation_created event received
+  # Why: new conversations need child names resolved for their participants
+  # Outcome: enrolled_children_changed emitted for each participant with enrolled children
+  #
+  # Special: uses event payload directly for conversation_id and participant_ids
+  # because the ConversationSummaries row may not exist yet
+  defp project_conversation_created(event) do
+    payload = event.payload
+    program_id = Map.get(payload, :program_id)
+    conversation_type = payload |> Map.get(:type, "direct") |> to_string()
+
+    if conversation_type == "direct" and program_id do
+      participant_ids = Map.get(payload, :participant_ids, [])
+      conversation_id = payload.conversation_id
+
+      Enum.each(participant_ids, fn user_id ->
+        child_names = get_child_names(user_id, program_id)
+
+        if child_names != [] do
+          emit_enrolled_children_changed(conversation_id, child_names)
+        end
+      end)
+    end
+  end
+
+  # Private — Re-derivation
+
+  # Trigger: a row in messaging_enrolled_children was added, removed, or updated
+  # Why: downstream consumers (ConversationSummaries) need the updated child name list
+  # Outcome: enrolled_children_changed domain event emitted for each affected conversation
+  defp re_derive_and_emit(parent_user_id, program_id) do
+    child_names = get_child_names(parent_user_id, program_id)
+
+    conversation_ids =
+      from(s in ConversationSummarySchema,
+        where:
+          s.user_id == ^parent_user_id and
+            s.program_id == ^program_id and
+            s.conversation_type == "direct",
+        select: s.conversation_id,
+        distinct: true
+      )
+      |> Repo.all()
+
+    Enum.each(conversation_ids, fn conversation_id ->
+      emit_enrolled_children_changed(conversation_id, child_names)
+    end)
+  end
+
+  # Trigger: need sorted child names for a (parent_user, program) pair
+  # Why: child names are displayed alphabetically, nil names excluded
+  # Outcome: list of non-nil first names, sorted alphabetically
+  defp get_child_names(parent_user_id, program_id) do
+    from(e in EnrolledChildrenSchema,
+      where:
+        e.parent_user_id == ^parent_user_id and
+          e.program_id == ^program_id and
+          not is_nil(e.child_first_name),
+      select: e.child_first_name,
+      order_by: e.child_first_name
+    )
+    |> Repo.all()
+  end
+
+  # Trigger: child names resolved for a conversation
+  # Why: ConversationSummaries projection listens for this event to update its read table
+  # Outcome: domain event broadcast on PubSub
+  defp emit_enrolled_children_changed(conversation_id, child_names) do
+    event =
+      DomainEvent.new(
+        :enrolled_children_changed,
+        conversation_id,
+        :conversation,
+        %{
+          conversation_id: conversation_id,
+          enrolled_child_names: child_names
+        }
+      )
+
+    Phoenix.PubSub.broadcast(
+      KlassHero.PubSub,
+      @enrolled_children_changed_topic,
+      {:domain_event, event}
+    )
+  end
+end

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -15,6 +15,30 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
   - `integration:family:child_created` — updates child_first_name
   - `integration:family:child_updated` — updates child_first_name
   - `integration:messaging:conversation_created` — triggers name resolution for new conversations
+
+  ## Cross-Context Coupling
+
+  Two paths in this module query Enrollment/Family tables directly via raw
+  string names:
+
+  - `bootstrap_from_write_tables/0` joins `enrollments`, `children`, and
+    `parents` to recover from a cold start where the read table is empty but
+    write tables already contain data (e.g. after seeding or a projection reset).
+  - `resolve_child_first_name/1` (called by `project_enrollment_created/1`)
+    looks up `children.first_name` because the `enrollment_created` integration
+    event payload does not carry the child's name.
+
+  These are **pragmatic cross-context couplings** at the adapter layer: raw
+  string table references (rather than schema-module aliases) sidestep
+  Boundary's compile-time isolation, but Messaging still gains runtime
+  knowledge of Enrollment's and Family's physical schema — a rename in those
+  contexts will silently break these paths.
+
+  Both paths mirror the precedent set by
+  `Family.Adapters.Driven.ACL.ChildEnrollmentACL` and
+  `Enrollment.Adapters.Driven.ACL.ProgramCatalogACL`, which adopt the same
+  raw-string workaround to avoid hard Boundary dependencies. Issue #685
+  tracks replacing all of these with dedicated cross-context ports.
   """
 
   use GenServer
@@ -248,22 +272,50 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
     child_id = payload.child_id
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
+    # Trigger: event payload lacks child_first_name
+    # Why: Enrollment context doesn't know the name; without this, rows stay nil
+    #      until a child_updated event fires — which never happens for enrollments
+    #      of pre-existing, unedited children
+    # Outcome: name resolved from children table (nil only if child concurrently deleted)
+    child_first_name = resolve_child_first_name(child_id)
+
     %EnrolledChildrenSchema{}
     |> Ecto.Changeset.change(%{
       id: Ecto.UUID.generate(),
       parent_user_id: parent_user_id,
       program_id: program_id,
       child_id: child_id,
-      child_first_name: nil,
+      child_first_name: child_first_name,
       inserted_at: now,
       updated_at: now
     })
     |> Repo.insert!(
-      on_conflict: {:replace, [:updated_at]},
+      on_conflict: {:replace, [:child_first_name, :updated_at]},
       conflict_target: [:parent_user_id, :program_id, :child_id]
     )
 
     re_derive_and_emit(parent_user_id, program_id)
+  end
+
+  # Trigger: project_enrollment_created needs child's first_name
+  # Why: the enrollment_created event payload does not carry the name
+  # Outcome: children.first_name for the given child_id, or nil if the row is missing
+  defp resolve_child_first_name(child_id) do
+    name =
+      Repo.one(
+        from(c in "children",
+          where: c.id == type(^child_id, :binary_id),
+          select: c.first_name
+        )
+      )
+
+    if is_nil(name) do
+      Logger.warning("EnrolledChildren: child row not found when resolving first_name",
+        child_id: child_id
+      )
+    end
+
+    name
   end
 
   # Trigger: enrollment_cancelled event received

--- a/lib/klass_hero/messaging/application/commands/create_direct_conversation.ex
+++ b/lib/klass_hero/messaging/application/commands/create_direct_conversation.ex
@@ -116,7 +116,8 @@ defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversation do
         conversation.id,
         conversation.type,
         provider_id,
-        participant_ids
+        participant_ids,
+        conversation.program_id
       )
 
     DomainEventBus.dispatch(@context, event)

--- a/lib/klass_hero/messaging/application/queries/get_conversation_context.ex
+++ b/lib/klass_hero/messaging/application/queries/get_conversation_context.ex
@@ -1,0 +1,30 @@
+defmodule KlassHero.Messaging.Application.Queries.GetConversationContext do
+  @moduledoc """
+  Use case for fetching enriched conversation context for title display.
+
+  Reads enrolled child names and other participant name from the
+  conversation_summaries read model (CQRS read side). Used by the web layer
+  to build human-readable conversation titles, e.g. "Sarah for Emma, Liam".
+  """
+
+  @conversation_summaries_reader Application.compile_env!(:klass_hero, [
+                                   :messaging,
+                                   :for_querying_conversation_summaries
+                                 ])
+
+  @doc """
+  Returns enrolled child names and other participant name for a conversation/user pair.
+
+  ## Parameters
+  - conversation_id: The conversation to look up
+  - user_id: The requesting user's ID (determines which summary row to read)
+
+  ## Returns
+  - Map with `:enrolled_child_names` (list of strings) and `:other_participant_name` (string or nil)
+  """
+  @spec execute(String.t(), String.t()) ::
+          %{enrolled_child_names: [String.t()], other_participant_name: String.t() | nil}
+  def execute(conversation_id, user_id) do
+    @conversation_summaries_reader.get_conversation_context(conversation_id, user_id)
+  end
+end

--- a/lib/klass_hero/messaging/application/queries/list_conversations.ex
+++ b/lib/klass_hero/messaging/application/queries/list_conversations.ex
@@ -62,7 +62,8 @@ defmodule KlassHero.Messaging.Application.Queries.ListConversations do
       unread_count: summary.unread_count,
       latest_message: build_latest_message(summary),
       last_read_at: summary.last_read_at,
-      other_participant_name: summary.other_participant_name
+      other_participant_name: summary.other_participant_name,
+      enrolled_child_names: summary.enrolled_child_names
     }
   end
 

--- a/lib/klass_hero/messaging/domain/events/messaging_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_events.ex
@@ -23,9 +23,10 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
           conversation_id :: String.t(),
           type :: :direct | :program_broadcast,
           provider_id :: String.t(),
-          participant_ids :: [String.t()]
+          participant_ids :: [String.t()],
+          program_id :: String.t() | nil
         ) :: DomainEvent.t()
-  def conversation_created(conversation_id, type, provider_id, participant_ids) do
+  def conversation_created(conversation_id, type, provider_id, participant_ids, program_id \\ nil) do
     DomainEvent.new(
       :conversation_created,
       conversation_id,
@@ -34,7 +35,8 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
         conversation_id: conversation_id,
         type: type,
         provider_id: provider_id,
-        participant_ids: participant_ids
+        participant_ids: participant_ids,
+        program_id: program_id
       }
     )
   end

--- a/lib/klass_hero/messaging/domain/ports/for_querying_conversation_summaries.ex
+++ b/lib/klass_hero/messaging/domain/ports/for_querying_conversation_summaries.ex
@@ -45,4 +45,14 @@ defmodule KlassHero.Messaging.Domain.Ports.ForQueryingConversationSummaries do
   DTO entirely.
   """
   @callback has_system_note?(conversation_id :: String.t(), token :: String.t()) :: boolean()
+
+  @doc """
+  Returns enrolled child names and other participant name for a conversation/user pair.
+
+  Used by the web layer to build enriched conversation titles (e.g. "Sarah for Emma, Liam").
+  Returns a map with `:enrolled_child_names` (list) and `:other_participant_name` (string or nil).
+  Falls back to empty defaults when no summary row exists yet.
+  """
+  @callback get_conversation_context(conversation_id :: String.t(), user_id :: String.t()) ::
+              %{enrolled_child_names: [String.t()], other_participant_name: String.t() | nil}
 end

--- a/lib/klass_hero/messaging/domain/read_models/conversation_summary.ex
+++ b/lib/klass_hero/messaging/domain/read_models/conversation_summary.ex
@@ -24,6 +24,7 @@ defmodule KlassHero.Messaging.Domain.ReadModels.ConversationSummary do
           unread_count: non_neg_integer(),
           last_read_at: DateTime.t() | nil,
           archived_at: DateTime.t() | nil,
+          enrolled_child_names: [String.t()],
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
@@ -48,7 +49,8 @@ defmodule KlassHero.Messaging.Domain.ReadModels.ConversationSummary do
     :updated_at,
     has_attachments: false,
     participant_count: 0,
-    unread_count: 0
+    unread_count: 0,
+    enrolled_child_names: []
   ]
 
   @spec new(map()) :: t()

--- a/lib/klass_hero/projection_supervisor.ex
+++ b/lib/klass_hero/projection_supervisor.ex
@@ -11,6 +11,7 @@ defmodule KlassHero.ProjectionSupervisor do
   use Supervisor
 
   alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
+  alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
@@ -24,6 +25,7 @@ defmodule KlassHero.ProjectionSupervisor do
     children = [
       VerifiedProviders,
       ProgramListings,
+      EnrolledChildren,
       ConversationSummaries,
       ProviderSessionStats
     ]

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -45,6 +45,7 @@ defmodule KlassHeroWeb.MessagingComponents do
   attr :unread_count, :integer, default: 0
   attr :latest_message, :map, default: nil
   attr :other_participant_name, :string, default: nil
+  attr :enrolled_child_names, :list, default: []
   attr :navigate, :string, default: nil
 
   def conversation_card(assigns) do
@@ -83,6 +84,9 @@ defmodule KlassHeroWeb.MessagingComponents do
               {format_timestamp(@latest_message && @latest_message.inserted_at)}
             </span>
           </div>
+          <p :if={@enrolled_child_names != []} class={["text-xs mt-0.5", Theme.text_color(:muted)]}>
+            {gettext("for")} {Enum.join(@enrolled_child_names, ", ")}
+          </p>
 
           <div class="flex items-center justify-between gap-2 mt-1">
             <p class={[
@@ -471,6 +475,7 @@ defmodule KlassHeroWeb.MessagingComponents do
         unread_count={conv_data.unread_count}
         latest_message={conv_data.latest_message}
         other_participant_name={conv_data.other_participant_name}
+        enrolled_child_names={Map.get(conv_data, :enrolled_child_names, [])}
         navigate={@navigate_base <> "/" <> conv_data.conversation.id}
       />
       <div :if={@conversations_empty?} id="conversations-empty-state" class="p-4">

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -475,7 +475,11 @@ defmodule KlassHeroWeb.MessagingComponents do
         unread_count={conv_data.unread_count}
         latest_message={conv_data.latest_message}
         other_participant_name={conv_data.other_participant_name}
-        enrolled_child_names={Map.get(conv_data, :enrolled_child_names, [])}
+        enrolled_child_names={
+          if @user_type == :parent,
+            do: [],
+            else: Map.get(conv_data, :enrolled_child_names, [])
+        }
         navigate={@navigate_base <> "/" <> conv_data.conversation.id}
       />
       <div :if={@conversations_empty?} id="conversations-empty-state" class="p-4">

--- a/lib/klass_hero_web/live/messages_live/show.ex
+++ b/lib/klass_hero_web/live/messages_live/show.ex
@@ -17,7 +17,10 @@ defmodule KlassHeroWeb.MessagesLive.Show do
 
   @impl true
   def mount(%{"id" => conversation_id}, _session, socket) do
-    MessagingLiveHelper.mount_conversation_show(socket, conversation_id, back_path: ~p"/messages")
+    MessagingLiveHelper.mount_conversation_show(socket, conversation_id,
+      back_path: ~p"/messages",
+      variant: :parent
+    )
   end
 
   @impl true

--- a/lib/klass_hero_web/live/messaging_live_helper.ex
+++ b/lib/klass_hero_web/live/messaging_live_helper.ex
@@ -136,7 +136,7 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
 
         socket =
           socket
-          |> assign(:page_title, get_conversation_title(conversation))
+          |> assign(:page_title, build_page_title(conversation, user_id))
           |> assign(:conversation, conversation)
           |> assign(:has_more, has_more)
           |> assign(:messages_empty?, Enum.empty?(messages))
@@ -322,16 +322,31 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
 
   @doc """
   Returns the title for a conversation.
+
+  For direct conversations with enrolled children (provider view):
+  "Sarah Johnson for Emma, Liam"
   """
-  def get_conversation_title(%{type: :program_broadcast, subject: subject}) when not is_nil(subject) do
+  def get_conversation_title(conversation, enrolled_child_names \\ [], other_participant_name \\ nil)
+
+  def get_conversation_title(%{type: :direct}, child_names, other_name)
+      when child_names != [] and not is_nil(other_name) do
+    formatted = Enum.join(child_names, ", ")
+    "#{other_name} #{gettext("for")} #{formatted}"
+  end
+
+  def get_conversation_title(%{type: :direct}, _child_names, other_name) when not is_nil(other_name) do
+    other_name
+  end
+
+  def get_conversation_title(%{type: :program_broadcast, subject: subject}, _, _) when not is_nil(subject) do
     subject
   end
 
-  def get_conversation_title(%{type: :program_broadcast}) do
+  def get_conversation_title(%{type: :program_broadcast}, _, _) do
     gettext("Program Broadcast")
   end
 
-  def get_conversation_title(_conversation) do
+  def get_conversation_title(_conversation, _, _) do
     gettext("Conversation")
   end
 
@@ -347,6 +362,15 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
   """
   def get_sender_name(sender_names, sender_id) do
     Map.get(sender_names, sender_id, "Unknown")
+  end
+
+  defp build_page_title(conversation, user_id) do
+    context = fetch_conversation_context(conversation.id, user_id)
+    get_conversation_title(conversation, context.enrolled_child_names, context.other_participant_name)
+  end
+
+  defp fetch_conversation_context(conversation_id, user_id) do
+    Messaging.get_conversation_context(conversation_id, user_id)
   end
 
   # Fetches the provider profile once to extract both the owner's identity_id

--- a/lib/klass_hero_web/live/messaging_live_helper.ex
+++ b/lib/klass_hero_web/live/messaging_live_helper.ex
@@ -110,6 +110,9 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
 
   ## Options
   - `:back_path` - The path to navigate back to (required)
+  - `:variant` - Viewer role (`:parent`, `:provider`, or `:staff`). Defaults to
+    `:parent` as the least-privileged default. Controls whether the page title
+    includes the enrolled-child suffix (only non-parent variants see it).
 
   ## Returns
   - `{:ok, socket}` on success
@@ -117,6 +120,7 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
   """
   def mount_conversation_show(socket, conversation_id, opts) do
     back_path = Keyword.fetch!(opts, :back_path)
+    variant = Keyword.get(opts, :variant, :parent)
     user_id = socket.assigns.current_scope.user.id
     mark_as_read? = connected?(socket)
 
@@ -136,7 +140,7 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
 
         socket =
           socket
-          |> assign(:page_title, build_page_title(conversation, user_id))
+          |> assign(:page_title, build_page_title(conversation, user_id, variant))
           |> assign(:conversation, conversation)
           |> assign(:has_more, has_more)
           |> assign(:messages_empty?, Enum.empty?(messages))
@@ -364,10 +368,21 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
     Map.get(sender_names, sender_id, "Unknown")
   end
 
-  defp build_page_title(conversation, user_id) do
+  # Trigger: page title is being assembled for a conversation show view
+  # Why: parents already know which of their own children are involved — suppress the
+  #      "for {names}" suffix for them; show it for provider and staff viewers
+  # Outcome: title string with or without the enrolled-child suffix
+  defp build_page_title(conversation, user_id, variant) do
     context = fetch_conversation_context(conversation.id, user_id)
-    get_conversation_title(conversation, context.enrolled_child_names, context.other_participant_name)
+    child_names = enrolled_child_names_for(variant, context.enrolled_child_names)
+    get_conversation_title(conversation, child_names, context.other_participant_name)
   end
+
+  @doc false
+  # Suppresses enrolled-child names for the parent viewer, passes them through for
+  # provider/staff viewers. Exposed so the variant-gating rule can be tested directly.
+  def enrolled_child_names_for(:parent, _names), do: []
+  def enrolled_child_names_for(_variant, names), do: names
 
   defp fetch_conversation_context(conversation_id, user_id) do
     Messaging.get_conversation_context(conversation_id, user_id)

--- a/lib/klass_hero_web/live/provider/messages_live/show.ex
+++ b/lib/klass_hero_web/live/provider/messages_live/show.ex
@@ -13,7 +13,10 @@ defmodule KlassHeroWeb.Provider.MessagesLive.Show do
 
   @impl true
   def mount(%{"id" => conversation_id}, _session, socket) do
-    MessagingLiveHelper.mount_conversation_show(socket, conversation_id, back_path: ~p"/provider/messages")
+    MessagingLiveHelper.mount_conversation_show(socket, conversation_id,
+      back_path: ~p"/provider/messages",
+      variant: :provider
+    )
   end
 
   @impl true

--- a/lib/klass_hero_web/live/staff/messages_live/show.ex
+++ b/lib/klass_hero_web/live/staff/messages_live/show.ex
@@ -13,7 +13,10 @@ defmodule KlassHeroWeb.Staff.MessagesLive.Show do
 
   @impl true
   def mount(%{"id" => conversation_id}, _session, socket) do
-    MessagingLiveHelper.mount_conversation_show(socket, conversation_id, back_path: ~p"/staff/messages")
+    MessagingLiveHelper.mount_conversation_show(socket, conversation_id,
+      back_path: ~p"/staff/messages",
+      variant: :staff
+    )
   end
 
   @impl true

--- a/priv/repo/migrations/20260417124224_create_messaging_enrolled_children.exs
+++ b/priv/repo/migrations/20260417124224_create_messaging_enrolled_children.exs
@@ -1,0 +1,19 @@
+defmodule KlassHero.Repo.Migrations.CreateMessagingEnrolledChildren do
+  use Ecto.Migration
+
+  def change do
+    create table(:messaging_enrolled_children, primary_key: false) do
+      add :id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()")
+      add :parent_user_id, :binary_id, null: false
+      add :program_id, :binary_id, null: false
+      add :child_id, :binary_id, null: false
+      add :child_first_name, :string
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:messaging_enrolled_children, [:parent_user_id, :program_id, :child_id])
+    create index(:messaging_enrolled_children, [:parent_user_id, :program_id])
+    create index(:messaging_enrolled_children, [:child_id])
+  end
+end

--- a/priv/repo/migrations/20260417124227_add_enrolled_child_names_to_conversation_summaries.exs
+++ b/priv/repo/migrations/20260417124227_add_enrolled_child_names_to_conversation_summaries.exs
@@ -1,0 +1,9 @@
+defmodule KlassHero.Repo.Migrations.AddEnrolledChildNamesToConversationSummaries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversation_summaries) do
+      add :enrolled_child_names, {:array, :string}, default: []
+    end
+  end
+end

--- a/test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs
+++ b/test/klass_hero/enrollment/domain/events/enrollment_events_enrollment_created_test.exs
@@ -1,0 +1,54 @@
+defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEventsEnrollmentCreatedTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  describe "enrollment_created/3" do
+    test "creates event with correct type and aggregate" do
+      enrollment_id = Ecto.UUID.generate()
+
+      payload = %{
+        enrollment_id: enrollment_id,
+        child_id: Ecto.UUID.generate(),
+        parent_id: Ecto.UUID.generate(),
+        parent_user_id: Ecto.UUID.generate(),
+        program_id: Ecto.UUID.generate(),
+        status: "pending"
+      }
+
+      event = EnrollmentEvents.enrollment_created(enrollment_id, payload)
+
+      assert %DomainEvent{} = event
+      assert event.event_type == :enrollment_created
+      assert event.aggregate_id == enrollment_id
+      assert event.aggregate_type == :enrollment
+      assert event.payload.enrollment_id == enrollment_id
+      assert event.payload.child_id == payload.child_id
+      assert event.payload.parent_user_id == payload.parent_user_id
+      assert event.payload.program_id == payload.program_id
+    end
+
+    test "base_payload enrollment_id wins over caller-supplied enrollment_id" do
+      real_id = Ecto.UUID.generate()
+      conflicting_payload = %{enrollment_id: "should-be-overridden", extra: "data"}
+
+      event = EnrollmentEvents.enrollment_created(real_id, conflicting_payload)
+
+      assert event.payload.enrollment_id == real_id
+      assert event.payload.extra == "data"
+    end
+
+    test "raises for nil enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentEvents.enrollment_created(nil) end
+    end
+
+    test "raises for empty string enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentEvents.enrollment_created("") end
+    end
+  end
+end

--- a/test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs
+++ b/test/klass_hero/enrollment/domain/events/enrollment_integration_events_enrollment_created_test.exs
@@ -1,0 +1,52 @@
+defmodule KlassHero.Enrollment.Domain.Events.EnrollmentIntegrationEventsEnrollmentCreatedTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentIntegrationEvents
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  describe "enrollment_created/3" do
+    test "creates integration event with correct structure" do
+      enrollment_id = Ecto.UUID.generate()
+
+      payload = %{
+        enrollment_id: enrollment_id,
+        child_id: Ecto.UUID.generate(),
+        parent_id: Ecto.UUID.generate(),
+        parent_user_id: Ecto.UUID.generate(),
+        program_id: Ecto.UUID.generate(),
+        status: "pending"
+      }
+
+      event = EnrollmentIntegrationEvents.enrollment_created(enrollment_id, payload)
+
+      assert %IntegrationEvent{} = event
+      assert event.event_type == :enrollment_created
+      assert event.source_context == :enrollment
+      assert event.entity_type == :enrollment
+      assert event.entity_id == enrollment_id
+      assert event.payload.parent_user_id == payload.parent_user_id
+    end
+
+    test "base_payload enrollment_id wins over caller-supplied enrollment_id" do
+      real_id = Ecto.UUID.generate()
+      conflicting_payload = %{enrollment_id: "should-be-overridden", extra: "data"}
+
+      event = EnrollmentIntegrationEvents.enrollment_created(real_id, conflicting_payload)
+
+      assert event.payload.enrollment_id == real_id
+      assert event.payload.extra == "data"
+    end
+
+    test "raises for nil enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentIntegrationEvents.enrollment_created(nil) end
+    end
+
+    test "raises for empty string enrollment_id" do
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty enrollment_id string/,
+                   fn -> EnrollmentIntegrationEvents.enrollment_created("") end
+    end
+  end
+end

--- a/test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs
+++ b/test/klass_hero/family/domain/events/family_events_child_lifecycle_test.exs
@@ -1,0 +1,61 @@
+defmodule KlassHero.Family.Domain.Events.FamilyEventsChildLifecycleTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Family.Domain.Events.FamilyEvents
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  describe "child_created/3" do
+    test "creates event with correct type and aggregate" do
+      child_id = Ecto.UUID.generate()
+      payload = %{child_id: child_id, parent_id: Ecto.UUID.generate(), first_name: "Emma", last_name: "Johnson"}
+
+      event = FamilyEvents.child_created(child_id, payload)
+
+      assert %DomainEvent{} = event
+      assert event.event_type == :child_created
+      assert event.aggregate_id == child_id
+      assert event.aggregate_type == :child
+      assert event.payload.child_id == child_id
+      assert event.payload.first_name == "Emma"
+    end
+
+    test "base_payload child_id wins over caller-supplied child_id" do
+      real_id = Ecto.UUID.generate()
+      payload = %{child_id: "should-be-overridden", first_name: "Emma"}
+      event = FamilyEvents.child_created(real_id, payload)
+      assert event.payload.child_id == real_id
+      assert event.payload.first_name == "Emma"
+    end
+
+    test "raises for nil child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/, fn ->
+        FamilyEvents.child_created(nil)
+      end
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/, fn ->
+        FamilyEvents.child_created("")
+      end
+    end
+  end
+
+  describe "child_updated/3" do
+    test "creates event with correct type and aggregate" do
+      child_id = Ecto.UUID.generate()
+      payload = %{child_id: child_id, parent_id: Ecto.UUID.generate(), first_name: "Emily", last_name: "Johnson"}
+      event = FamilyEvents.child_updated(child_id, payload)
+      assert %DomainEvent{} = event
+      assert event.event_type == :child_updated
+      assert event.aggregate_id == child_id
+      assert event.aggregate_type == :child
+      assert event.payload.first_name == "Emily"
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/, fn ->
+        FamilyEvents.child_updated("")
+      end
+    end
+  end
+end

--- a/test/klass_hero/family/domain/events/family_integration_events_child_lifecycle_test.exs
+++ b/test/klass_hero/family/domain/events/family_integration_events_child_lifecycle_test.exs
@@ -1,0 +1,46 @@
+defmodule KlassHero.Family.Domain.Events.FamilyIntegrationEventsChildLifecycleTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Family.Domain.Events.FamilyIntegrationEvents
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  describe "child_created/3" do
+    test "creates integration event with correct structure" do
+      child_id = Ecto.UUID.generate()
+      payload = %{child_id: child_id, parent_id: Ecto.UUID.generate(), first_name: "Emma", last_name: "Johnson"}
+      event = FamilyIntegrationEvents.child_created(child_id, payload)
+      assert %IntegrationEvent{} = event
+      assert event.event_type == :child_created
+      assert event.source_context == :family
+      assert event.entity_type == :child
+      assert event.entity_id == child_id
+      assert event.payload.first_name == "Emma"
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/, fn ->
+        FamilyIntegrationEvents.child_created("")
+      end
+    end
+  end
+
+  describe "child_updated/3" do
+    test "creates integration event with correct structure" do
+      child_id = Ecto.UUID.generate()
+      payload = %{child_id: child_id, parent_id: Ecto.UUID.generate(), first_name: "Emily", last_name: "Johnson"}
+      event = FamilyIntegrationEvents.child_updated(child_id, payload)
+      assert %IntegrationEvent{} = event
+      assert event.event_type == :child_updated
+      assert event.source_context == :family
+      assert event.entity_type == :child
+      assert event.entity_id == child_id
+      assert event.payload.first_name == "Emily"
+    end
+
+    test "raises for empty string child_id" do
+      assert_raise ArgumentError, ~r/requires a non-empty child_id string/, fn ->
+        FamilyIntegrationEvents.child_updated("")
+      end
+    end
+  end
+end

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -6,6 +6,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
 
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSchema
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSummarySchema
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.MessageSchema
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ParticipantSchema
   alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
@@ -203,6 +204,86 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
 
       assert Map.has_key?(summary.system_notes, token),
              "Expected system_notes to contain key #{token}, got: #{inspect(summary.system_notes)}"
+    end
+
+    test "populates enrolled_child_names uniformly across parent and provider summary rows" do
+      # Trigger: regression test for a bootstrap asymmetry bug —
+      #          resolve_enrolled_child_names used to filter by the current row's
+      #          user_id, which matched only the parent's row.
+      # Why: event-driven path updates all participant rows of a conversation with
+      #      the same list; bootstrap must do the same to stay consistent after restart.
+      # Outcome: both the parent's and the provider's summary rows carry ["Emma"].
+      parent_user = user_fixture(name: "Sarah Johnson")
+      provider_user = user_fixture(name: "Claudia Wolf")
+
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+      child = insert(:child_schema, first_name: "Emma")
+      insert(:child_guardian_schema, child_id: child.id, guardian_id: parent.id)
+
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      conversation_id = Ecto.UUID.generate()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id,
+        program_id: program.id
+      })
+
+      Repo.insert!(%ParticipantSchema{
+        id: Ecto.UUID.generate(),
+        conversation_id: conversation_id,
+        user_id: parent_user.id,
+        joined_at: now
+      })
+
+      Repo.insert!(%ParticipantSchema{
+        id: Ecto.UUID.generate(),
+        conversation_id: conversation_id,
+        user_id: provider_user.id,
+        joined_at: now
+      })
+
+      Repo.insert!(%EnrolledChildrenSchema{
+        id: Ecto.UUID.generate(),
+        parent_user_id: parent_user.id,
+        program_id: program.id,
+        child_id: child.id,
+        child_first_name: "Emma",
+        inserted_at: now,
+        updated_at: now
+      })
+
+      stop_supervised!(ConversationSummaries)
+
+      bootstrap_name = :"bootstrap_enrolled_children_#{System.unique_integer([:positive])}"
+
+      bootstrap_pid =
+        start_supervised!({ConversationSummaries, name: bootstrap_name},
+          id: :bootstrap_enrolled_children
+        )
+
+      _ = :sys.get_state(bootstrap_pid)
+
+      parent_summary =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^parent_user.id
+          )
+        )
+
+      provider_summary =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^provider_user.id
+          )
+        )
+
+      assert parent_summary.enrolled_child_names == ["Emma"]
+      assert provider_summary.enrolled_child_names == ["Emma"]
     end
   end
 

--- a/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
@@ -2,16 +2,21 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
   use KlassHero.DataCase, async: false
 
   import Ecto.Query
+  import ExUnit.CaptureLog
   import KlassHero.Factory
 
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
   alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
   alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
 
   @test_server_name :enrolled_children_projection_test
+  @enrollment_created_topic "integration:enrollment:enrollment_created"
 
   setup do
     pid = start_supervised!({EnrolledChildren, name: @test_server_name})
+    # Drain bootstrap (runs in handle_continue) so later broadcasts are what we measure
+    _ = :sys.get_state(@test_server_name)
     {:ok, pid: pid}
   end
 
@@ -67,6 +72,102 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
         |> Repo.aggregate(:count)
 
       assert count == 0
+    end
+  end
+
+  describe "handle enrollment_created event" do
+    test "resolves child_first_name from children table on insert" do
+      user = user_fixture(name: "Sarah Johnson")
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      child = insert(:child_schema, first_name: "Emma", last_name: "Johnson")
+      insert(:child_guardian_schema, child_id: child.id, guardian_id: parent.id)
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      enrollment_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :enrollment_created,
+          :enrollment,
+          :enrollment,
+          enrollment_id,
+          %{
+            enrollment_id: enrollment_id,
+            child_id: child.id,
+            parent_id: parent.id,
+            parent_user_id: user.id,
+            program_id: program.id,
+            status: "confirmed"
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        @enrollment_created_topic,
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      row =
+        Repo.one(
+          from(e in EnrolledChildrenSchema,
+            where: e.parent_user_id == ^user.id and e.program_id == ^program.id
+          )
+        )
+
+      assert row != nil
+      assert row.child_id == child.id
+      assert row.child_first_name == "Emma"
+    end
+
+    test "inserts row with nil child_first_name and logs warning when child row is missing" do
+      user = user_fixture(name: "Unknown Parent")
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      missing_child_id = Ecto.UUID.generate()
+      enrollment_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :enrollment_created,
+          :enrollment,
+          :enrollment,
+          enrollment_id,
+          %{
+            enrollment_id: enrollment_id,
+            child_id: missing_child_id,
+            parent_id: parent.id,
+            parent_user_id: user.id,
+            program_id: program.id,
+            status: "confirmed"
+          }
+        )
+
+      log =
+        capture_log(fn ->
+          Phoenix.PubSub.broadcast(
+            KlassHero.PubSub,
+            @enrollment_created_topic,
+            {:integration_event, event}
+          )
+
+          _ = :sys.get_state(@test_server_name)
+        end)
+
+      assert log =~ "child row not found"
+
+      row =
+        Repo.one(
+          from(e in EnrolledChildrenSchema,
+            where: e.parent_user_id == ^user.id and e.program_id == ^program.id
+          )
+        )
+
+      assert row != nil
+      assert row.child_first_name == nil
     end
   end
 

--- a/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
@@ -1,0 +1,77 @@
+defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest do
+  use KlassHero.DataCase, async: false
+
+  import Ecto.Query
+  import KlassHero.Factory
+
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
+  alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
+  alias KlassHero.Repo
+
+  @test_server_name :enrolled_children_projection_test
+
+  setup do
+    pid = start_supervised!({EnrolledChildren, name: @test_server_name})
+    {:ok, pid: pid}
+  end
+
+  describe "bootstrap" do
+    test "projects existing enrollments into messaging_enrolled_children on startup" do
+      user = user_fixture(name: "Sarah Johnson")
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      child = insert(:child_schema, first_name: "Emma", last_name: "Johnson")
+      insert(:child_guardian_schema, child_id: child.id, guardian_id: parent.id)
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      insert(:enrollment_schema,
+        parent_id: parent.id,
+        child_id: child.id,
+        program_id: program.id,
+        status: "confirmed"
+      )
+
+      EnrolledChildren.rebuild(@test_server_name)
+
+      rows =
+        from(e in EnrolledChildrenSchema,
+          where: e.parent_user_id == ^user.id and e.program_id == ^program.id
+        )
+        |> Repo.all()
+
+      assert length(rows) == 1
+      [row] = rows
+      assert row.child_id == child.id
+      assert row.child_first_name == "Emma"
+    end
+
+    test "ignores cancelled enrollments during bootstrap" do
+      user = user_fixture(name: "Bob Smith")
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      child = insert(:child_schema, first_name: "Max")
+      insert(:child_guardian_schema, child_id: child.id, guardian_id: parent.id)
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      insert(:enrollment_schema,
+        parent_id: parent.id,
+        child_id: child.id,
+        program_id: program.id,
+        status: "cancelled"
+      )
+
+      EnrolledChildren.rebuild(@test_server_name)
+
+      count =
+        from(e in EnrolledChildrenSchema, where: e.parent_user_id == ^user.id)
+        |> Repo.aggregate(:count)
+
+      assert count == 0
+    end
+  end
+
+  # Helper to create users with specific names
+  defp user_fixture(attrs) do
+    KlassHero.AccountsFixtures.user_fixture(attrs)
+  end
+end

--- a/test/klass_hero_web/live/messaging_live_helper_test.exs
+++ b/test/klass_hero_web/live/messaging_live_helper_test.exs
@@ -48,6 +48,24 @@ defmodule KlassHeroWeb.MessagingLiveHelperTest do
     end
   end
 
+  describe "enrolled_child_names_for/2" do
+    test "returns [] for :parent variant (suffix is suppressed in title)" do
+      assert MessagingLiveHelper.enrolled_child_names_for(:parent, ["Emma", "Liam"]) == []
+      assert MessagingLiveHelper.enrolled_child_names_for(:parent, []) == []
+    end
+
+    test "passes the names through unchanged for :provider variant" do
+      assert MessagingLiveHelper.enrolled_child_names_for(:provider, ["Emma", "Liam"]) ==
+               ["Emma", "Liam"]
+
+      assert MessagingLiveHelper.enrolled_child_names_for(:provider, []) == []
+    end
+
+    test "passes the names through unchanged for :staff variant" do
+      assert MessagingLiveHelper.enrolled_child_names_for(:staff, ["Emma"]) == ["Emma"]
+    end
+  end
+
   describe "own_message?/2" do
     test "returns true when the message sender is the given user" do
       user_id = Ecto.UUID.generate()

--- a/test/klass_hero_web/live/messaging_live_helper_test.exs
+++ b/test/klass_hero_web/live/messaging_live_helper_test.exs
@@ -4,22 +4,47 @@ defmodule KlassHeroWeb.MessagingLiveHelperTest do
   alias KlassHero.Messaging.Domain.Models.Message
   alias KlassHeroWeb.MessagingLiveHelper
 
-  describe "get_conversation_title/1" do
-    test "returns subject for a program_broadcast conversation with a subject" do
+  describe "get_conversation_title/3" do
+    test "returns parent name with child names for direct conversation with enrolled children" do
+      conversation = %{type: :direct}
+      child_names = ["Emma", "Liam"]
+      other_name = "Sarah Johnson"
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, child_names, other_name) ==
+               "Sarah Johnson for Emma, Liam"
+    end
+
+    test "returns parent name with single child for direct conversation" do
+      conversation = %{type: :direct}
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, ["Emma"], "Sarah Johnson") ==
+               "Sarah Johnson for Emma"
+    end
+
+    test "returns other participant name when no enrolled children" do
+      conversation = %{type: :direct}
+
+      assert MessagingLiveHelper.get_conversation_title(conversation, [], "Sarah Johnson") ==
+               "Sarah Johnson"
+    end
+
+    test "returns subject for program_broadcast with subject" do
       conversation = %{type: :program_broadcast, subject: "Summer Camp Update"}
 
-      assert MessagingLiveHelper.get_conversation_title(conversation) == "Summer Camp Update"
+      assert MessagingLiveHelper.get_conversation_title(conversation, [], nil) ==
+               "Summer Camp Update"
     end
 
-    test "returns 'Program Broadcast' for a program_broadcast conversation without a subject" do
+    test "returns 'Program Broadcast' for broadcast without subject" do
       conversation = %{type: :program_broadcast, subject: nil}
 
-      assert MessagingLiveHelper.get_conversation_title(conversation) == "Program Broadcast"
+      assert MessagingLiveHelper.get_conversation_title(conversation, [], nil) ==
+               "Program Broadcast"
     end
 
-    test "returns 'Conversation' for any other conversation type" do
-      assert MessagingLiveHelper.get_conversation_title(%{type: :direct}) == "Conversation"
-      assert MessagingLiveHelper.get_conversation_title(%{type: :group}) == "Conversation"
+    test "returns 'Conversation' as fallback" do
+      assert MessagingLiveHelper.get_conversation_title(%{type: :direct}, [], nil) ==
+               "Conversation"
     end
   end
 


### PR DESCRIPTION
Closes #551.

## Summary

- Added cross-context event plumbing: Enrollment now emits `enrollment_created` integration events (`create_enrollment.ex`, `enrollment_events.ex`, `enrollment_integration_events.ex`, new `promote_integration_events.ex` driving handler); Family emits `child_created` / `child_updated` (`create_child.ex`, `update_child.ex`, `family_events.ex`, `family_integration_events.ex`, new handler).
- Introduced the `EnrolledChildren` projection (`enrolled_children.ex`, new `messaging_enrolled_children` table via migration) that subscribes to the above integration events plus `conversation_created` and maintains a `(parent_user_id, program_id, child_id)` lookup. Emits an internal `enrolled_children_changed` domain event that the sibling `ConversationSummaries` projection consumes.
- Extended `conversation_summaries` with an `enrolled_child_names` array column and taught `ConversationSummaries` to pick up the new state (`conversation_summary_schema.ex:32`, new handler in `conversation_summaries.ex`, new migration).
- Wired `EnrolledChildren` into `ProjectionSupervisor` (order matters: runs before `ConversationSummaries`, which consumes its emitted event) and added a `for_querying_conversation_summaries` read port + repository (`conversation_summaries_repository.ex`, `for_querying_conversation_summaries.ex`).
- UI: `get_conversation_title/3` renders `\"Parent Name for Child1, Child2\"` for direct conversations with enrolled children (`messaging_live_helper.ex:329-351`); `conversation_card` renders a `for {names}` subtitle line (`messaging_components.ex:48, 87-89, 478`).
- Design notes under `docs/features/` document the feature spec and the implementation plan.

## Review Focus

- **Event-driven projection correctness** — `lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex` subscribes to 5 topics. Pay attention to `project_enrollment_created/1` at line 268 which resolves `child_first_name` from the `children` table via `resolve_child_first_name/1` at line 303 (rather than relying on the event payload, which doesn't carry the name); and `project_conversation_created/1` at line 384 which emits `enrolled_children_changed` only when the conversation is `direct` and has a `program_id`. `re_derive_and_emit/2` at line 408 filters summaries by `program_id`, so direct conversations with `program_id: nil` (ad-hoc DMs) intentionally do not receive enrolled-child subtitles.
- **Raw-string cross-context table queries** — `bootstrap_from_write_tables/0` and `resolve_child_first_name/1` both query Enrollment/Family tables by raw string name (`\"enrollments\"`, `\"children\"`, `\"parents\"`). This is a pragmatic cross-context coupling acknowledged in the module's `@moduledoc` and mirrors the pre-existing pattern in `ChildEnrollmentACL` / `ProgramCatalogACL`. Issue #685 tracks replacing all three uniformly with proper ports.
- **Two-stage integration event promotion** — Enrollment and Family now promote domain events to integration events via new `promote_integration_events.ex` driving handlers (priority 10 on each context's `DomainEventBus`). `application.ex` registers both; verify the payload shapes in `enrollment_integration_events.ex` (`enrollment_created`) and `family_integration_events.ex` (`child_created`, `child_updated`) match what `EnrolledChildren` reads.
- **Bootstrap ordering and idempotency** — `ProjectionSupervisor` lists `EnrolledChildren` before `ConversationSummaries` because the latter consumes events the former emits. Both projections have `handle_continue(:bootstrap)` + retry logic and are idempotent via upsert (`on_conflict: {:replace, [:child_first_name, :updated_at]}` on `EnrolledChildren`).
- **Migration safety** — `priv/repo/migrations/20260417124224_create_messaging_enrolled_children.exs` adds a table with a unique index on `(parent_user_id, program_id, child_id)`; `20260417124227_add_enrolled_child_names_to_conversation_summaries.exs` adds a nullable-defaulting `{:array, :string}` column. Neither locks tables meaningfully on modern Postgres.

## Test Plan

- [x] \`mix precommit\` — 4121 passed, 12 skipped, 18 excluded; no warnings attributable to this branch
- [x] \`mix test test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs\` — bootstrap + event-driven tests pass (4 tests)
- [x] Architecture review via \`/review-architecture\` — 15/18 checks passed, 2 warnings, both tracked in #685
- [x] Test-drive via Tidewave + Playwright — full report at \`docs/reports/test-drive-2026-04-17.md\`. Caught a projection bug (child_first_name stayed nil for pre-existing children) and fixed it in-branch (commit \`8dc87496\`).
- [x] Live event simulation: broadcasting \`enrollment_created\` for a real child populates \`messaging_enrolled_children.child_first_name\` in one step (no \`child_updated\` follow-up required)
- [x] Missing-child case: broadcast with fake \`child_id\` produces a row with \`child_first_name: nil\` and a logged warning
- [x] UI rendering (mobile 375px + desktop 1280px): subtitle \`for Emma, Liam\` renders on conversation card; title \`Thomas Schmidt for Emma, Liam\` renders on the detail page; unicode names (Anna-Maria Schröder-Lindberg, Jean-François, María José, Øyvind) wrap correctly with no horizontal overflow
- [ ] On staging: create an enrollment via the UI for a pre-existing unedited child, then verify \`enrolled_child_names\` appears on the corresponding direct conversation within a few seconds
- [ ] On staging: run \`EnrolledChildren.rebuild/0\` against a stale read table and verify it rebuilds correctly against a populated write set