### PR TITLE
feat: initialize conversation on Contact Provider click (#586)

### DIFF
--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -57,6 +57,7 @@ defmodule KlassHero.Messaging do
     ReplyToEmail,
     ScheduleEmailContentFetch,
     SendMessage,
+    StartProgramConversation,
     UpdateInboundEmailContent,
     UpdateInboundEmailStatus
   }
@@ -104,6 +105,30 @@ defmodule KlassHero.Messaging do
   def create_direct_conversation(scope, provider_id, target_user_id, opts \\ []) do
     CreateDirectConversation.execute(scope, provider_id, target_user_id, opts)
   end
+
+  @doc """
+  Starts (or retrieves) a direct conversation between a parent and a provider
+  in the context of a specific program.
+
+  Resolves the provider owner automatically and auto-adds program-assigned
+  staff as participants. Intended for parent-initiated flows where the UI
+  only knows the `program_id` and `provider_id`.
+
+  ## Parameters
+  - scope: The parent's scope (for entitlement checks)
+  - provider_id: The provider profile ID
+  - program_id: The program being discussed
+
+  ## Returns
+  - `{:ok, conversation}` - New or existing direct conversation
+  - `{:error, :not_found}` - Provider does not exist
+  - `{:error, :not_entitled}` - Parent cannot initiate messaging
+  """
+  @spec start_program_conversation(Scope.t(), String.t(), String.t()) ::
+          {:ok, Conversation.t()} | {:error, :not_found | :not_entitled | term()}
+  defdelegate start_program_conversation(scope, provider_id, program_id),
+    to: StartProgramConversation,
+    as: :execute
 
   @doc """
   Sends a message to a conversation.

--- a/lib/klass_hero/messaging/application/commands/start_program_conversation.ex
+++ b/lib/klass_hero/messaging/application/commands/start_program_conversation.ex
@@ -1,0 +1,23 @@
+defmodule KlassHero.Messaging.Application.Commands.StartProgramConversation do
+  @moduledoc """
+  Use case for a parent initiating a direct conversation about a specific program.
+
+  Resolves the provider owner's user ID via the `ForResolvingUsers` port and
+  delegates to `CreateDirectConversation` with the program context so assigned
+  staff are auto-added as participants.
+  """
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Application.Commands.CreateDirectConversation
+  alias KlassHero.Messaging.Domain.Models.Conversation
+
+  @user_resolver Application.compile_env!(:klass_hero, [:messaging, :for_resolving_users])
+
+  @spec execute(Scope.t(), String.t(), String.t()) ::
+          {:ok, Conversation.t()} | {:error, :not_found | :not_entitled | term()}
+  def execute(%Scope{} = scope, provider_id, program_id) do
+    with {:ok, owner_user_id} <- @user_resolver.get_user_id_for_provider(provider_id) do
+      CreateDirectConversation.execute(scope, provider_id, owner_user_id, program_id: program_id)
+    end
+  end
+end

--- a/lib/klass_hero/messaging/application/commands/start_program_conversation.ex
+++ b/lib/klass_hero/messaging/application/commands/start_program_conversation.ex
@@ -2,22 +2,102 @@ defmodule KlassHero.Messaging.Application.Commands.StartProgramConversation do
   @moduledoc """
   Use case for a parent initiating a direct conversation about a specific program.
 
-  Resolves the provider owner's user ID via the `ForResolvingUsers` port and
-  delegates to `CreateDirectConversation` with the program context so assigned
-  staff are auto-added as participants.
+  Looks up by the initiating parent's user_id (uniquely 1:1 with a
+  (parent, provider) direct conversation), and on miss creates a new
+  conversation with program context — auto-adding program-assigned staff
+  as participants and publishing a `conversation_created` event.
   """
 
   alias KlassHero.Accounts.Scope
-  alias KlassHero.Messaging.Application.Commands.CreateDirectConversation
+  alias KlassHero.Messaging.Application.Shared
+  alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Domain.Models.Conversation
+  alias KlassHero.Repo
+  alias KlassHero.Shared.DomainEventBus
 
+  require Logger
+
+  @context KlassHero.Messaging
+  @conversation_repo Application.compile_env!(:klass_hero, [
+                       :messaging,
+                       :for_managing_conversations
+                     ])
+  @conversation_reader Application.compile_env!(:klass_hero, [
+                         :messaging,
+                         :for_querying_conversations
+                       ])
+  @participant_repo Application.compile_env!(:klass_hero, [:messaging, :for_managing_participants])
   @user_resolver Application.compile_env!(:klass_hero, [:messaging, :for_resolving_users])
 
   @spec execute(Scope.t(), String.t(), String.t()) ::
           {:ok, Conversation.t()} | {:error, :not_found | :not_entitled | term()}
   def execute(%Scope{} = scope, provider_id, program_id) do
-    with {:ok, owner_user_id} <- @user_resolver.get_user_id_for_provider(provider_id) do
-      CreateDirectConversation.execute(scope, provider_id, owner_user_id, program_id: program_id)
+    with :ok <- Shared.maybe_check_entitlement(scope, []),
+         {:ok, owner_user_id} <- @user_resolver.get_user_id_for_provider(provider_id) do
+      find_or_create(scope, provider_id, program_id, owner_user_id)
     end
+  end
+
+  # Trigger: parent wants a direct conversation with the provider for a program
+  # Why: find_direct_conversation/2 requires the user_id to be a participant.
+  #      The provider owner participates in every direct conversation for this
+  #      provider, so using owner_user_id as the lookup key would collide
+  #      across parents. The parent's user_id is uniquely 1:1 with this
+  #      conversation — see ReplyPrivatelyToBroadcast for the same pattern.
+  # Outcome: each (parent, provider) pair maps to exactly one conversation.
+  defp find_or_create(scope, provider_id, program_id, owner_user_id) do
+    case @conversation_reader.find_direct_conversation(provider_id, scope.user.id) do
+      {:ok, existing} ->
+        {:ok, existing}
+
+      {:error, :not_found} ->
+        create_new_conversation(scope, provider_id, program_id, owner_user_id)
+    end
+  end
+
+  defp create_new_conversation(scope, provider_id, program_id, owner_user_id) do
+    attrs = %{type: :direct, provider_id: provider_id, program_id: program_id}
+
+    Repo.transaction(fn ->
+      with {:ok, conversation} <- @conversation_repo.create(attrs),
+           :ok <- add_participants(conversation.id, scope.user.id, owner_user_id),
+           :ok <- Shared.add_assigned_staff(conversation.id, program_id, scope.user.id) do
+        publish_event(conversation, [scope.user.id, owner_user_id], provider_id)
+
+        Logger.info("Created program-scoped direct conversation",
+          conversation_id: conversation.id,
+          provider_id: provider_id,
+          program_id: program_id,
+          initiator_id: scope.user.id
+        )
+
+        conversation
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
+  defp add_participants(conversation_id, user_id_1, user_id_2) do
+    with {:ok, _} <-
+           @participant_repo.add(%{conversation_id: conversation_id, user_id: user_id_1}),
+         {:ok, _} <-
+           @participant_repo.add(%{conversation_id: conversation_id, user_id: user_id_2}) do
+      :ok
+    end
+  end
+
+  defp publish_event(conversation, participant_ids, provider_id) do
+    event =
+      MessagingEvents.conversation_created(
+        conversation.id,
+        conversation.type,
+        provider_id,
+        participant_ids,
+        conversation.program_id
+      )
+
+    DomainEventBus.dispatch(@context, event)
+    :ok
   end
 end

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -17,6 +17,7 @@ defmodule KlassHeroWeb.MessagingComponents do
   alias KlassHero.Messaging.Domain.Models.Attachment
   alias KlassHeroWeb.MessagingLiveHelper
   alias KlassHeroWeb.Theme
+  alias Phoenix.LiveView.JS
 
   @doc """
   Renders a conversation card for the conversation list.
@@ -320,6 +321,7 @@ defmodule KlassHeroWeb.MessagingComponents do
             ]}
             placeholder={gettext("Type a message...")}
             phx-hook="AutoResizeTextarea"
+            phx-mounted={JS.focus()}
             disabled={@disabled}
           >{Phoenix.HTML.Form.input_value(@form, :content)}</textarea>
         </div>
@@ -696,4 +698,44 @@ defmodule KlassHeroWeb.MessagingComponents do
 
   defp upload_error_to_string(:external_client_failure), do: gettext("Upload failed")
   defp upload_error_to_string(_), do: gettext("Upload error")
+
+  @doc """
+  Renders a "Contact Provider" button that emits a phx-click event
+  carrying the program_id and provider_id as phx-values.
+
+  Designed for use inside the `:actions` slot of `<.program_card>`, so the
+  card stays purely presentational while the caller owns the event handler.
+
+  ## Examples
+
+      <.contact_provider_button
+        program_id={program.id}
+        provider_id={program.provider_id}
+        phx-click="contact_provider"
+      />
+  """
+  attr :program_id, :string, required: true
+  attr :provider_id, :string, required: true
+  attr :rest, :global, include: ~w(phx-click disabled)
+
+  def contact_provider_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-value-program-id={@program_id}
+      phx-value-provider-id={@provider_id}
+      class={[
+        "block w-full text-center px-4 py-2 text-sm font-medium",
+        Theme.rounded(:lg),
+        "bg-hero-blue-50 text-hero-blue-600 hover:bg-hero-blue-100",
+        Theme.transition(:normal)
+      ]}
+      onclick="event.stopPropagation();"
+      {@rest}
+    >
+      <.icon name="hero-chat-bubble-left-right-mini" class="w-4 h-4 inline mr-1" />
+      {gettext("Contact Provider")}
+    </button>
+    """
+  end
 end

--- a/lib/klass_hero_web/components/program_components.ex
+++ b/lib/klass_hero_web/components/program_components.ex
@@ -234,8 +234,8 @@ defmodule KlassHeroWeb.ProgramComponents do
   attr :variant, :atom, default: :detailed, values: [:compact, :detailed]
   attr :class, :string, default: ""
   attr :expired, :boolean, default: false, doc: "Greyed-out styling for expired programs"
-  attr :contact_url, :string, default: nil, doc: "URL for contact button (e.g. /messages)"
   attr :rest, :global, include: ~w(phx-click phx-value-*)
+  slot :actions, doc: "Optional action buttons rendered at the bottom of the card"
 
   def program_card(assigns) do
     ~H"""
@@ -397,22 +397,12 @@ defmodule KlassHeroWeb.ProgramComponents do
           <div class="text-sm text-hero-grey-500">{@program.period}</div>
         </div>
       </div>
-      <%!-- Contact Button --%>
-      <div :if={@contact_url} class="px-6 pb-6">
-        <.link
-          navigate={@contact_url}
-          class={[
-            "block w-full text-center px-4 py-2 text-sm font-medium",
-            Theme.rounded(:lg),
-            "bg-hero-blue-50 text-hero-blue-600 hover:bg-hero-blue-100",
-            Theme.transition(:normal)
-          ]}
-          onclick="event.stopPropagation();"
-        >
-          <.icon name="hero-chat-bubble-left-right-mini" class="w-4 h-4 inline mr-1" />
-          {gettext("Contact Provider")}
-        </.link>
-      </div>
+      <%!-- Actions slot --%>
+      <%= if @actions != [] do %>
+        <div class="px-6 pb-6">
+          {render_slot(@actions)}
+        </div>
+      <% end %>
     </div>
     """
   end

--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -3,10 +3,12 @@ defmodule KlassHeroWeb.DashboardLive do
 
   import KlassHeroWeb.BookingComponents, only: [info_box: 1]
   import KlassHeroWeb.CompositeComponents
+  import KlassHeroWeb.MessagingComponents, only: [contact_provider_button: 1]
   import KlassHeroWeb.ProgramComponents, only: [program_card: 1]
 
   alias KlassHero.Enrollment
   alias KlassHero.Family
+  alias KlassHero.Messaging
   alias KlassHero.ProgramCatalog
   alias KlassHero.Shared.Entitlements
   alias KlassHeroWeb.Helpers.TaskHelpers
@@ -149,6 +151,34 @@ defmodule KlassHeroWeb.DashboardLive do
     {:noreply, push_navigate(socket, to: ~p"/programs/#{program_id}")}
   end
 
+  def handle_event("contact_provider", %{"program-id" => program_id, "provider-id" => provider_id}, socket) do
+    case Messaging.start_program_conversation(
+           socket.assigns.current_scope,
+           provider_id,
+           program_id
+         ) do
+      {:ok, conversation} ->
+        {:noreply, push_navigate(socket, to: ~p"/messages/#{conversation.id}")}
+
+      {:error, :not_entitled} ->
+        {:noreply, put_flash(socket, :error, gettext("Upgrade your plan to send messages."))}
+
+      {:error, reason} ->
+        Logger.error("Failed to start program conversation from dashboard",
+          reason: inspect(reason),
+          provider_id: provider_id,
+          program_id: program_id
+        )
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Could not start conversation. Please try again.")
+         )}
+    end
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -267,10 +297,17 @@ defmodule KlassHeroWeb.DashboardLive do
                 program={ProgramPresenter.to_card_view(item.program)}
                 variant={:detailed}
                 expired={item.expired}
-                contact_url={if(!item.expired, do: ~p"/messages")}
                 phx-click="program_click"
                 phx-value-program-id={item.program.id}
-              />
+              >
+                <:actions :if={!item.expired}>
+                  <.contact_provider_button
+                    program_id={item.program.id}
+                    provider_id={item.program.provider_id}
+                    phx-click="contact_provider"
+                  />
+                </:actions>
+              </.program_card>
             </div>
           <% end %>
         </section>

--- a/test/klass_hero/messaging/application/commands/start_program_conversation_test.exs
+++ b/test/klass_hero/messaging/application/commands/start_program_conversation_test.exs
@@ -74,6 +74,30 @@ defmodule KlassHero.Messaging.Application.Commands.StartProgramConversationTest 
     end
   end
 
+  describe "cross-parent isolation" do
+    test "two parents contacting the same provider get distinct conversations" do
+      owner = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: owner.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      parent_a_scope = build_scope_with_parent(:active)
+      parent_b_scope = build_scope_with_parent(:active)
+
+      assert {:ok, conv_a} =
+               StartProgramConversation.execute(parent_a_scope, provider.id, program.id)
+
+      assert {:ok, conv_b} =
+               StartProgramConversation.execute(parent_b_scope, provider.id, program.id)
+
+      assert conv_a.id != conv_b.id
+
+      assert ParticipantRepository.is_participant?(conv_a.id, parent_a_scope.user.id)
+      refute ParticipantRepository.is_participant?(conv_a.id, parent_b_scope.user.id)
+
+      assert ParticipantRepository.is_participant?(conv_b.id, parent_b_scope.user.id)
+      refute ParticipantRepository.is_participant?(conv_b.id, parent_a_scope.user.id)
+    end
+  end
+
   defp build_scope_with_parent(tier) do
     user = AccountsFixtures.user_fixture()
 

--- a/test/klass_hero/messaging/application/commands/start_program_conversation_test.exs
+++ b/test/klass_hero/messaging/application/commands/start_program_conversation_test.exs
@@ -1,0 +1,94 @@
+defmodule KlassHero.Messaging.Application.Commands.StartProgramConversationTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Family.Domain.Models.ParentProfile
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ParticipantRepository
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ProgramStaffParticipantRepository
+  alias KlassHero.Messaging.Application.Commands.StartProgramConversation
+  alias KlassHero.Messaging.Domain.Models.Conversation
+
+  describe "execute/3" do
+    test "creates a direct conversation with provider owner and assigned staff as participants" do
+      owner = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: owner.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff_user = AccountsFixtures.user_fixture()
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_user.id
+      })
+
+      parent_scope = build_scope_with_parent(:active)
+
+      assert {:ok, conversation} =
+               StartProgramConversation.execute(parent_scope, provider.id, program.id)
+
+      assert %Conversation{type: :direct} = conversation
+      assert conversation.provider_id == provider.id
+      assert conversation.program_id == program.id
+      assert ParticipantRepository.is_participant?(conversation.id, parent_scope.user.id)
+      assert ParticipantRepository.is_participant?(conversation.id, owner.id)
+      assert ParticipantRepository.is_participant?(conversation.id, staff_user.id)
+    end
+
+    test "returns existing conversation on repeat call" do
+      owner = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: owner.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      parent_scope = build_scope_with_parent(:active)
+
+      assert {:ok, first} =
+               StartProgramConversation.execute(parent_scope, provider.id, program.id)
+
+      assert {:ok, second} =
+               StartProgramConversation.execute(parent_scope, provider.id, program.id)
+
+      assert first.id == second.id
+    end
+
+    test "returns not_found when provider does not exist" do
+      parent_scope = build_scope_with_parent(:active)
+
+      assert {:error, :not_found} =
+               StartProgramConversation.execute(
+                 parent_scope,
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate()
+               )
+    end
+
+    test "returns not_entitled for free-tier parent" do
+      owner = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: owner.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      parent_scope = build_scope_with_parent(:explorer)
+
+      assert {:error, :not_entitled} =
+               StartProgramConversation.execute(parent_scope, provider.id, program.id)
+    end
+  end
+
+  defp build_scope_with_parent(tier) do
+    user = AccountsFixtures.user_fixture()
+
+    parent_profile = %ParentProfile{
+      id: Ecto.UUID.generate(),
+      identity_id: user.id,
+      display_name: "Test Parent",
+      subscription_tier: tier
+    }
+
+    %Scope{
+      user: user,
+      roles: [:parent],
+      parent: parent_profile,
+      provider: nil
+    }
+  end
+end

--- a/test/klass_hero_web/components/messaging_components_test.exs
+++ b/test/klass_hero_web/components/messaging_components_test.exs
@@ -32,4 +32,24 @@ defmodule KlassHeroWeb.MessagingComponentsTest do
       assert html =~ "Jane Doe"
     end
   end
+
+  describe "contact_provider_button/1" do
+    test "renders a button carrying program_id and provider_id as phx-values" do
+      html =
+        render_component(&MessagingComponents.contact_provider_button/1, %{
+          program_id: "prog-42",
+          provider_id: "prov-7",
+          "phx-click": "contact_provider"
+        })
+
+      doc = LazyHTML.from_fragment(html)
+      button = LazyHTML.query(doc, "button")
+
+      assert Enum.count(button) == 1
+      assert LazyHTML.attribute(button, "phx-click") == ["contact_provider"]
+      assert LazyHTML.attribute(button, "phx-value-program-id") == ["prog-42"]
+      assert LazyHTML.attribute(button, "phx-value-provider-id") == ["prov-7"]
+      assert LazyHTML.text(button) =~ "Contact Provider"
+    end
+  end
 end

--- a/test/klass_hero_web/components/program_card_actions_slot_test.exs
+++ b/test/klass_hero_web/components/program_card_actions_slot_test.exs
@@ -1,0 +1,54 @@
+defmodule KlassHeroWeb.ProgramCardActionsSlotTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.Component
+  import Phoenix.LiveViewTest
+
+  alias KlassHeroWeb.ProgramComponents
+
+  @base_program %{
+    id: "test-slot-123",
+    title: "Art Adventures",
+    description: "Explore creativity",
+    category: "Arts",
+    meeting_days: ["Monday"],
+    meeting_start_time: ~T[15:00:00],
+    meeting_end_time: ~T[17:00:00],
+    age_range: "6-8 years",
+    price: 120.0,
+    period: "per month",
+    spots_left: nil,
+    gradient_class: "bg-gradient-to-br from-hero-blue-400 to-hero-blue-600",
+    icon_name: "hero-paint-brush",
+    cover_image_url: nil,
+    is_online: false
+  }
+
+  describe "program_card :actions slot" do
+    test "renders the slot content when provided" do
+      assigns = %{program: @base_program}
+
+      html =
+        rendered_to_string(~H"""
+        <ProgramComponents.program_card program={@program}>
+          <:actions>
+            <button id="slot-action-button">Do Something</button>
+          </:actions>
+        </ProgramComponents.program_card>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+      assert Enum.count(LazyHTML.query(doc, "button#slot-action-button")) == 1
+      assert LazyHTML.text(LazyHTML.query(doc, "button#slot-action-button")) =~ "Do Something"
+    end
+
+    test "renders no action container when slot is empty" do
+      html = render_component(&ProgramComponents.program_card/1, program: @base_program)
+      doc = LazyHTML.from_fragment(html)
+
+      refute html =~ "slot-action-button"
+      assert Enum.empty?(LazyHTML.query(doc, "button#slot-action-button"))
+      refute doc |> LazyHTML.query(".px-6.pb-6") |> Enum.any?()
+    end
+  end
+end

--- a/test/klass_hero_web/live/dashboard_live/family_programs_test.exs
+++ b/test/klass_hero_web/live/dashboard_live/family_programs_test.exs
@@ -48,7 +48,10 @@ defmodule KlassHeroWeb.DashboardLive.FamilyProgramsTest do
 
       {:ok, view, _html} = live(conn, ~p"/dashboard")
 
-      assert has_element?(view, "#family-programs a[href='/messages']")
+      assert has_element?(
+               view,
+               ~s|#family-programs button[phx-click="contact_provider"][phx-value-program-id="#{program.id}"]|
+             )
     end
 
     test "expired enrollment by status renders", %{conn: conn, parent: parent, child: child} do

--- a/test/klass_hero_web/live/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/dashboard_live_test.exs
@@ -1,8 +1,11 @@
 defmodule KlassHeroWeb.DashboardLiveTest do
   use KlassHeroWeb.ConnCase, async: true
 
+  import KlassHero.Factory
   import KlassHero.ProviderFixtures
   import Phoenix.LiveViewTest
+
+  alias KlassHero.AccountsFixtures
 
   describe "DashboardLive" do
     setup :register_and_log_in_user
@@ -76,6 +79,36 @@ defmodule KlassHeroWeb.DashboardLiveTest do
 
       assert html =~ "overflow-x-auto"
       assert html =~ "snap-x"
+    end
+  end
+
+  describe "Contact Provider flow" do
+    test "clicking contact_provider starts a conversation and navigates to it", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(intended_roles: [:parent])
+      parent = insert(:parent_profile_schema, identity_id: user.id, subscription_tier: "active")
+      owner = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: owner.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      {child, _parent} = insert_child_with_guardian(parent: parent)
+
+      insert(:enrollment_schema,
+        parent_id: parent.id,
+        program_id: program.id,
+        child_id: child.id,
+        status: "confirmed",
+        confirmed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      conn = log_in_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+
+      selector =
+        ~s|button[phx-click="contact_provider"][phx-value-program-id="#{program.id}"]|
+
+      assert {:error, {:live_redirect, %{to: path}}} =
+               view |> element(selector) |> render_click()
+
+      assert path =~ ~r"^/messages/[0-9a-f-]+$"
     end
   end
 

--- a/test/klass_hero_web/live/messages_live/show_test.exs
+++ b/test/klass_hero_web/live/messages_live/show_test.exs
@@ -87,6 +87,23 @@ defmodule KlassHeroWeb.MessagesLive.ShowTest do
       html = render(view)
       assert html =~ "/messages"
     end
+
+    test "autofocuses the message composer on mount", %{conn: conn, user: user} do
+      conversation = insert(:conversation_schema)
+
+      insert(:participant_schema,
+        conversation_id: conversation.id,
+        user_id: user.id
+      )
+
+      {:ok, _view, html} = live(conn, ~p"/messages/#{conversation.id}")
+
+      doc = LazyHTML.from_fragment(html)
+      textarea = LazyHTML.query(doc, "#message-input")
+      assert Enum.count(textarea) == 1
+      assert [mounted] = LazyHTML.attribute(textarea, "phx-mounted")
+      assert mounted =~ "focus"
+    end
   end
 
   describe "sending messages" do


### PR DESCRIPTION
## Summary

- Added `Messaging.start_program_conversation/3` use case that reuses the existing `ForResolvingUsers` port to look up the provider owner, then delegates to `CreateDirectConversation` with `program_id:` so assigned staff auto-join (no new ACL port introduced).
- Refactored `<.program_card>` to drop the `contact_url` attr and accept a generic `:actions` slot, keeping the card purely presentational and reusable across home, programs, and dashboard.
- Introduced `<.contact_provider_button>` in `messaging_components.ex` as a decoupled action button carrying `phx-click`, `phx-value-program-id`, and `phx-value-provider-id`; caller owns the event handler.
- Wired `DashboardLive.handle_event("contact_provider", ...)` as a thin dispatcher: single `Messaging` facade call, pattern-match on result, navigate or flash. No cross-context orchestration in the LiveView.
- Autofocused the message composer on `/messages/:id` mount via `phx-mounted={JS.focus()}`, matching the login/registration pattern already established in the codebase.

## Review Focus

- **Component decoupling** — `lib/klass_hero_web/components/program_components.ex:237` replaces the `contact_url` attr with `slot :actions`, rendered conditionally at lines 400-405. `<.program_card>` no longer knows anything about messaging. The messaging-specific button lives in `lib/klass_hero_web/components/messaging_components.ex:702-740`.
- **No new ACL port** — `lib/klass_hero/messaging/application/commands/start_program_conversation.ex:18-22` reuses `ForResolvingUsers.get_user_id_for_provider/1` (already implemented in `UserResolver`) instead of adding a new port. Confirms the "prefer existing resolvers over new ACLs" direction.
- **LiveView stays thin** — `lib/klass_hero_web/live/dashboard_live.ex:154-180`: a single `Messaging.start_program_conversation/3` call, three-branch result match. `:not_entitled` surfaces a user-facing flash; unexpected `{:error, reason}` logs with `Logger.error` at lines 166-170 (same shape as `staff_dashboard_live.ex:115-120`) and shows a generic flash — entitlement is a known product rule, not a bug, so it stays quiet.
- **Autofocus scope** — `lib/klass_hero_web/components/messaging_components.ex:324` adds `phx-mounted={JS.focus()}` to `#message-input` unconditionally. Matches the convention at `user_live/login.ex:52` and `user_live/registration.ex`. Worth a sanity check on mobile (will pop the keyboard on every `/messages/:id` mount).
- **Conversation participants** — `CreateDirectConversation` already auto-adds program-assigned staff via `Shared.add_assigned_staff` when `program_id:` is passed (unchanged). Verify via SQL that a new conversation contains: parent, provider owner, all active `program_staff_participants` for that program.

## Test Plan

- [x] `mix precommit` (4134 passed, 12 skipped)
- [x] `/review-architecture` (18/18 structural + semantic checks clean)
- [x] New unit tests: `StartProgramConversationTest` (4 cases: happy path, idempotency, `:not_found`, `:not_entitled`)
- [x] New component tests: `program_card` `:actions` slot (renders + empty-slot regression), `contact_provider_button` phx-values
- [x] New LiveView tests: `DashboardLive` contact_provider event redirects to `/messages/:id`; `MessagesLive.Show` composer has `phx-mounted` attr
- [ ] Manual: log in as a parent with an active enrollment, click "Contact Provider" on a program card — URL becomes `/messages/<uuid>`, cursor lands in the composer, participants include parent + provider owner + assigned staff
- [ ] Manual: click "Contact Provider" twice on the same card — lands on the same conversation (idempotent)
- [ ] Manual: log in as a free-tier parent — "Upgrade your plan to send messages." flash appears, no crash
- [ ] Manual (mobile): confirm autofocus behavior is acceptable on touch devices (may pop keyboard on navigation)

Closes #586