### PR TITLE
feat: per-session view in provider dashboard (#373)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -58,6 +58,7 @@ alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramR
 alias KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProgramStaffAssignmentRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProviderProfileRepository
+alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMemberRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.VerificationDocumentRepository
@@ -287,6 +288,7 @@ config :klass_hero, :provider,
   for_querying_staff_members: StaffMemberRepository,
   for_storing_program_staff_assignments: ProgramStaffAssignmentRepository,
   for_querying_program_staff_assignments: ProgramStaffAssignmentRepository,
+  for_querying_session_details: SessionDetailsRepository,
   for_querying_session_stats: SessionStatsRepository,
   for_resolving_session_stats: ParticipationSessionStatsACL
 

--- a/docs/superpowers/plans/2026-04-18-per-session-view-implementation.md
+++ b/docs/superpowers/plans/2026-04-18-per-session-view-implementation.md
@@ -1,0 +1,2303 @@
+# Per-Session View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the per-session view in the provider dashboard (issue #373) by introducing a new `ProviderSessionDetails` projection in the Provider context, surfaced through a new port, a thin use case, and a `sessions_modal` component.
+
+**Architecture:** Event-driven projection maintained by a supervised GenServer in the Provider context, subscribing to Participation + Provider integration events. Bootstraps on every boot via a cross-table SELECT. Read is a single-table query on `provider_session_details`. UI reuses `participation_status` with a new `:cancelled` variant.
+
+**Tech Stack:** Elixir 1.20, Phoenix 1.8, LiveView 1.1, Ecto + PostgreSQL, Phoenix.PubSub, Oban (indirect), Tidewave MCP (for all interactive verification), Tailwind CSS.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-per-session-view-projection-design.md`
+
+**Branch:** `feat/373-per-session-view`
+
+---
+
+## Execution Directives (apply to every task)
+
+1. **Tidewave MCP is the default tool for all interactive verification.** Prefer `project_eval`, `execute_sql_query`, `get_logs`, `get_ecto_schemas`, `get_docs`, `get_source_location` over bash/iex. When the plan says "verify" or "inspect", that means Tidewave.
+2. **Strict TDD red-green.** Every implementation task begins with a failing test that's *verified* to fail. Implementation follows to make it pass — and only that test. No speculative code.
+3. **Elixir conventions** — apply `idiomatic-elixir` (pattern matching, pipes, guards, no `String.to_atom/1` on input, struct access not bracket access) for every `.ex`/`.exs` file. Apply `elixir-ecto-patterns` for migrations, schemas, queries.
+4. **Commit after every green test** — the project uses conventional commits (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`). Commit messages should not reference Claude.
+5. **Run `mix precommit`** at the end of a task cluster (the plan marks explicit checkpoints). The full suite must pass before marking done.
+6. **Before opening a PR** — run `/review-architecture` (boundary-checker + architecture-reviewer) and resolve findings. Expected flag: bootstrap cross-context reads; mitigation is per-context helpers.
+
+---
+
+## Pre-flight Facts (resolved during plan writing)
+
+- `integration:participation:session_cancelled` **does not exist**. Must be added: factory in `ParticipationIntegrationEvents`, promotion handler in `PromoteIntegrationEvents`, and emission from the domain when a session is cancelled.
+- `ProjectionSupervisor` lives at `lib/klass_hero/projection_supervisor.ex` — a centralized supervisor for all projections. The new projection is added to its `children` list.
+- `session_created` payload carries `{session_id, program_id, session_date, start_time, end_time}` — **not** `program_title` or `provider_id`. The projection handler resolves these via a read of the `programs` table inside the Provider repo, same as the bootstrap query. This is the one acknowledged cross-context read, symmetric with bootstrap.
+- Staff integration events (`staff_assigned_to_program`, `staff_unassigned_from_program`) carry `staff_member_id`, `provider_id`, `program_id`, `staff_user_id`, `assigned_at`/`unassigned_at` — **not** `staff_member_name`. Handler reads the name from `staff_members` (same Provider context — in-context, fine).
+
+---
+
+## File Structure Map
+
+**New files:**
+
+| Path | Responsibility |
+|---|---|
+| `lib/klass_hero/provider/domain/read_models/session_detail.ex` | DTO returned to the web layer |
+| `lib/klass_hero/provider/domain/ports/for_querying_session_details.ex` | Port behaviour |
+| `lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_session_detail_schema.ex` | Ecto schema for `provider_session_details` |
+| `lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper.ex` | Schema ↔ DTO |
+| `lib/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository.ex` | Implements the port |
+| `lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex` | Projection GenServer |
+| `lib/klass_hero/provider/application/queries/list_program_sessions.ex` | Use case |
+| `priv/repo/migrations/<ts>_create_provider_session_details.exs` | Migration |
+| `test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs` | Unit tests for handlers |
+| `test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs` | Bootstrap + rebuild tests |
+| `test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs` | Repository tests |
+| `test/klass_hero/provider/application/queries/list_program_sessions_test.exs` | Use-case test |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `lib/klass_hero/participation/domain/events/participation_integration_events.ex` | Add `session_cancelled/3` factory |
+| `lib/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events.ex` | Add `session_cancelled` handler clause |
+| `lib/klass_hero/participation/...` (cancel use case) | Emit `session_cancelled` domain event on cancellation — find actual file via Task 1 |
+| `lib/klass_hero/projection_supervisor.ex` | Add `ProviderSessionDetails` to children |
+| `config/config.exs` | Wire `for_querying_session_details` under `:provider` key |
+| `config/test.exs` | (if needed) bind test adapter |
+| `lib/klass_hero_web/components/participation_components.ex` | Extend `participation_status` with `:cancelled` clause |
+| `lib/klass_hero_web/components/provider_components.ex` | Add `sessions_modal/1`; add Sessions button to `programs_table` Actions |
+| `lib/klass_hero_web/live/provider_live/dashboard_live.ex` | Add `:sessions_modal` assign + `view_sessions`/`close_sessions` handlers |
+| `priv/gettext/de/LC_MESSAGES/default.po` | German translations for new strings |
+| `priv/gettext/default.pot` | Regenerate via `mix gettext.extract` |
+
+---
+
+## Task 0: Preflight — Tidewave & Branch Check
+
+**Goal:** Confirm the dev env is usable before touching code.
+
+- [ ] **Step 1:** Confirm the Phoenix server is up and Tidewave is reachable.
+
+Via Tidewave:
+
+```elixir
+# Tidewave: project_eval
+Application.started_applications() |> Enum.find(fn {app, _, _} -> app == :klass_hero end)
+```
+
+Expected: a tuple `{:klass_hero, _description, _version}`. If nil, alert the user that Tidewave/Phoenix is not running before proceeding.
+
+- [ ] **Step 2:** Confirm current branch.
+
+```bash
+git branch --show-current
+```
+
+Expected: `feat/373-per-session-view`.
+
+- [ ] **Step 3:** Confirm baseline precommit is clean.
+
+```bash
+mix precommit
+```
+
+Expected: all green. If not, stop and fix before starting work.
+
+---
+
+## Task 1: Add `session_cancelled` Integration Event
+
+**Files:**
+- Modify: `lib/klass_hero/participation/domain/events/participation_integration_events.ex`
+- Test: `test/klass_hero/participation/domain/events/participation_integration_events_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/klass_hero/participation/domain/events/participation_integration_events_test.exs`:
+
+```elixir
+describe "session_cancelled/3" do
+  test "creates a session_cancelled integration event" do
+    event = ParticipationIntegrationEvents.session_cancelled("session-1", %{program_id: "program-1"})
+
+    assert event.event_type == :session_cancelled
+    assert event.source_context == :participation
+    assert event.entity_type == :session
+    assert event.entity_id == "session-1"
+    assert event.payload.session_id == "session-1"
+    assert event.payload.program_id == "program-1"
+  end
+
+  test "raises when session_id is nil" do
+    assert_raise ArgumentError, fn ->
+      ParticipationIntegrationEvents.session_cancelled(nil, %{program_id: "p"})
+    end
+  end
+
+  test "raises when program_id is missing" do
+    assert_raise ArgumentError, fn ->
+      ParticipationIntegrationEvents.session_cancelled("session-1", %{})
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+mix test test/klass_hero/participation/domain/events/participation_integration_events_test.exs --only describe:"session_cancelled/3"
+```
+
+Expected: FAIL with `UndefinedFunctionError` or similar (function does not exist). If you get a different failure, stop and investigate.
+
+- [ ] **Step 3: Add the factory function**
+
+In `lib/klass_hero/participation/domain/events/participation_integration_events.ex`, add above the last `end`:
+
+```elixir
+# ---------------------------------------------------------------------------
+# session_cancelled (entity type: :session)
+# ---------------------------------------------------------------------------
+
+@typedoc "Payload for `:session_cancelled` events."
+@type session_cancelled_payload :: %{
+        required(:session_id) => String.t(),
+        required(:program_id) => String.t(),
+        optional(atom()) => term()
+      }
+
+@doc """
+Creates a `session_cancelled` integration event.
+
+Published when a session is cancelled (e.g. provider cancels a scheduled session).
+"""
+def session_cancelled(session_id, payload \\ %{}, opts \\ [])
+
+def session_cancelled(session_id, %{program_id: _} = payload, opts)
+    when is_binary(session_id) and byte_size(session_id) > 0 do
+  base_payload = %{session_id: session_id}
+
+  IntegrationEvent.new(
+    :session_cancelled,
+    @source_context,
+    :session,
+    session_id,
+    Map.merge(payload, base_payload),
+    opts
+  )
+end
+
+def session_cancelled(session_id, payload, _opts) when is_binary(session_id) and byte_size(session_id) > 0 do
+  missing = [:program_id] -- Map.keys(payload)
+
+  raise ArgumentError,
+        "session_cancelled missing required payload keys: #{inspect(missing)}"
+end
+
+def session_cancelled(session_id, _payload, _opts) do
+  raise ArgumentError,
+        "session_cancelled/3 requires a non-empty session_id string, got: #{inspect(session_id)}"
+end
+```
+
+Also add `:session_cancelled` to the moduledoc event list near the top.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+mix test test/klass_hero/participation/domain/events/participation_integration_events_test.exs --only describe:"session_cancelled/3"
+```
+
+Expected: 3 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/klass_hero/participation/domain/events/participation_integration_events.ex \
+        test/klass_hero/participation/domain/events/participation_integration_events_test.exs
+git commit -m "feat: add session_cancelled integration event"
+```
+
+---
+
+## Task 2: Promote `session_cancelled` Domain Event
+
+**Files:**
+- Modify: `lib/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events.ex`
+- Test: `test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs`
+
+- [ ] **Step 1:** Find the emission path. Use Tidewave:
+
+```elixir
+# Tidewave: project_eval
+KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents
+|> Code.fetch_docs()
+```
+
+Verify the module handles each session lifecycle event via a `handle/1` clause.
+
+- [ ] **Step 2: Write the failing test**
+
+Append a describe block to `promote_integration_events_test.exs` mirroring the existing `session_completed` test. Structure:
+
+```elixir
+describe "handle/1 for :session_cancelled" do
+  test "promotes to integration event and publishes" do
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, "integration:participation:session_cancelled")
+
+    event = %DomainEvent{
+      event_type: :session_cancelled,
+      aggregate_id: "session-42",
+      payload: %{program_id: "program-1"}
+    }
+
+    assert :ok = PromoteIntegrationEvents.handle(event)
+
+    assert_receive {:integration_event, %IntegrationEvent{event_type: :session_cancelled} = ie}, 200
+    assert ie.entity_id == "session-42"
+    assert ie.payload.program_id == "program-1"
+  end
+end
+```
+
+(Match the existing file's imports/aliases — copy from a neighboring describe block.)
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+mix test test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs -t describe:"handle/1 for :session_cancelled"
+```
+
+Expected: FAIL because no clause matches `:session_cancelled`.
+
+- [ ] **Step 4: Add the handler clause**
+
+In `promote_integration_events.ex`, add after the `session_completed` clause:
+
+```elixir
+def handle(%DomainEvent{event_type: :session_cancelled} = event) do
+  # Trigger: session_cancelled domain event dispatched when a session is cancelled
+  # Why: downstream projections (e.g. ProviderSessionDetails) must mark it cancelled
+  # Outcome: best-effort publish; swallow failures since cancellation is already persisted
+  ParticipationIntegrationEvents.session_cancelled(event.aggregate_id, event.payload)
+  |> IntegrationEventPublishing.publish_best_effort("session_cancelled",
+    session_id: event.aggregate_id
+  )
+end
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+mix test test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events.ex \
+        test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+git commit -m "feat: promote session_cancelled domain event to integration event"
+```
+
+> **Note on domain emission:** Finding the cancellation use case (if one exists) and wiring the domain event emission is out of this ticket's scope — the projection only needs to react to the event when it *does* arrive. If the cancellation flow does not yet exist in the domain, file a follow-up issue and continue.
+
+---
+
+## Task 3: Migration for `provider_session_details`
+
+**Files:**
+- Create: `priv/repo/migrations/<timestamp>_create_provider_session_details.exs`
+
+- [ ] **Step 1: Generate the migration scaffold**
+
+```bash
+mix ecto.gen.migration create_provider_session_details
+```
+
+Expected: new file under `priv/repo/migrations/` with timestamp prefix.
+
+- [ ] **Step 2: Write the migration**
+
+Replace the generated body with:
+
+```elixir
+defmodule KlassHero.Repo.Migrations.CreateProviderSessionDetails do
+  use Ecto.Migration
+
+  def change do
+    create table(:provider_session_details, primary_key: false) do
+      add :session_id,                  :binary_id, primary_key: true
+      add :program_id,                  :binary_id, null: false
+      add :program_title,               :string,    null: false
+      add :provider_id,                 :binary_id, null: false
+
+      add :session_date,                :date,      null: false
+      add :start_time,                  :time,      null: false
+      add :end_time,                    :time,      null: false
+      add :status,                      :string,    null: false
+
+      add :current_assigned_staff_id,   :binary_id
+      add :current_assigned_staff_name, :string
+      add :cover_staff_id,              :binary_id
+      add :cover_staff_name,            :string
+
+      add :checked_in_count,            :integer,   null: false, default: 0
+      add :total_count,                 :integer,   null: false, default: 0
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:provider_session_details, [:provider_id, :program_id, :session_date])
+    create index(:provider_session_details, [:provider_id, :session_date])
+  end
+end
+```
+
+- [ ] **Step 3: Run the migration**
+
+```bash
+mix ecto.migrate
+```
+
+- [ ] **Step 4: Verify the table via Tidewave**
+
+```elixir
+# Tidewave: execute_sql_query
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'provider_session_details'
+ORDER BY ordinal_position;
+```
+
+Expected: 16 columns in the order above; `null` only on the staff/cover columns.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add priv/repo/migrations/*_create_provider_session_details.exs
+git commit -m "feat: add provider_session_details read table"
+```
+
+---
+
+## Task 4: Ecto Schema, DTO, Mapper
+
+**Files:**
+- Create: `lib/klass_hero/provider/domain/read_models/session_detail.ex`
+- Create: `lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_session_detail_schema.ex`
+- Create: `lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper.ex`
+- Test: `test/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper_test.exs`
+
+- [ ] **Step 1: Write the DTO**
+
+`lib/klass_hero/provider/domain/read_models/session_detail.ex`:
+
+```elixir
+defmodule KlassHero.Provider.Domain.ReadModels.SessionDetail do
+  @moduledoc "Display-optimized session detail for the provider dashboard."
+
+  @enforce_keys [:session_id, :program_id, :provider_id, :session_date, :start_time, :end_time, :status]
+  defstruct [
+    :session_id,
+    :program_id,
+    :program_title,
+    :provider_id,
+    :session_date,
+    :start_time,
+    :end_time,
+    :status,
+    :current_assigned_staff_id,
+    :current_assigned_staff_name,
+    :cover_staff_id,
+    :cover_staff_name,
+    checked_in_count: 0,
+    total_count: 0
+  ]
+
+  @type status :: :scheduled | :in_progress | :completed | :cancelled
+
+  @type t :: %__MODULE__{
+          session_id: binary(),
+          program_id: binary(),
+          program_title: String.t() | nil,
+          provider_id: binary(),
+          session_date: Date.t(),
+          start_time: Time.t(),
+          end_time: Time.t(),
+          status: status(),
+          current_assigned_staff_id: binary() | nil,
+          current_assigned_staff_name: String.t() | nil,
+          cover_staff_id: binary() | nil,
+          cover_staff_name: String.t() | nil,
+          checked_in_count: non_neg_integer(),
+          total_count: non_neg_integer()
+        }
+end
+```
+
+- [ ] **Step 2: Write the Ecto schema**
+
+`lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_session_detail_schema.ex`:
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema do
+  @moduledoc """
+  Read table for the Provider dashboard's per-session view (issue #373).
+
+  Populated by the `ProviderSessionDetails` projection from Participation + Provider
+  integration events. Do not write directly — use the projection.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:session_id, :binary_id, autogenerate: false}
+  @foreign_key_type :binary_id
+
+  schema "provider_session_details" do
+    field :program_id, :binary_id
+    field :program_title, :string
+    field :provider_id, :binary_id
+
+    field :session_date, :date
+    field :start_time, :time
+    field :end_time, :time
+    field :status, Ecto.Enum, values: [:scheduled, :in_progress, :completed, :cancelled]
+
+    field :current_assigned_staff_id, :binary_id
+    field :current_assigned_staff_name, :string
+    field :cover_staff_id, :binary_id
+    field :cover_staff_name, :string
+
+    field :checked_in_count, :integer, default: 0
+    field :total_count, :integer, default: 0
+
+    timestamps(type: :utc_datetime)
+  end
+end
+```
+
+- [ ] **Step 3: Write the failing mapper test**
+
+`test/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper_test.exs`:
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapperTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  test "to_read_model/1 maps schema struct to DTO with all fields" do
+    schema = %ProviderSessionDetailSchema{
+      session_id: "s-1",
+      program_id: "p-1",
+      program_title: "Judo",
+      provider_id: "pr-1",
+      session_date: ~D[2026-05-01],
+      start_time: ~T[15:00:00],
+      end_time: ~T[16:00:00],
+      status: :scheduled,
+      current_assigned_staff_id: "staff-1",
+      current_assigned_staff_name: "Alice",
+      cover_staff_id: nil,
+      cover_staff_name: nil,
+      checked_in_count: 3,
+      total_count: 5
+    }
+
+    assert %SessionDetail{
+             session_id: "s-1",
+             program_title: "Judo",
+             status: :scheduled,
+             current_assigned_staff_name: "Alice",
+             checked_in_count: 3,
+             total_count: 5
+           } = ProviderSessionDetailMapper.to_read_model(schema)
+  end
+end
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper_test.exs
+```
+
+Expected: FAIL with undefined module / function.
+
+- [ ] **Step 5: Write the mapper**
+
+`lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper.ex`:
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapper do
+  @moduledoc "Maps between ProviderSessionDetailSchema and the SessionDetail read model."
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  @spec to_read_model(ProviderSessionDetailSchema.t()) :: SessionDetail.t()
+  def to_read_model(%ProviderSessionDetailSchema{} = s) do
+    %SessionDetail{
+      session_id: s.session_id,
+      program_id: s.program_id,
+      program_title: s.program_title,
+      provider_id: s.provider_id,
+      session_date: s.session_date,
+      start_time: s.start_time,
+      end_time: s.end_time,
+      status: s.status,
+      current_assigned_staff_id: s.current_assigned_staff_id,
+      current_assigned_staff_name: s.current_assigned_staff_name,
+      cover_staff_id: s.cover_staff_id,
+      cover_staff_name: s.cover_staff_name,
+      checked_in_count: s.checked_in_count,
+      total_count: s.total_count
+    }
+  end
+end
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper_test.exs
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/klass_hero/provider/domain/read_models/session_detail.ex \
+        lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_session_detail_schema.ex \
+        lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper.ex \
+        test/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper_test.exs
+git commit -m "feat: add SessionDetail DTO, schema, and mapper"
+```
+
+---
+
+## Task 5: Port Behaviour
+
+**Files:**
+- Create: `lib/klass_hero/provider/domain/ports/for_querying_session_details.ex`
+
+- [ ] **Step 1: Write the port**
+
+```elixir
+defmodule KlassHero.Provider.Domain.Ports.ForQueryingSessionDetails do
+  @moduledoc """
+  Read port for per-session detail rows.
+
+  Implementations query the `provider_session_details` projection table
+  (populated by `ProviderSessionDetails` GenServer).
+  """
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  @callback list_by_program(provider_id :: binary(), program_id :: binary()) :: [SessionDetail.t()]
+end
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Via Tidewave:
+
+```elixir
+# Tidewave: project_eval
+Code.ensure_loaded?(KlassHero.Provider.Domain.Ports.ForQueryingSessionDetails)
+```
+
+Expected: `true`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/klass_hero/provider/domain/ports/for_querying_session_details.ex
+git commit -m "feat: add ForQueryingSessionDetails port"
+```
+
+---
+
+## Task 6: Repository (implements the port)
+
+**Files:**
+- Create: `lib/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository.ex`
+- Test: `test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepositoryTest do
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepository
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+  alias KlassHero.Repo
+
+  defp insert_row(attrs) do
+    %ProviderSessionDetailSchema{}
+    |> Ecto.Changeset.change(attrs)
+    |> Repo.insert!()
+  end
+
+  describe "list_by_program/2" do
+    test "returns rows ordered by session_date then start_time" do
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "Judo",
+        provider_id: provider_id,
+        session_date: ~D[2026-05-02],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: :scheduled
+      })
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "Judo",
+        provider_id: provider_id,
+        session_date: ~D[2026-05-01],
+        start_time: ~T[15:00:00],
+        end_time: ~T[16:00:00],
+        status: :scheduled
+      })
+
+      [first, second] = SessionDetailsRepository.list_by_program(provider_id, program_id)
+
+      assert %SessionDetail{session_date: ~D[2026-05-01]} = first
+      assert %SessionDetail{session_date: ~D[2026-05-02]} = second
+    end
+
+    test "returns [] for unknown program" do
+      assert [] == SessionDetailsRepository.list_by_program(Ecto.UUID.generate(), Ecto.UUID.generate())
+    end
+
+    test "does not leak across providers" do
+      program_id = Ecto.UUID.generate()
+      mine = Ecto.UUID.generate()
+      theirs = Ecto.UUID.generate()
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(), program_id: program_id, program_title: "J",
+        provider_id: theirs, session_date: ~D[2026-05-01], start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00], status: :scheduled
+      })
+
+      assert [] == SessionDetailsRepository.list_by_program(mine, program_id)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs
+```
+
+Expected: FAIL — module not defined.
+
+- [ ] **Step 3: Write the repository**
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepository do
+  @moduledoc "Read-only repository for the provider_session_details projection."
+
+  @behaviour KlassHero.Provider.Domain.Ports.ForQueryingSessionDetails
+
+  import Ecto.Query
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Repo
+
+  @impl true
+  def list_by_program(provider_id, program_id) when is_binary(provider_id) and is_binary(program_id) do
+    from(d in ProviderSessionDetailSchema,
+      where: d.provider_id == ^provider_id and d.program_id == ^program_id,
+      order_by: [asc: d.session_date, asc: d.start_time]
+    )
+    |> Repo.all()
+    |> Enum.map(&ProviderSessionDetailMapper.to_read_model/1)
+  end
+end
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs
+```
+
+Expected: 3 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository.ex \
+        test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs
+git commit -m "feat: add SessionDetailsRepository (implements port)"
+```
+
+---
+
+## Task 7: Projection GenServer Skeleton
+
+**Files:**
+- Create: `lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex`
+- Test: `test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs`
+
+- [ ] **Step 1: Write a minimal skeleton test**
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsTest do
+  use KlassHero.DataCase, async: false
+
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+
+  setup do
+    start_supervised!({ProviderSessionDetails, name: :test_provider_session_details})
+    :ok
+  end
+
+  test "starts and responds to a ping call" do
+    assert Process.whereis(:test_provider_session_details) |> is_pid()
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+```
+
+Expected: FAIL (module undefined).
+
+- [ ] **Step 3: Write the skeleton**
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails do
+  @moduledoc """
+  Event-driven projection maintaining `provider_session_details`.
+
+  Subscribes to Participation session/attendance events and Provider staff events.
+  Self-heals on every boot by replaying the bootstrap query into the read table.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @session_created_topic           "integration:participation:session_created"
+  @session_started_topic           "integration:participation:session_started"
+  @session_completed_topic         "integration:participation:session_completed"
+  @session_cancelled_topic         "integration:participation:session_cancelled"
+  @roster_seeded_topic             "integration:participation:roster_seeded"
+  @child_checked_in_topic          "integration:participation:child_checked_in"
+  @child_checked_out_topic         "integration:participation:child_checked_out"
+  @child_marked_absent_topic       "integration:participation:child_marked_absent"
+  @staff_assigned_topic            "integration:provider:staff_assigned_to_program"
+  @staff_unassigned_topic          "integration:provider:staff_unassigned_from_program"
+
+  @topics [
+    @session_created_topic, @session_started_topic, @session_completed_topic,
+    @session_cancelled_topic, @roster_seeded_topic,
+    @child_checked_in_topic, @child_checked_out_topic, @child_marked_absent_topic,
+    @staff_assigned_topic, @staff_unassigned_topic
+  ]
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Rebuilds the read table from write models. Useful after seeds."
+  def rebuild(name \\ __MODULE__), do: GenServer.call(name, :rebuild, :infinity)
+
+  @impl true
+  def init(_opts) do
+    Enum.each(@topics, &Phoenix.PubSub.subscribe(KlassHero.PubSub, &1))
+    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+  end
+
+  @impl true
+  def handle_continue(:bootstrap, state) do
+    # implementation comes in Task 13
+    {:noreply, %{state | bootstrapped: true}}
+  end
+
+  @impl true
+  def handle_call(:rebuild, _from, state) do
+    # implementation comes in Task 13
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:retry_bootstrap, state) do
+    {:noreply, state, {:continue, :bootstrap}}
+  end
+
+  @impl true
+  def handle_info({:integration_event, _event}, state) do
+    # event clauses come in Tasks 8–12
+    {:noreply, state}
+  end
+end
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex \
+        test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+git commit -m "feat: scaffold ProviderSessionDetails projection GenServer"
+```
+
+---
+
+## Task 8: Handler — `session_created`
+
+**Goal:** when a session is created, insert a row with session timestamps + current program assignment staff. Resolve `program_title` and `provider_id` via a read of the `programs` write table.
+
+**Files:**
+- Modify: `lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex`
+- Modify: `test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs`
+
+- [ ] **Step 1:** Via Tidewave, confirm the Program Catalog schema module path and field names:
+
+```elixir
+# Tidewave: get_ecto_schemas
+```
+
+Locate `KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramSchema`. Note fields: `id`, `title`, `provider_id`.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `provider_session_details_test.exs`:
+
+```elixir
+describe "session_created" do
+  test "inserts a row with defaults, resolving program_title and provider_id" do
+    provider_id = Ecto.UUID.generate()
+    program_id = Ecto.UUID.generate()
+    session_id = Ecto.UUID.generate()
+
+    # Minimal program row so the handler can resolve title/provider_id
+    {:ok, _} = KlassHero.Repo.query(
+      "INSERT INTO programs (id, title, provider_id, status, inserted_at, updated_at) VALUES ($1, $2, $3, $4, NOW(), NOW())",
+      [Ecto.UUID.dump!(program_id), "Judo", Ecto.UUID.dump!(provider_id), "active"]
+    )
+
+    event = build_integration_event(:session_created, session_id, %{
+      session_id: session_id,
+      program_id: program_id,
+      session_date: ~D[2026-05-01],
+      start_time: ~T[15:00:00],
+      end_time: ~T[16:00:00]
+    })
+
+    Phoenix.PubSub.broadcast(KlassHero.PubSub,
+      "integration:participation:session_created",
+      {:integration_event, event}
+    )
+
+    eventually(fn ->
+      row = KlassHero.Repo.get(
+        KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema,
+        session_id
+      )
+      assert row.program_id == program_id
+      assert row.program_title == "Judo"
+      assert row.provider_id == provider_id
+      assert row.status == :scheduled
+      assert row.checked_in_count == 0
+      assert row.total_count == 0
+    end)
+  end
+end
+```
+
+Add `build_integration_event/3` and `eventually/1` helpers at the top of the module (outside `describe`):
+
+```elixir
+defp build_integration_event(event_type, entity_id, payload) do
+  KlassHero.Shared.Domain.Events.IntegrationEvent.new(
+    event_type,
+    :participation,
+    :session,
+    entity_id,
+    payload
+  )
+end
+
+defp eventually(fun, attempts \\ 20, delay \\ 25) do
+  try do
+    fun.()
+  rescue
+    ExUnit.AssertionError when attempts > 0 ->
+      Process.sleep(delay)
+      eventually(fun, attempts - 1, delay)
+  end
+end
+```
+
+> **Note:** the project's existing projection tests may have a helper already; use it if so — inspect `test/klass_hero/messaging/adapters/driven/projections/` for a canonical `eventually/1`.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs --only describe:"session_created"
+```
+
+Expected: FAIL (row not inserted).
+
+- [ ] **Step 4: Implement the handler**
+
+In `provider_session_details.ex`:
+
+```elixir
+alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+alias KlassHero.Repo
+alias KlassHero.Shared.Domain.Events.IntegrationEvent
+import Ecto.Query
+
+def handle_info({:integration_event, %IntegrationEvent{event_type: :session_created} = event}, state) do
+  project_session_created(event.payload)
+  {:noreply, state}
+end
+
+defp project_session_created(%{
+       session_id: session_id,
+       program_id: program_id,
+       session_date: session_date,
+       start_time: start_time,
+       end_time: end_time
+     }) do
+  {program_title, provider_id} = resolve_program(program_id)
+  {staff_id, staff_name} = resolve_current_assigned_staff(program_id)
+
+  now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+  attrs = %{
+    session_id: session_id,
+    program_id: program_id,
+    program_title: program_title,
+    provider_id: provider_id,
+    session_date: session_date,
+    start_time: start_time,
+    end_time: end_time,
+    status: "scheduled",
+    current_assigned_staff_id: staff_id,
+    current_assigned_staff_name: staff_name,
+    checked_in_count: 0,
+    total_count: 0,
+    inserted_at: now,
+    updated_at: now
+  }
+
+  Repo.insert_all(
+    "provider_session_details",
+    [attrs],
+    on_conflict: {:replace_all_except, [:session_id, :inserted_at]},
+    conflict_target: [:session_id]
+  )
+end
+
+defp resolve_program(program_id) do
+  # Read from the programs write table. This is a cross-context read scoped to
+  # event handling; symmetric with the bootstrap query. If boundary-checker
+  # flags it, extract a ProgramCatalog read helper.
+  case Repo.query(
+         "SELECT title, provider_id FROM programs WHERE id = $1",
+         [Ecto.UUID.dump!(program_id)]
+       ) do
+    {:ok, %{rows: [[title, provider_id_bin]]}} ->
+      {title, Ecto.UUID.cast!(provider_id_bin)}
+
+    _ ->
+      Logger.warning("session_created: program not found", program_id: program_id)
+      {nil, nil}
+  end
+end
+
+defp resolve_current_assigned_staff(program_id) do
+  case Repo.query(
+         """
+         SELECT psa.staff_member_id, sm.display_name
+         FROM program_staff_assignments psa
+         JOIN staff_members sm ON sm.id = psa.staff_member_id
+         WHERE psa.program_id = $1 AND psa.unassigned_at IS NULL
+         ORDER BY psa.assigned_at ASC
+         LIMIT 1
+         """,
+         [Ecto.UUID.dump!(program_id)]
+       ) do
+    {:ok, %{rows: [[staff_id_bin, name]]}} -> {Ecto.UUID.cast!(staff_id_bin), name}
+    _ -> {nil, nil}
+  end
+end
+```
+
+> **Verify column names** with Tidewave before wiring — the `staff_members` table's display column may be `display_name` or `first_name` + `last_name`. Use `get_ecto_schemas` or `execute_sql_query SELECT * FROM staff_members LIMIT 1`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs --only describe:"session_created"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat: project session_created into provider_session_details"
+```
+
+---
+
+## Task 9: Handlers — Status Transitions
+
+**Goal:** `session_started` → `:in_progress`, `session_completed` → `:completed`, `session_cancelled` → `:cancelled`.
+
+**Files:**
+- Modify: `lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex`
+- Modify: `test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```elixir
+describe "status transitions" do
+  setup :insert_seed_session
+
+  test "session_started sets status=:in_progress", %{session_id: session_id} do
+    broadcast(:session_started, session_id, %{session_id: session_id, program_id: "prog"})
+
+    eventually(fn ->
+      assert %{status: :in_progress} = reload(session_id)
+    end)
+  end
+
+  test "session_completed sets status=:completed", %{session_id: session_id} do
+    broadcast(:session_completed, session_id, %{
+      session_id: session_id, program_id: "prog", provider_id: "prv", program_title: "Judo"
+    })
+
+    eventually(fn -> assert %{status: :completed} = reload(session_id) end)
+  end
+
+  test "session_cancelled sets status=:cancelled", %{session_id: session_id} do
+    broadcast(:session_cancelled, session_id, %{session_id: session_id, program_id: "prog"})
+
+    eventually(fn -> assert %{status: :cancelled} = reload(session_id) end)
+  end
+end
+
+defp broadcast(event_type, entity_id, payload) do
+  event = build_integration_event(event_type, entity_id, payload)
+  Phoenix.PubSub.broadcast(KlassHero.PubSub, "integration:participation:#{event_type}", {:integration_event, event})
+end
+
+defp reload(session_id) do
+  KlassHero.Repo.get(
+    KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema,
+    session_id
+  )
+end
+
+defp insert_seed_session(_ctx) do
+  session_id = Ecto.UUID.generate()
+
+  KlassHero.Repo.insert_all("provider_session_details", [%{
+    session_id: session_id,
+    program_id: Ecto.UUID.generate(),
+    program_title: "X",
+    provider_id: Ecto.UUID.generate(),
+    session_date: ~D[2026-05-01],
+    start_time: ~T[09:00:00],
+    end_time: ~T[10:00:00],
+    status: "scheduled",
+    checked_in_count: 0, total_count: 0,
+    inserted_at: DateTime.utc_now() |> DateTime.truncate(:second),
+    updated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+  }])
+
+  %{session_id: session_id}
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs --only describe:"status transitions"
+```
+
+Expected: 3 FAILs (no status change).
+
+- [ ] **Step 3: Implement**
+
+In `provider_session_details.ex`:
+
+```elixir
+def handle_info({:integration_event, %IntegrationEvent{event_type: :session_started} = event}, state) do
+  update_status(event.entity_id, :in_progress)
+  {:noreply, state}
+end
+
+def handle_info({:integration_event, %IntegrationEvent{event_type: :session_completed} = event}, state) do
+  update_status(event.entity_id, :completed)
+  {:noreply, state}
+end
+
+def handle_info({:integration_event, %IntegrationEvent{event_type: :session_cancelled} = event}, state) do
+  update_status(event.entity_id, :cancelled)
+  {:noreply, state}
+end
+
+defp update_status(session_id, status) do
+  from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
+  |> Repo.update_all(set: [status: status, updated_at: DateTime.utc_now() |> DateTime.truncate(:second)])
+end
+```
+
+Delete the fallback `handle_info({:integration_event, _event}, state)` you scaffolded in Task 7 once all event types have explicit clauses (final fallback comes in Task 12).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs --only describe:"status transitions"
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat: project session status transitions"
+```
+
+---
+
+## Task 10: Handler — `roster_seeded`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+describe "roster_seeded" do
+  setup :insert_seed_session
+
+  test "sets total_count from seeded_count", %{session_id: session_id} do
+    broadcast(:roster_seeded, session_id, %{session_id: session_id, program_id: "p", seeded_count: 7})
+
+    eventually(fn -> assert %{total_count: 7} = reload(session_id) end)
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs --only describe:"roster_seeded"
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```elixir
+def handle_info({:integration_event, %IntegrationEvent{event_type: :roster_seeded, payload: %{seeded_count: seeded_count}} = event}, state) do
+  from(d in ProviderSessionDetailSchema, where: d.session_id == ^event.entity_id)
+  |> Repo.update_all(set: [total_count: seeded_count, updated_at: DateTime.utc_now() |> DateTime.truncate(:second)])
+  {:noreply, state}
+end
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat: project roster_seeded total_count"
+```
+
+---
+
+## Task 11: Handler — Attendance Counters
+
+**Goal:** `child_checked_in` increments; `child_checked_out` and `child_marked_absent` are explicit no-ops (log at debug).
+
+- [ ] **Step 1: Write the failing tests**
+
+```elixir
+describe "attendance counters" do
+  setup :insert_seed_session
+
+  test "child_checked_in increments checked_in_count", %{session_id: session_id} do
+    broadcast(:child_checked_in, "rec-1", %{record_id: "rec-1", session_id: session_id, child_id: "c-1"})
+
+    eventually(fn -> assert %{checked_in_count: 1} = reload(session_id) end)
+  end
+
+  test "two check-ins increment to 2", %{session_id: session_id} do
+    broadcast(:child_checked_in, "rec-1", %{record_id: "rec-1", session_id: session_id, child_id: "c-1"})
+    broadcast(:child_checked_in, "rec-2", %{record_id: "rec-2", session_id: session_id, child_id: "c-2"})
+
+    eventually(fn -> assert %{checked_in_count: 2} = reload(session_id) end)
+  end
+
+  test "child_checked_out does not decrement", %{session_id: session_id} do
+    broadcast(:child_checked_in, "rec-1", %{record_id: "rec-1", session_id: session_id, child_id: "c-1"})
+    eventually(fn -> assert %{checked_in_count: 1} = reload(session_id) end)
+
+    broadcast(:child_checked_out, "rec-1", %{record_id: "rec-1", session_id: session_id, child_id: "c-1"})
+
+    # Small wait then assert unchanged
+    Process.sleep(50)
+    assert %{checked_in_count: 1} = reload(session_id)
+  end
+
+  test "child_marked_absent does not change count", %{session_id: session_id} do
+    broadcast(:child_marked_absent, "rec-1", %{record_id: "rec-1", session_id: session_id, child_id: "c-1"})
+
+    Process.sleep(50)
+    assert %{checked_in_count: 0} = reload(session_id)
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Expected: 1st/2nd FAIL (0 instead of 1/2). 3rd/4th may pass by accident if there's still a catch-all clause — remove any catch-all before running.
+
+- [ ] **Step 3: Implement**
+
+```elixir
+def handle_info({:integration_event, %IntegrationEvent{event_type: :child_checked_in, payload: %{session_id: session_id}}}, state) do
+  from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
+  |> Repo.update_all(inc: [checked_in_count: 1],
+                      set: [updated_at: DateTime.utc_now() |> DateTime.truncate(:second)])
+  {:noreply, state}
+end
+
+def handle_info({:integration_event, %IntegrationEvent{event_type: :child_checked_out}}, state) do
+  # Intentional no-op: once a child is counted on check-in, they stay counted.
+  {:noreply, state}
+end
+
+def handle_info({:integration_event, %IntegrationEvent{event_type: :child_marked_absent}}, state) do
+  # Intentional no-op: absence does not affect checked_in_count.
+  {:noreply, state}
+end
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat: project attendance counters"
+```
+
+---
+
+## Task 12: Handlers — Staff Assignment / Unassignment
+
+**Goal:** Bulk-update `current_assigned_staff_*` on all `:scheduled` rows for a program.
+
+- [ ] **Step 1:** Via Tidewave, confirm `staff_members` has the display column we use:
+
+```elixir
+# Tidewave: execute_sql_query
+SELECT column_name FROM information_schema.columns
+WHERE table_name = 'staff_members' ORDER BY ordinal_position;
+```
+
+Note the column name (e.g. `display_name` or `full_name`). Adjust the SQL below accordingly.
+
+- [ ] **Step 2: Write the failing tests**
+
+```elixir
+describe "staff assignment" do
+  test "staff_assigned_to_program updates scheduled sessions for the program" do
+    program_id = Ecto.UUID.generate()
+    scheduled_id = Ecto.UUID.generate()
+    completed_id = Ecto.UUID.generate()
+    staff_id = Ecto.UUID.generate()
+
+    KlassHero.Repo.query!(
+      "INSERT INTO staff_members (id, provider_id, display_name, inserted_at, updated_at) VALUES ($1, $2, $3, NOW(), NOW())",
+      [Ecto.UUID.dump!(staff_id), Ecto.UUID.dump!(Ecto.UUID.generate()), "Alice"]
+    )
+
+    insert_detail(session_id: scheduled_id, program_id: program_id, status: "scheduled")
+    insert_detail(session_id: completed_id, program_id: program_id, status: "completed")
+
+    event = build_integration_event(:staff_assigned_to_program, staff_id, %{
+      staff_member_id: staff_id,
+      program_id: program_id,
+      provider_id: Ecto.UUID.generate()
+    })
+
+    Phoenix.PubSub.broadcast(KlassHero.PubSub,
+      "integration:provider:staff_assigned_to_program",
+      {:integration_event, event}
+    )
+
+    eventually(fn ->
+      assert %{current_assigned_staff_id: ^staff_id, current_assigned_staff_name: "Alice"} =
+               reload(scheduled_id)
+      assert %{current_assigned_staff_id: nil} = reload(completed_id)
+    end)
+  end
+
+  test "staff_unassigned_from_program clears scheduled rows for the program" do
+    # similar setup — insert a scheduled row with staff, then broadcast unassign,
+    # assert staff_id is nil after
+  end
+end
+
+defp insert_detail(attrs) do
+  base = %{
+    session_id: Ecto.UUID.generate(),
+    program_id: Ecto.UUID.generate(),
+    program_title: "P",
+    provider_id: Ecto.UUID.generate(),
+    session_date: ~D[2026-05-01],
+    start_time: ~T[09:00:00],
+    end_time: ~T[10:00:00],
+    status: "scheduled",
+    checked_in_count: 0, total_count: 0,
+    inserted_at: DateTime.utc_now() |> DateTime.truncate(:second),
+    updated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+  }
+  KlassHero.Repo.insert_all("provider_session_details", [Map.merge(base, Map.new(attrs))])
+end
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Expected: 2 FAIL.
+
+- [ ] **Step 4: Implement**
+
+```elixir
+def handle_info({:integration_event, %IntegrationEvent{event_type: :staff_assigned_to_program, payload: payload}}, state) do
+  %{staff_member_id: staff_id, program_id: program_id} = payload
+  staff_name = lookup_staff_name(staff_id)
+
+  from(d in ProviderSessionDetailSchema,
+    where: d.program_id == ^program_id and d.status == :scheduled
+  )
+  |> Repo.update_all(
+    set: [
+      current_assigned_staff_id: staff_id,
+      current_assigned_staff_name: staff_name,
+      updated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    ]
+  )
+
+  {:noreply, state}
+end
+
+def handle_info({:integration_event, %IntegrationEvent{event_type: :staff_unassigned_from_program, payload: %{program_id: program_id}}}, state) do
+  from(d in ProviderSessionDetailSchema,
+    where: d.program_id == ^program_id and d.status == :scheduled
+  )
+  |> Repo.update_all(
+    set: [
+      current_assigned_staff_id: nil,
+      current_assigned_staff_name: nil,
+      updated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    ]
+  )
+
+  {:noreply, state}
+end
+
+defp lookup_staff_name(staff_id) do
+  case Repo.query(
+         "SELECT display_name FROM staff_members WHERE id = $1",
+         [Ecto.UUID.dump!(staff_id)]
+       ) do
+    {:ok, %{rows: [[name]]}} -> name
+    _ -> nil
+  end
+end
+```
+
+Then add a final catch-all for unknown events:
+
+```elixir
+def handle_info({:integration_event, _event}, state), do: {:noreply, state}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat: project staff assignment changes for scheduled sessions"
+```
+
+---
+
+## Task 13: Bootstrap + `rebuild/0`
+
+**Files:**
+- Modify: `lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex`
+- Create: `test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsBootstrapTest do
+  use KlassHero.DataCase, async: false
+
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Repo
+
+  @tag :bootstrap
+  test "bootstrap projects every existing session from write tables" do
+    # Seed the write tables (bypassing events)
+    provider_id = Ecto.UUID.generate()
+    program_id = Ecto.UUID.generate()
+    session_id = Ecto.UUID.generate()
+
+    Repo.query!(
+      "INSERT INTO programs (id, title, provider_id, status, inserted_at, updated_at) VALUES ($1, $2, $3, 'active', NOW(), NOW())",
+      [Ecto.UUID.dump!(program_id), "Judo", Ecto.UUID.dump!(provider_id)]
+    )
+
+    Repo.query!(
+      """
+      INSERT INTO program_sessions (id, program_id, session_date, start_time, end_time, status, inserted_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, 'scheduled', NOW(), NOW())
+      """,
+      [Ecto.UUID.dump!(session_id), Ecto.UUID.dump!(program_id), ~D[2026-05-01], ~T[15:00:00], ~T[16:00:00]]
+    )
+
+    start_supervised!({ProviderSessionDetails, name: :bootstrap_test})
+    :ok = ProviderSessionDetails.rebuild(:bootstrap_test)
+
+    row = Repo.get(ProviderSessionDetailSchema, session_id)
+    assert row.program_title == "Judo"
+    assert row.provider_id == provider_id
+    assert row.status == :scheduled
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
+```
+
+Expected: FAIL (no row).
+
+- [ ] **Step 3: Implement the bootstrap query**
+
+Replace the placeholder `handle_continue(:bootstrap, state)` and `handle_call(:rebuild, ...)` in `provider_session_details.ex`:
+
+```elixir
+@impl true
+def handle_continue(:bootstrap, state) do
+  case do_bootstrap() do
+    :ok ->
+      {:noreply, %{state | bootstrapped: true}}
+
+    {:error, reason} ->
+      Logger.warning("ProviderSessionDetails bootstrap failed; retrying", reason: inspect(reason))
+      Process.send_after(self(), :retry_bootstrap, 1_000)
+      {:noreply, state}
+  end
+end
+
+@impl true
+def handle_call(:rebuild, _from, state) do
+  :ok = do_bootstrap()
+  {:reply, :ok, %{state | bootstrapped: true}}
+end
+
+defp do_bootstrap do
+  sql = """
+  SELECT
+    ps.id::text                            AS session_id,
+    ps.program_id::text                    AS program_id,
+    p.title                                AS program_title,
+    p.provider_id::text                    AS provider_id,
+    ps.session_date,
+    ps.start_time,
+    ps.end_time,
+    ps.status::text                        AS status,
+    psa.staff_member_id::text              AS current_assigned_staff_id,
+    sm.display_name                        AS current_assigned_staff_name,
+    COALESCE(counts.checked_in, 0)         AS checked_in_count,
+    COALESCE(counts.total, 0)              AS total_count
+  FROM program_sessions ps
+  JOIN programs p ON p.id = ps.program_id
+  LEFT JOIN program_staff_assignments psa
+         ON psa.program_id = ps.program_id
+        AND psa.unassigned_at IS NULL
+  LEFT JOIN staff_members sm
+         ON sm.id = psa.staff_member_id
+  LEFT JOIN (
+    SELECT session_id,
+           COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out')) AS checked_in,
+           COUNT(*) AS total
+    FROM participation_records
+    GROUP BY session_id
+  ) counts ON counts.session_id = ps.id
+  """
+
+  case Repo.query(sql) do
+    {:ok, %{rows: rows}} ->
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      attrs_list =
+        Enum.map(rows, fn [sid, pid, title, prov, date, stime, etime, status, staff_id, staff_name, cin, total] ->
+          %{
+            session_id: sid,
+            program_id: pid,
+            program_title: title,
+            provider_id: prov,
+            session_date: date,
+            start_time: stime,
+            end_time: etime,
+            status: status,
+            current_assigned_staff_id: staff_id,
+            current_assigned_staff_name: staff_name,
+            checked_in_count: cin,
+            total_count: total,
+            inserted_at: now,
+            updated_at: now
+          }
+        end)
+
+      _ = Repo.insert_all(
+        "provider_session_details",
+        attrs_list,
+        on_conflict: {:replace_all_except, [:session_id, :inserted_at]},
+        conflict_target: [:session_id]
+      )
+
+      :ok
+
+    {:error, reason} ->
+      {:error, reason}
+  end
+end
+```
+
+Adjust staff display column name (`display_name` vs. `full_name`) based on Task 12's Tidewave check.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+mix test test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify bootstrap output via Tidewave**
+
+```elixir
+# Tidewave: execute_sql_query
+SELECT COUNT(*) FROM provider_session_details;
+SELECT COUNT(*) FROM program_sessions;
+```
+
+Counts should match once the projection is running in the dev environment.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat: bootstrap ProviderSessionDetails from write tables"
+```
+
+---
+
+## Task 14: Supervisor Registration + DI Wiring
+
+**Files:**
+- Modify: `lib/klass_hero/projection_supervisor.ex`
+- Modify: `config/config.exs`
+
+- [ ] **Step 1:** Verify the supervisor list via Tidewave:
+
+```elixir
+# Tidewave: project_eval
+Supervisor.which_children(KlassHero.ProjectionSupervisor)
+```
+
+Note current children; the new projection will join them.
+
+- [ ] **Step 2:** Add the projection to the supervisor.
+
+In `lib/klass_hero/projection_supervisor.ex`, add alias and child:
+
+```elixir
+alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+# ...
+children = [
+  VerifiedProviders,
+  ProgramListings,
+  EnrolledChildren,
+  ConversationSummaries,
+  ProviderSessionStats,
+  ProviderSessionDetails
+]
+```
+
+- [ ] **Step 3:** Wire the port in `config/config.exs` under the existing `:provider` key:
+
+```elixir
+config :klass_hero, :provider,
+  # ... existing bindings ...,
+  for_querying_session_details:
+    KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepository
+```
+
+- [ ] **Step 4:** Verify compile + boot.
+
+```bash
+mix compile --warnings-as-errors
+iex -S mix phx.server  # Then Ctrl+C twice to exit, or leave running for Tidewave
+```
+
+Via Tidewave, confirm the projection is supervised:
+
+```elixir
+Supervisor.which_children(KlassHero.ProjectionSupervisor)
+|> Enum.map(fn {mod, _, _, _} -> mod end)
+```
+
+Expected: list includes `ProviderSessionDetails`.
+
+- [ ] **Step 5:** Commit.
+
+```bash
+git add -u
+git commit -m "chore: supervise ProviderSessionDetails and wire port binding"
+```
+
+---
+
+## Task 15: Use Case — `ListProgramSessions`
+
+**Files:**
+- Create: `lib/klass_hero/provider/application/queries/list_program_sessions.ex`
+- Test: `test/klass_hero/provider/application/queries/list_program_sessions_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule KlassHero.Provider.Application.Queries.ListProgramSessionsTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias KlassHero.Provider.Application.Queries.ListProgramSessions
+
+  setup :verify_on_exit!
+
+  test "delegates to the port with (provider_id, program_id)" do
+    provider_id = Ecto.UUID.generate()
+    program_id = Ecto.UUID.generate()
+    expected = []
+
+    KlassHero.Provider.ForQueryingSessionDetailsMock
+    |> expect(:list_by_program, fn ^provider_id, ^program_id -> expected end)
+
+    assert ^expected = ListProgramSessions.run(provider_id, program_id)
+  end
+end
+```
+
+- [ ] **Step 2:** Add the mock. In `test/support/mocks.ex` (or equivalent — check the repo's convention):
+
+```elixir
+Mox.defmock(KlassHero.Provider.ForQueryingSessionDetailsMock,
+  for: KlassHero.Provider.Domain.Ports.ForQueryingSessionDetails)
+```
+
+In `config/test.exs`:
+
+```elixir
+config :klass_hero, :provider,
+  for_querying_session_details: KlassHero.Provider.ForQueryingSessionDetailsMock
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+```bash
+mix test test/klass_hero/provider/application/queries/list_program_sessions_test.exs
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement**
+
+```elixir
+defmodule KlassHero.Provider.Application.Queries.ListProgramSessions do
+  @moduledoc "Lists per-session detail rows for a provider's program."
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  @for_querying_session_details Application.compile_env!(
+                                  :klass_hero,
+                                  [:provider, :for_querying_session_details]
+                                )
+
+  @spec run(binary(), binary()) :: [SessionDetail.t()]
+  def run(provider_id, program_id),
+    do: @for_querying_session_details.list_by_program(provider_id, program_id)
+end
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat: add ListProgramSessions query use case"
+```
+
+---
+
+## Task 16: Extend `participation_status` with `:cancelled`
+
+**Files:**
+- Modify: `lib/klass_hero_web/components/participation_components.ex`
+- Test: `test/klass_hero_web/components/participation_components_test.exs` (create if missing)
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+test "participation_status renders :cancelled with red badge and x-circle icon" do
+  html =
+    render_component(&KlassHeroWeb.ParticipationComponents.participation_status/1,
+      status: :cancelled, size: "sm"
+    )
+
+  assert html =~ "bg-red-100"
+  assert html =~ "hero-x-circle"
+  assert html =~ "Cancelled"
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — unmatched status.
+
+- [ ] **Step 3: Implement**
+
+Add three new clauses to the private helpers in `participation_components.ex`:
+
+```elixir
+defp status_color_classes(:cancelled), do: "bg-red-100 text-red-700 border border-red-300"
+defp status_icon(:cancelled), do: "hero-x-circle"
+defp status_label(:cancelled), do: gettext("Cancelled")
+```
+
+(Replace helper names if the file uses different ones — read the existing code at `participation_components.ex:126` first.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate gettext POT**
+
+```bash
+mix gettext.extract --merge
+```
+
+Add German translation for `Cancelled` in `priv/gettext/de/LC_MESSAGES/default.po` → `"Abgesagt"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat: extend participation_status with :cancelled variant"
+```
+
+---
+
+## Task 17: `sessions_modal/1` Component
+
+**Files:**
+- Modify: `lib/klass_hero_web/components/provider_components.ex`
+- Test: `test/klass_hero_web/components/provider_components_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+describe "sessions_modal/1" do
+  test "renders the provided sessions in order" do
+    modal = %{
+      program_id: "prog-1",
+      program_title: "Judo",
+      sessions: [
+        %KlassHero.Provider.Domain.ReadModels.SessionDetail{
+          session_id: "s-1", program_id: "prog-1", provider_id: "prv-1",
+          session_date: ~D[2026-05-01], start_time: ~T[15:00:00], end_time: ~T[16:00:00],
+          status: :scheduled, program_title: "Judo",
+          current_assigned_staff_name: "Alice",
+          checked_in_count: 0, total_count: 0
+        },
+        %KlassHero.Provider.Domain.ReadModels.SessionDetail{
+          session_id: "s-2", program_id: "prog-1", provider_id: "prv-1",
+          session_date: ~D[2026-05-08], start_time: ~T[15:00:00], end_time: ~T[16:00:00],
+          status: :cancelled, program_title: "Judo",
+          current_assigned_staff_name: nil,
+          checked_in_count: 0, total_count: 0
+        }
+      ]
+    }
+
+    html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
+
+    assert html =~ "Judo"
+    assert html =~ "Alice"
+    assert html =~ "Unassigned"
+    # Cancelled row hides attendance
+    refute html =~ ~r/0\s*\/\s*0.*cancelled/is
+  end
+
+  test "shows empty state when sessions is []" do
+    modal = %{program_id: "p", program_title: "T", sessions: []}
+    html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
+    assert html =~ "No sessions scheduled yet"
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — function not defined.
+
+- [ ] **Step 3: Implement**
+
+In `provider_components.ex`, add below `roster_modal/1`:
+
+```elixir
+@doc """
+Renders a modal listing every session of a program with date/time, assigned
+staff, cover staff (reserved), attendance count, and status.
+
+## Example
+
+    <.sessions_modal :if={@sessions_modal} modal={@sessions_modal} />
+"""
+attr :modal, :map, required: true
+
+def sessions_modal(assigns) do
+  ~H"""
+  <div
+    id="sessions-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="sessions-modal-title"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    phx-window-keydown="close_sessions"
+    phx-key="escape"
+  >
+    <div
+      class="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col"
+      phx-click-away="close_sessions"
+    >
+      <div class="flex items-center justify-between px-6 py-4 border-b">
+        <h2 id="sessions-modal-title" class={Theme.typography(:section_title)}>
+          {gettext("Sessions — %{title}", title: @modal.program_title)}
+        </h2>
+        <button type="button" phx-click="close_sessions" aria-label={gettext("Close")}>
+          <.icon name="hero-x-mark" class="w-5 h-5" />
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto">
+        <%= if @modal.sessions == [] do %>
+          <div class="text-center py-12">
+            <.icon name="hero-calendar-days" class="w-12 h-12 text-hero-grey-300 mx-auto" />
+            <p class="mt-4 text-hero-grey-500">{gettext("No sessions scheduled yet.")}</p>
+          </div>
+        <% else %>
+          <table class="w-full text-sm">
+            <thead class="bg-hero-grey-50 text-left">
+              <tr>
+                <th class="px-4 py-3">{gettext("Date / time")}</th>
+                <th class="px-4 py-3">{gettext("Assigned staff")}</th>
+                <th class="px-4 py-3">{gettext("Cover")}</th>
+                <th class="px-4 py-3">{gettext("Attendance")}</th>
+                <th class="px-4 py-3">{gettext("Status")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={s <- @modal.sessions} class="border-t">
+                <td class="px-4 py-3">
+                  {Calendar.strftime(s.session_date, "%a, %d %b")}
+                  <span class="text-hero-grey-500">
+                    · {Calendar.strftime(s.start_time, "%H:%M")}–{Calendar.strftime(s.end_time, "%H:%M")}
+                  </span>
+                </td>
+                <td class="px-4 py-3">
+                  {s.current_assigned_staff_name || gettext("Unassigned")}
+                </td>
+                <td class="px-4 py-3 text-hero-grey-500">
+                  {s.cover_staff_name || "—"}
+                </td>
+                <td class="px-4 py-3">
+                  <span :if={s.status != :cancelled}>
+                    {s.checked_in_count} / {s.total_count}
+                  </span>
+                </td>
+                <td class="px-4 py-3">
+                  <.participation_status status={s.status} size="sm" />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  """
+end
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Expected: PASS.
+
+- [ ] **Step 5:** Extract new gettext strings.
+
+```bash
+mix gettext.extract --merge
+```
+
+Translate new keys in `priv/gettext/de/LC_MESSAGES/default.po`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat: add sessions_modal component"
+```
+
+---
+
+## Task 18: Sessions Button in `programs_table` Actions
+
+**Files:**
+- Modify: `lib/klass_hero_web/components/provider_components.ex`
+- Test: `test/klass_hero_web/components/provider_components_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+test "programs_table renders a Sessions button per row" do
+  program = %{
+    id: "prog-1", title: "Judo", status: :active,
+    # whatever else the existing programs_table expects — copy from existing tests
+  }
+
+  html = render_component(&KlassHeroWeb.ProviderComponents.programs_table/1, programs: [program])
+
+  assert html =~ "phx-click=\"view_sessions\""
+  assert html =~ "phx-value-program-id=\"prog-1\""
+  assert html =~ ~s|aria-label="View sessions"|
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — button absent.
+
+- [ ] **Step 3: Add the button**
+
+In `provider_components.ex` around line 1366–1385 (the existing Actions cluster), add:
+
+```heex
+<button
+  type="button"
+  phx-click="view_sessions"
+  phx-value-program-id={@program.id}
+  phx-value-program-title={@program.title}
+  class={icon_button_classes()}
+  aria-label={gettext("View sessions")}
+>
+  <.icon name="hero-calendar-days" class="w-5 h-5" />
+</button>
+```
+
+(Use the existing `icon_button_classes/0` helper if that's the convention; otherwise mirror the classes used on the Preview / Roster buttons.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat: add Sessions button to programs_table Actions"
+```
+
+---
+
+## Task 19: DashboardLive Handlers
+
+**Files:**
+- Modify: `lib/klass_hero_web/live/provider_live/dashboard_live.ex`
+- Modify: `lib/klass_hero_web/live/provider_live/dashboard_live.html.heex` (if template is separate)
+
+- [ ] **Step 1:** Via Tidewave, inspect the LiveView module:
+
+```elixir
+# Tidewave: get_source_location
+{KlassHeroWeb.ProviderLive.DashboardLive, :mount}
+```
+
+Note where to add the handlers and template hook.
+
+- [ ] **Step 2: Write the failing LiveView test**
+
+Append to the existing dashboard test:
+
+```elixir
+test "clicking Sessions opens the modal with the program's sessions", %{conn: conn, provider: provider} do
+  program = seed_program_with_session!(provider, title: "Judo")
+
+  {:ok, view, _html} = live(conn, ~p"/provider/dashboard?tab=programs")
+
+  view
+  |> element(~s|button[phx-click="view_sessions"][phx-value-program-id="#{program.id}"]|)
+  |> render_click()
+
+  assert has_element?(view, "#sessions-modal")
+  assert has_element?(view, "#sessions-modal td", "Judo") or
+         render(view) =~ "Judo"
+
+  # Close via X
+  view |> element("#sessions-modal button[phx-click='close_sessions']") |> render_click()
+  refute has_element?(view, "#sessions-modal")
+end
+```
+
+`seed_program_with_session!/2` should insert a program row, a program_session row, and then call `ProviderSessionDetails.rebuild(...)` so the projection sees them. Implement it in the test helpers module.
+
+- [ ] **Step 3: Run to verify it fails**
+
+```bash
+mix test test/klass_hero_web/live/provider_live/dashboard_live_test.exs:<line>
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement**
+
+In `dashboard_live.ex`:
+
+```elixir
+alias KlassHero.Provider.Application.Queries.ListProgramSessions
+
+@impl true
+def mount(_params, _session, socket) do
+  # ... existing logic ...
+  {:ok, assign(socket, :sessions_modal, nil)}
+end
+
+@impl true
+def handle_event("view_sessions",
+      %{"program-id" => program_id, "program-title" => title}, socket) do
+  provider_id = socket.assigns.current_scope.user.provider_id
+  sessions = ListProgramSessions.run(provider_id, program_id)
+
+  {:noreply,
+   assign(socket, :sessions_modal,
+     %{program_id: program_id, program_title: title, sessions: sessions})}
+end
+
+def handle_event("close_sessions", _params, socket) do
+  {:noreply, assign(socket, :sessions_modal, nil)}
+end
+```
+
+In the template:
+
+```heex
+<.sessions_modal :if={@sessions_modal} modal={@sessions_modal} />
+```
+
+(Place near existing modals. Confirm `ProviderComponents` is already imported in the view; if not, add `import KlassHeroWeb.ProviderComponents` in the layout/html.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat: wire sessions modal into provider dashboard"
+```
+
+---
+
+## Task 20: End-to-End Precommit & Architecture Review
+
+- [ ] **Step 1:** Run `mix precommit`:
+
+```bash
+mix precommit
+```
+
+Expected: all green. If anything fails, fix and rerun.
+
+- [ ] **Step 2:** Run the architecture review:
+
+Invoke the `review-architecture` skill:
+
+```
+/review-architecture
+```
+
+Expected findings + resolutions:
+
+- **Boundary-checker may flag `Repo.query("SELECT ... FROM programs")` inside Provider context.** Mitigation: introduce `KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramReadForProjections.get_title_and_provider/1` (or similar), wire it via a new read-only port, and call it from the projection. Same for staff_members (same context — acceptable) and the bootstrap SQL.
+- **Architecture-reviewer should see** the new port in `ports/`, the repository in `adapters/driven/`, and wiring in `config/config.exs` — all conforming.
+
+If flags are structural (bad naming, wrong directory), fix before proceeding.
+
+- [ ] **Step 3:** Use Tidewave to sanity-check projection state in dev:
+
+```elixir
+# Tidewave: execute_sql_query
+SELECT provider_id, COUNT(*) FROM provider_session_details GROUP BY provider_id;
+```
+
+Counts should align with expected provider ↔ session relationships.
+
+- [ ] **Step 4:** Use Tidewave to tail logs during a manual smoke test:
+
+```elixir
+# Tidewave: get_logs
+tail: 200
+```
+
+Create a session manually in dev; observe the projection consuming `session_created`.
+
+- [ ] **Step 5:** Commit any review fixes.
+
+```bash
+git add -u && git commit -m "refactor: address architecture-review feedback"
+```
+
+---
+
+## Task 21: PR
+
+- [ ] **Step 1:** Push the branch.
+
+```bash
+git pull --rebase
+git push -u origin feat/373-per-session-view
+```
+
+- [ ] **Step 2:** Open the PR.
+
+```bash
+gh pr create --title "feat: per-session view in provider dashboard (#373)" --body "$(cat <<'EOF'
+## Summary
+- New `ProviderSessionDetails` projection in the Provider context, subscribed to Participation + Provider integration events.
+- Sessions button + modal on provider dashboard showing date/time, assigned staff, cover (reserved), attendance, status.
+- Extended `participation_status` with `:cancelled` variant; added `session_cancelled` integration event.
+
+Closes #373.
+
+## Review Focus
+- Projection event handlers and idempotency/ordering behavior (see spec).
+- Bootstrap cross-context read pattern (acknowledged; fallback to per-context helpers if boundary-checker flags).
+- Staff reassignment "scheduled-only" rule.
+
+## Test Plan
+- [ ] `mix precommit` green.
+- [ ] Projection unit, bootstrap, repository, use-case, component, and LiveView tests all pass.
+- [ ] `/review-architecture` clean or with only known-mitigated findings.
+- [ ] Manual dev smoke: create a session, cancel a session, check-in a child → modal reflects each change.
+
+## Follow-ups
+- Migrate `list_admin_sessions/1` to the same projection (separate ticket).
+- Implement cover-provider domain support (#373 sub-issue).
+EOF
+)"
+```
+
+- [ ] **Step 3:** Paste the PR URL back to the user.
+
+---
+
+## Self-Review Checklist
+
+- **Spec coverage:**
+  - ✅ Port contract — Task 5
+  - ✅ Read model DTO — Task 4
+  - ✅ Schema + migration — Tasks 3–4
+  - ✅ Projection + all 10 event handlers — Tasks 7–12
+  - ✅ Bootstrap + rebuild — Task 13
+  - ✅ Supervision + DI — Task 14
+  - ✅ Use case — Task 15
+  - ✅ UI component extension (participation_status :cancelled) — Task 16
+  - ✅ sessions_modal — Task 17
+  - ✅ Sessions button — Task 18
+  - ✅ LiveView wiring — Task 19
+  - ✅ Testing strategy (6 layers) — Tasks 1, 2, 4, 6, 9–13, 16–19
+  - ✅ Rollout/Review — Task 20
+  - ✅ Open items — Resolved in Pre-flight + Tasks 1, 2, 14
+
+- **Placeholder scan:** No TBDs; every step has code or commands.
+
+- **Type consistency:**
+  - `SessionDetail.t()` used consistently.
+  - Port callback `list_by_program/2` matches in port, repo, and use case.
+  - Projection module name `ProviderSessionDetails` used consistently.
+  - Read table name `provider_session_details` used consistently.
+  - Topics strings consistent with source-of-truth event factory patterns.
+
+- **Scope check:** Single feature, single plan. Follow-ups are named and deferred.

--- a/docs/superpowers/specs/2026-04-18-per-session-view-projection-design.md
+++ b/docs/superpowers/specs/2026-04-18-per-session-view-projection-design.md
@@ -1,0 +1,382 @@
+# Per-Session View Projection
+
+**Issue:** #373 — [FEATURE] Add per-session view to program inventory dashboard
+**Date:** 2026-04-18
+**Status:** Approved
+
+## Problem
+
+Providers managing a program on the provider dashboard can see program-level data (title, status, enrollment count, staff) but cannot drill into individual sessions. To see sessions, they currently have no UI at all. The admin area has a sessions view backed by a live 4-table JOIN in `SessionRepository.list_admin_sessions/1`, but that is not surfaced to providers, and its shape is admin-centric.
+
+The AC requires:
+
+- A "Sessions" button in the Actions column of the provider dashboard's program inventory.
+- A modal where each row represents a session with columns: date/time, assigned provider, cover provider, attendance.
+- Sessions sorted by earliest date.
+- Completed sessions visually distinct from upcoming ones.
+
+## Solution
+
+Introduce a new event-driven projection — `ProviderSessionDetails` — in the **Provider** context. The projection denormalizes session lifecycle data (from Participation), attendance counts (from Participation), and staff assignment (from Provider) into a single `provider_session_details` read table, queried through a new `ForQueryingSessionDetails` port.
+
+The provider dashboard's new Sessions modal reads only from this projection via a thin use case — no cross-context orchestration in the LiveView, and no new ACL adapter is introduced.
+
+**Scope boundary:** this projection powers the new provider modal only. The existing admin JOIN query (`list_admin_sessions/1`) is left untouched; a follow-up ticket can migrate admin to the same projection and retire the JOIN.
+
+**Cover provider:** schema-reserved but deferred. The current domain (`ProgramStaffAssignment`) models staff at program level with no primary/cover distinction. Cover columns are nullable and populated only when the domain is extended.
+
+## Architecture Overview
+
+```
+Participation Context                   Provider Context
+      |                                       |
+  session_created                    staff_assigned_to_program
+  session_started                    staff_unassigned_from_program
+  session_completed
+  session_cancelled (add if missing)
+  roster_seeded
+  child_checked_in
+  child_checked_out
+  child_marked_absent
+      |                                       |
+      +--------------- PubSub -----------------+
+                           |
+        Provider: ProviderSessionDetails Projection (GenServer)
+            - maintains provider_session_details table
+            - self-heals on boot via handle_continue(:bootstrap)
+            - exposes rebuild/0 escape hatch
+                           |
+                provider_session_details
+                           |
+        Provider: SessionDetailsRepository (implements port)
+                           |
+        Provider: ListProgramSessions (use case / query)
+                           |
+        Web: DashboardLive "view_sessions" handler
+                           |
+        Web: sessions_modal component (uses participation_status)
+```
+
+Cross-context isolation is preserved:
+
+- The projection consumes only integration events, not other contexts' Ecto schemas at runtime.
+- The projection's bootstrap query reaches across context tables — same pattern as the existing `list_admin_sessions/1` — and is the one acknowledged exception. If `boundary-checker` flags it later, introduce per-context read helpers (`Participation.list_all_sessions_for_bootstrap/0`, etc.) and call those.
+- LiveView reads through a single Provider-context port — no multi-context orchestration in the web layer.
+
+## Events Consumed
+
+### Participation events
+
+| Topic | Handler effect |
+|---|---|
+| `integration:participation:session_created` | Insert row; `status=:scheduled`, `total_count=0`, `checked_in_count=0`; resolve current program assignment and populate `current_assigned_staff_*` |
+| `integration:participation:session_started` | Update `status=:in_progress` for `session_id` |
+| `integration:participation:session_completed` | Update `status=:completed` for `session_id` |
+| `integration:participation:session_cancelled` | Update `status=:cancelled` for `session_id` |
+| `integration:participation:roster_seeded` | Set `total_count = seeded_count` for `session_id` |
+| `integration:participation:child_checked_in` | Atomic `checked_in_count += 1` for `session_id` |
+| `integration:participation:child_checked_out` | No-op on counts (child already counted on check-in) |
+| `integration:participation:child_marked_absent` | No-op on counts |
+
+**`session_cancelled`** — verify the event currently exists in Participation's integration events. If absent, add it (domain + integration promotion) when `ProgramSession.status` transitions to `:cancelled`. Payload: `session_id`, `program_id`.
+
+### Provider events
+
+| Topic | Handler effect |
+|---|---|
+| `integration:provider:staff_assigned_to_program` | Bulk `UPDATE` all rows where `program_id = event.program_id AND status = :scheduled`; set `current_assigned_staff_*` from event |
+| `integration:provider:staff_unassigned_from_program` | Bulk `UPDATE` all rows where `program_id = event.program_id AND status = :scheduled`; clear `current_assigned_staff_*` |
+
+**"Scheduled-only" rule** — staff reassignment affects only sessions not yet delivered (`status = :scheduled`). Sessions that are in progress, completed, or cancelled keep whatever staff was displayed at the time. This is semantically stricter than a date-based filter and correctly handles same-day edge cases (a session completed earlier today, or one currently running).
+
+### Handler idempotency & ordering
+
+- `session_created` uses upsert (`ON CONFLICT` with `replace_all_except`) — duplicate delivery is a no-op.
+- All other handlers use `UPDATE WHERE session_id = ?` — running twice is a no-op.
+- Counter handlers use atomic SQL increments — safe under concurrent delivery.
+- Events arriving for unknown `session_id` (e.g., `child_checked_in` before `session_created`) affect zero rows. A warning is logged. The next boot's bootstrap reconciles counts from the write table.
+
+### Counter strategy
+
+Attendance counts are stored as integers and mutated via atomic SQL increments. Check-outs and absences do not decrement — once a child is counted on check-in, they stay counted. The only scenario that would require a decrement is undoing a check-in, which is not a modeled write operation today. If added later, a corresponding `child_check_in_reversed` event would handle it.
+
+Reconciliation is guaranteed by self-healing bootstrap: every boot recomputes counts from `participation_records`, so any drift is erased on the next deploy.
+
+## Data Model
+
+### Migration
+
+```elixir
+defmodule KlassHero.Repo.Migrations.CreateProviderSessionDetails do
+  use Ecto.Migration
+
+  def change do
+    create table(:provider_session_details, primary_key: false) do
+      add :session_id,                  :binary_id, primary_key: true
+      add :program_id,                  :binary_id, null: false
+      add :program_title,               :string,    null: false
+      add :provider_id,                 :binary_id, null: false
+
+      add :session_date,                :date,      null: false
+      add :start_time,                  :time,      null: false
+      add :end_time,                    :time,      null: false
+      add :status,                      :string,    null: false
+
+      add :current_assigned_staff_id,   :binary_id
+      add :current_assigned_staff_name, :string
+      add :cover_staff_id,              :binary_id
+      add :cover_staff_name,            :string
+
+      add :checked_in_count,            :integer,   null: false, default: 0
+      add :total_count,                 :integer,   null: false, default: 0
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:provider_session_details, [:provider_id, :program_id, :session_date])
+    create index(:provider_session_details, [:provider_id, :session_date])
+  end
+end
+```
+
+No foreign keys. Projections are intentionally decoupled from source tables to avoid coupling deployment order and to prevent source-table deletes from cascading into the read model.
+
+### Read Model DTO
+
+```elixir
+defmodule KlassHero.Provider.Domain.ReadModels.SessionDetail do
+  defstruct [
+    :session_id, :program_id, :program_title, :provider_id,
+    :session_date, :start_time, :end_time, :status,
+    :current_assigned_staff_id, :current_assigned_staff_name,
+    :cover_staff_id, :cover_staff_name,
+    :checked_in_count, :total_count
+  ]
+end
+```
+
+### Ecto Schema
+
+`ProviderSessionDetailSchema` — binary_id primary key on `session_id`; `status` as `Ecto.Enum` with values `[:scheduled, :in_progress, :completed, :cancelled]`.
+
+## Port Contract
+
+```elixir
+defmodule KlassHero.Provider.Domain.Ports.ForQueryingSessionDetails do
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  @callback list_by_program(provider_id :: binary(), program_id :: binary()) ::
+              [SessionDetail.t()]
+end
+```
+
+Sorted by `session_date` ascending, then `start_time` ascending. No pagination — session volume per program is bounded (typically < 50).
+
+## Module Layout
+
+```
+lib/klass_hero/provider/
+  domain/
+    read_models/session_detail.ex
+    ports/for_querying_session_details.ex
+  adapters/driven/
+    persistence/
+      schemas/provider_session_detail_schema.ex
+      mappers/provider_session_detail_mapper.ex
+      repositories/session_details_repository.ex
+    projections/provider_session_details.ex
+  application/queries/list_program_sessions.ex
+```
+
+## Dependency Injection
+
+```elixir
+# config/config.exs (under existing :provider key)
+config :klass_hero, :provider,
+  # ... existing bindings ...,
+  for_querying_session_details:
+    KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepository
+```
+
+## Supervision & Bootstrap
+
+### Startup
+
+Matches the `ProgramListings` pattern:
+
+```elixir
+def init(_opts) do
+  Enum.each(@topics, &Phoenix.PubSub.subscribe(KlassHero.PubSub, &1))
+  {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+end
+
+def handle_continue(:bootstrap, state), do: attempt_bootstrap(state)
+```
+
+Subscribing before bootstrapping ensures no events are missed during startup.
+
+### Bootstrap query
+
+A single query joins `program_sessions`, `programs`, `program_staff_assignments`, `staff_members`, and `participation_records` to compute every row of `provider_session_details` in one pass. Results are batch-upserted with `on_conflict: {:replace_all_except, [:session_id, :inserted_at]}` — safe to run alongside in-flight event handlers.
+
+### `rebuild/0` escape hatch
+
+```elixir
+def rebuild(name \\ __MODULE__), do: GenServer.call(name, :rebuild, :infinity)
+```
+
+Re-runs the bootstrap query. Used after seeds (which bypass event publishing) or any time drift is suspected.
+
+### Supervision
+
+Add `ProviderSessionDetails` to the Provider context supervision tree with a **permanent** restart policy (same as `ProgramListings`), so repeated failures escalate rather than silently retry.
+
+### Retry
+
+`handle_info(:retry_bootstrap, state) -> {:noreply, state, {:continue, :bootstrap}}` — reuses the same continue path when transient failures occur during boot.
+
+### Deletion of sessions
+
+Not a modeled write operation today. If added later, a `session_deleted` event handler (plus a `DELETE ... WHERE session_id NOT IN (...)` pass in `rebuild/0`) would handle it.
+
+## Web Layer
+
+### Use case
+
+```elixir
+defmodule KlassHero.Provider.Application.Queries.ListProgramSessions do
+  @for_querying_session_details Application.compile_env!(
+    :klass_hero, [:provider, :for_querying_session_details]
+  )
+
+  def run(provider_id, program_id),
+    do: @for_querying_session_details.list_by_program(provider_id, program_id)
+end
+```
+
+Authorization (does this provider own this program?) is handled by the LiveView's auth pipeline upstream — the query assumes a trusted `(provider_id, program_id)` pair.
+
+### LiveView additions (`DashboardLive`)
+
+- Socket assign: `:sessions_modal` — `nil` when closed, `%{program_id, program_title, sessions}` when open.
+- `handle_event("view_sessions", %{"program-id" => id, "program-title" => title}, socket)` — calls `ListProgramSessions.run/2` and assigns modal state.
+- `handle_event("close_sessions", _, socket)` — clears modal state.
+
+### "Sessions" button
+
+Added to the Actions column of `programs_table` in `provider_components.ex:1366–1385`. Icon: `hero-calendar-days`. `aria-label` gettext'd.
+
+### `sessions_modal/1` component
+
+Mirrors `roster_modal/1` (line 1456) structure — overlay, `phx-click-away` close, titled header, close (X) button — but renders a single table (no tabs).
+
+Columns:
+
+1. **Date / time** — `session.session_date` + `start_time`–`end_time`, formatted.
+2. **Assigned staff** — `current_assigned_staff_name` or `gettext("Unassigned")`.
+3. **Cover** — `cover_staff_name` or `"—"`. Reserved column, always dash for now.
+4. **Attendance** — `{checked_in_count} / {total_count}`. Hidden when `status == :cancelled` (matches admin sessions view precedent at `admin/sessions_live.html.heex:116`).
+5. **Status** — `<.participation_status status={session.status} size="sm" />`.
+
+Sort is produced by the repository — no client-side sort logic.
+
+**Empty state:** icon + "No sessions scheduled yet." when `sessions == []`.
+
+### Component extension: `participation_status`
+
+Add a `:cancelled` clause to the existing component at `participation_components.ex:126`:
+
+- Color: `bg-red-100 text-red-700 border border-red-300`
+- Icon: `hero-x-circle`
+- Label: `gettext("Cancelled")`
+
+The same badge is used by anywhere else that renders session status (for semantic consistency).
+
+### Internationalization
+
+All user-facing strings through `gettext/1`. German translations added to `priv/gettext/de/LC_MESSAGES/default.po`.
+
+### Accessibility
+
+- Sessions button `aria-label` set.
+- Modal carries `role="dialog"`, `aria-labelledby={modal_title_id}`, `aria-modal="true"`.
+- `phx-click-away` closes (matches `roster_modal`).
+
+## Testing Strategy
+
+### Unit tests — projection event handlers
+
+`test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs`
+
+- Each event type asserts its resulting DB state.
+- Idempotency: repeat delivery is a no-op.
+- Ordering: `child_checked_in` before `session_created` logs a warning; bootstrap reconciles.
+- Staff reassignment: past session unchanged, future session updated.
+- Status transitions: `scheduled → in_progress → completed`; `:cancelled` as terminal.
+
+### Unit tests — repository
+
+`test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs`
+
+- `list_by_program/2` returns sorted rows.
+- Unknown program returns `[]`.
+- No cross-provider leakage.
+- Full DTO shape populated.
+
+### Bootstrap test
+
+- Seed write tables directly, start projection, assert full population.
+- Drift the read table manually, call `rebuild/0`, assert reconciliation.
+
+### Use-case test
+
+- Stubs the port, asserts delegation.
+
+### LiveView test
+
+`test/klass_hero_web/live/provider_live/dashboard_live_test.exs`
+
+- Click Sessions button opens modal.
+- Columns render expected values for a known session.
+- `:completed` / `:scheduled` / `:cancelled` render distinct badges.
+- Attendance count hidden for cancelled rows.
+- Empty state for zero-session program.
+- Close (X) and click-away both close the modal.
+
+### Component render tests
+
+- `sessions_modal/1` structural render.
+- `participation_status/1` with `:cancelled`.
+
+### Architecture validation
+
+Run `/review-architecture` post-implementation. Expected-clean on: projection context placement, port naming, DI wiring, use-case shape. Expected flag on bootstrap's cross-context table reads — resolvable via per-context read helpers or explicit Boundary config.
+
+### Non-goals
+
+- No load testing (volumes don't warrant).
+- No new Ecto tests (upsert is standard).
+- No duplicate tests for the unchanged parts of `participation_status`.
+
+## Rollout
+
+1. Merge schema + projection + port + repository + wiring + tests. Projection boots, self-populates from existing write data on first deploy.
+2. Merge use case + LiveView modal + button + component extension. Feature visible to providers.
+3. Follow-up ticket: migrate `list_admin_sessions/1` to read from the same projection; retire the JOIN.
+4. Follow-up ticket (issue #373 sub-issue): cover provider — domain change to support per-session delivery, new event, projection extension.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Projection drift from write model | Self-healing bootstrap on every boot + `rebuild/0` |
+| `session_cancelled` event missing | Verify before implementation; add if absent |
+| Bootstrap query crosses context boundaries | Acknowledge; refactor to per-context helpers if boundary-checker flags |
+| Past-session staff display flips on reassignment | `status = :scheduled` filter in bulk update |
+| Counter races under concurrent event delivery | Atomic SQL increments |
+| Undo of check-in not reflected | Not a modeled operation today; out of scope |
+
+## Open Items Before Implementation
+
+1. Confirm whether `session_cancelled` integration event exists in Participation; add if missing.
+2. Confirm `ProviderSessionDetails` supervision lands on the Provider context supervisor (vs. the application-level supervisor). The house style (`ProgramListings` location) dictates the answer.

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -387,17 +387,22 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
     conversation_type = payload |> Map.get(:type, "direct") |> to_string()
 
     if conversation_type == "direct" and program_id do
-      participant_ids = Map.get(payload, :participant_ids, [])
-      conversation_id = payload.conversation_id
-
-      Enum.each(participant_ids, fn user_id ->
-        child_names = get_child_names(user_id, program_id)
-
-        if child_names != [] do
-          emit_enrolled_children_changed(conversation_id, child_names)
-        end
-      end)
+      emit_enrolled_children_for_direct_participants(
+        payload.conversation_id,
+        Map.get(payload, :participant_ids, []),
+        program_id
+      )
     end
+  end
+
+  defp emit_enrolled_children_for_direct_participants(conversation_id, participant_ids, program_id) do
+    Enum.each(participant_ids, fn user_id ->
+      child_names = get_child_names(user_id, program_id)
+
+      if child_names != [] do
+        emit_enrolled_children_changed(conversation_id, child_names)
+      end
+    end)
   end
 
   # Private — Re-derivation

--- a/lib/klass_hero/messaging/application/commands/send_message.ex
+++ b/lib/klass_hero/messaging/application/commands/send_message.ex
@@ -279,18 +279,22 @@ defmodule KlassHero.Messaging.Application.Commands.SendMessage do
 
     case result do
       {:ok, %{type: :program_broadcast, provider_id: provider_id, program_id: program_id}} ->
-        cond do
-          provider_owner?(provider_id, sender_id) -> :ok
-          staff_assigned?(program_id, sender_id) -> :ok
-          active_staff_for_provider?(provider_id, sender_id) -> :ok
-          true -> {:error, :broadcast_reply_not_allowed}
-        end
+        check_broadcast_reply_permission(provider_id, program_id, sender_id)
 
       {:ok, _direct_conversation} ->
         :ok
 
       {:error, :not_found} ->
         {:error, :not_found}
+    end
+  end
+
+  defp check_broadcast_reply_permission(provider_id, program_id, sender_id) do
+    cond do
+      provider_owner?(provider_id, sender_id) -> :ok
+      staff_assigned?(program_id, sender_id) -> :ok
+      active_staff_for_provider?(provider_id, sender_id) -> :ok
+      true -> {:error, :broadcast_reply_not_allowed}
     end
   end
 

--- a/lib/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -56,6 +56,16 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteI
     )
   end
 
+  def handle(%DomainEvent{event_type: :session_cancelled} = event) do
+    # Trigger: session_cancelled domain event dispatched when a session is cancelled
+    # Why: downstream projections (e.g. ProviderSessionDetails) must mark it cancelled
+    # Outcome: best-effort publish; swallow failures since cancellation is already persisted
+    ParticipationIntegrationEvents.session_cancelled(event.aggregate_id, event.payload)
+    |> IntegrationEventPublishing.publish_best_effort("session_cancelled",
+      session_id: event.aggregate_id
+    )
+  end
+
   def handle(%DomainEvent{event_type: :roster_seeded} = event) do
     # Trigger: roster_seeded domain event dispatched from SeedSessionRoster use case
     # Why: downstream contexts may need to know roster is ready (e.g. notifications)

--- a/lib/klass_hero/participation/domain/events/participation_integration_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_integration_events.ex
@@ -13,6 +13,8 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents d
     Entity type: `:session`.
   - `:session_completed` - Emitted when a session ends (all check-outs done).
     Entity type: `:session`.
+  - `:session_cancelled` - Emitted when a session is cancelled (e.g. provider cancels a scheduled session).
+    Entity type: `:session`.
   - `:roster_seeded` - Emitted after participation records are bulk-seeded for a session.
     Entity type: `:session`.
   - `:child_checked_in` - Emitted when a child is checked into a session.
@@ -587,5 +589,49 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents d
   def behavioral_note_rejected(note_id, _payload, _opts) do
     raise ArgumentError,
           "behavioral_note_rejected/3 requires a non-empty note_id string, got: #{inspect(note_id)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # session_cancelled (entity type: :session)
+  # ---------------------------------------------------------------------------
+
+  @typedoc "Payload for `:session_cancelled` events."
+  @type session_cancelled_payload :: %{
+          required(:session_id) => String.t(),
+          required(:program_id) => String.t(),
+          optional(atom()) => term()
+        }
+
+  @doc """
+  Creates a `session_cancelled` integration event.
+
+  Published when a session is cancelled (e.g. provider cancels a scheduled session).
+  """
+  def session_cancelled(session_id, payload \\ %{}, opts \\ [])
+
+  def session_cancelled(session_id, %{program_id: _} = payload, opts)
+      when is_binary(session_id) and byte_size(session_id) > 0 do
+    base_payload = %{session_id: session_id}
+
+    IntegrationEvent.new(
+      :session_cancelled,
+      @source_context,
+      :session,
+      session_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def session_cancelled(session_id, payload, _opts) when is_binary(session_id) and byte_size(session_id) > 0 do
+    missing = [:program_id] -- Map.keys(payload)
+
+    raise ArgumentError,
+          "session_cancelled missing required payload keys: #{inspect(missing)}"
+  end
+
+  def session_cancelled(session_id, _payload, _opts) do
+    raise ArgumentError,
+          "session_cancelled/3 requires a non-empty session_id string, got: #{inspect(session_id)}"
   end
 end

--- a/lib/klass_hero/projection_supervisor.ex
+++ b/lib/klass_hero/projection_supervisor.ex
@@ -14,6 +14,7 @@ defmodule KlassHero.ProjectionSupervisor do
   alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
 
   def start_link(init_arg) do
@@ -27,7 +28,8 @@ defmodule KlassHero.ProjectionSupervisor do
       ProgramListings,
       EnrolledChildren,
       ConversationSummaries,
-      ProviderSessionStats
+      ProviderSessionStats,
+      ProviderSessionDetails
     ]
 
     Supervisor.init(children, strategy: :one_for_one, max_restarts: 10, max_seconds: 60)

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -518,7 +518,7 @@ defmodule KlassHero.Provider do
           SessionDetail.t()
         ]
   def list_program_sessions(provider_id, program_id) when is_binary(provider_id) and is_binary(program_id) do
-    ListProgramSessions.run(provider_id, program_id)
+    ListProgramSessions.execute(provider_id, program_id)
   end
 
   # ===========================================================================

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -57,6 +57,7 @@ defmodule KlassHero.Provider do
   alias KlassHero.Provider.Application.Commands.Verification.ApproveVerificationDocument
   alias KlassHero.Provider.Application.Commands.Verification.RejectVerificationDocument
   alias KlassHero.Provider.Application.Commands.Verification.SubmitVerificationDocument
+  alias KlassHero.Provider.Application.Queries.ListProgramSessions
   alias KlassHero.Provider.Application.Queries.ProgramStaffAssignmentQueries
   alias KlassHero.Provider.Application.Queries.ProviderProfileQueries
   alias KlassHero.Provider.Application.Queries.StaffMemberQueries
@@ -72,6 +73,8 @@ defmodule KlassHero.Provider do
   # ===========================================================================
   # Commands
   # ===========================================================================
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
 
   @doc """
   Creates a new provider profile.
@@ -502,6 +505,20 @@ defmodule KlassHero.Provider do
   @spec get_total_session_count(String.t()) :: non_neg_integer()
   def get_total_session_count(provider_id) when is_binary(provider_id) do
     @session_stats_repo.get_total_count(provider_id)
+  end
+
+  @doc """
+  Lists per-session detail rows for a provider's program.
+
+  Returns a list of `SessionDetail` read-model structs from the
+  `provider_session_details` projection. Scoped to the given provider;
+  cross-provider lookups return `[]`.
+  """
+  @spec list_program_sessions(String.t(), String.t()) :: [
+          SessionDetail.t()
+        ]
+  def list_program_sessions(provider_id, program_id) when is_binary(provider_id) and is_binary(program_id) do
+    ListProgramSessions.run(provider_id, program_id)
   end
 
   # ===========================================================================

--- a/lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper.ex
@@ -1,0 +1,26 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapper do
+  @moduledoc "Maps between ProviderSessionDetailSchema and the SessionDetail read model."
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  @spec to_read_model(ProviderSessionDetailSchema.t()) :: SessionDetail.t()
+  def to_read_model(%ProviderSessionDetailSchema{} = s) do
+    %SessionDetail{
+      session_id: s.session_id,
+      program_id: s.program_id,
+      program_title: s.program_title,
+      provider_id: s.provider_id,
+      session_date: s.session_date,
+      start_time: s.start_time,
+      end_time: s.end_time,
+      status: s.status,
+      current_assigned_staff_id: s.current_assigned_staff_id,
+      current_assigned_staff_name: s.current_assigned_staff_name,
+      cover_staff_id: s.cover_staff_id,
+      cover_staff_name: s.cover_staff_name,
+      checked_in_count: s.checked_in_count,
+      total_count: s.total_count
+    }
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository.ex
@@ -1,0 +1,21 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepository do
+  @moduledoc "Read-only repository for the provider_session_details projection."
+
+  @behaviour KlassHero.Provider.Domain.Ports.ForQueryingSessionDetails
+
+  import Ecto.Query
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Repo
+
+  @impl true
+  def list_by_program(provider_id, program_id) when is_binary(provider_id) and is_binary(program_id) do
+    from(d in ProviderSessionDetailSchema,
+      where: d.provider_id == ^provider_id and d.program_id == ^program_id,
+      order_by: [asc: d.session_date, asc: d.start_time]
+    )
+    |> Repo.all()
+    |> Enum.map(&ProviderSessionDetailMapper.to_read_model/1)
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_session_detail_schema.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_session_detail_schema.ex
@@ -1,0 +1,34 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema do
+  @moduledoc """
+  Read table for the Provider dashboard's per-session view (issue #373).
+
+  Populated by the `ProviderSessionDetails` projection from Participation + Provider
+  integration events. Do not write directly — use the projection.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:session_id, :binary_id, autogenerate: false}
+  @foreign_key_type :binary_id
+
+  schema "provider_session_details" do
+    field :program_id, :binary_id
+    field :program_title, :string
+    field :provider_id, :binary_id
+
+    field :session_date, :date
+    field :start_time, :time
+    field :end_time, :time
+    field :status, Ecto.Enum, values: [:scheduled, :in_progress, :completed, :cancelled]
+
+    field :current_assigned_staff_id, :binary_id
+    field :current_assigned_staff_name, :string
+    field :cover_staff_id, :binary_id
+    field :cover_staff_name, :string
+
+    field :checked_in_count, :integer, default: 0
+    field :total_count, :integer, default: 0
+
+    timestamps(type: :utc_datetime)
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -90,6 +90,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   # Trigger: session entered the live window (instructor started it)
   # Why: dashboard badge flips from scheduled → in_progress
   # Outcome: row's status column updated to :in_progress
+  @impl true
   def handle_info({:integration_event, %IntegrationEvent{event_type: :session_started} = event}, state) do
     update_status(event.entity_id, :in_progress)
     {:noreply, state}
@@ -98,6 +99,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   # Trigger: session finished (end-of-session finalization)
   # Why: dashboard badge flips from in_progress → completed
   # Outcome: row's status column updated to :completed
+  @impl true
   def handle_info({:integration_event, %IntegrationEvent{event_type: :session_completed} = event}, state) do
     update_status(event.entity_id, :completed)
     {:noreply, state}
@@ -106,6 +108,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   # Trigger: session cancelled (by provider or system)
   # Why: dashboard badge reflects cancellation, independent of prior status
   # Outcome: row's status column updated to :cancelled
+  @impl true
   def handle_info({:integration_event, %IntegrationEvent{event_type: :session_cancelled} = event}, state) do
     update_status(event.entity_id, :cancelled)
     {:noreply, state}
@@ -167,12 +170,24 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   # Trigger: any of the session_started/completed/cancelled handlers
   # Why: the three status-transition handlers share the same update shape;
   #      centralising keeps the transitions uniform and easy to audit
-  # Outcome: the row's status column (and updated_at) is updated in place
+  # Outcome: the row's status column (and updated_at) is updated in place.
+  #          If the session row is missing (unknown session_id), a warning is
+  #          logged per spec.
   defp update_status(session_id, status) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
-    |> Repo.update_all(set: [status: status, updated_at: now])
+    {updated, _} =
+      from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
+      |> Repo.update_all(set: [status: status, updated_at: now])
+
+    if updated == 0 do
+      Logger.warning("ProviderSessionDetails status transition skipped: session not found",
+        session_id: session_id,
+        target_status: status
+      )
+    end
+
+    :ok
   end
 
   # Trigger: session_created handler needs program_title + provider_id

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -8,6 +8,12 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
 
   use GenServer
 
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  require Logger
+
   @session_created_topic "integration:participation:session_created"
   @session_started_topic "integration:participation:session_started"
   @session_completed_topic "integration:participation:session_completed"
@@ -63,9 +69,109 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     {:noreply, state, {:continue, :bootstrap}}
   end
 
+  # Trigger: Received a session_created integration event
+  # Why: a new session exists — project a row with defaults, resolving
+  #      program_title/provider_id from the programs write table and the
+  #      currently assigned staff from program_staff_assignments
+  # Outcome: one row upserted into provider_session_details
   @impl true
-  def handle_info({:integration_event, _event}, state) do
-    # event clauses come in Tasks 8–12
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_created} = event}, state) do
+    Logger.debug("ProviderSessionDetails projecting session_created",
+      session_id: event.entity_id,
+      event_id: event.event_id
+    )
+
+    project_session_created(event.payload)
     {:noreply, state}
   end
+
+  @impl true
+  def handle_info({:integration_event, _event}, state) do
+    # other event clauses come in Tasks 9–12
+    {:noreply, state}
+  end
+
+  defp project_session_created(%{
+         session_id: session_id,
+         program_id: program_id,
+         session_date: session_date,
+         start_time: start_time,
+         end_time: end_time
+       }) do
+    {program_title, provider_id} = resolve_program(program_id)
+    {staff_id, staff_name} = resolve_current_assigned_staff(program_id)
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    attrs = %{
+      session_id: session_id,
+      program_id: program_id,
+      program_title: program_title,
+      provider_id: provider_id,
+      session_date: session_date,
+      start_time: start_time,
+      end_time: end_time,
+      status: :scheduled,
+      current_assigned_staff_id: staff_id,
+      current_assigned_staff_name: staff_name,
+      checked_in_count: 0,
+      total_count: 0,
+      inserted_at: now,
+      updated_at: now
+    }
+
+    Repo.insert_all(
+      ProviderSessionDetailSchema,
+      [attrs],
+      on_conflict: {:replace_all_except, [:session_id, :inserted_at]},
+      conflict_target: [:session_id]
+    )
+  end
+
+  # Trigger: session_created handler needs program_title + provider_id
+  # Why: the programs write table is the source of truth; reading it directly
+  #      avoids adding a new ACL port just for two fields. Symmetric with the
+  #      bootstrap query that will live in this module (Task 13).
+  # Outcome: {title, provider_id_string} tuple, or {nil, nil} on miss
+  defp resolve_program(program_id) do
+    case Repo.query(
+           "SELECT title, provider_id FROM programs WHERE id = $1",
+           [Ecto.UUID.dump!(program_id)]
+         ) do
+      {:ok, %{rows: [[title, provider_id_bin]]}} ->
+        {title, Ecto.UUID.cast!(provider_id_bin)}
+
+      _ ->
+        Logger.warning("session_created: program not found", program_id: program_id)
+        {nil, nil}
+    end
+  end
+
+  # Trigger: session_created handler needs the currently assigned staff
+  # Why: display at session creation uses the program's active assignment
+  # Outcome: {staff_id_string, "First Last"} tuple, or {nil, nil} if no assignment
+  defp resolve_current_assigned_staff(program_id) do
+    case Repo.query(
+           """
+           SELECT psa.staff_member_id, sm.first_name, sm.last_name
+           FROM program_staff_assignments psa
+           JOIN staff_members sm ON sm.id = psa.staff_member_id
+           WHERE psa.program_id = $1 AND psa.unassigned_at IS NULL
+           ORDER BY psa.assigned_at ASC
+           LIMIT 1
+           """,
+           [Ecto.UUID.dump!(program_id)]
+         ) do
+      {:ok, %{rows: [[staff_id_bin, first_name, last_name]]}} ->
+        {Ecto.UUID.cast!(staff_id_bin), build_staff_name(first_name, last_name)}
+
+      _ ->
+        {nil, nil}
+    end
+  end
+
+  defp build_staff_name(nil, nil), do: nil
+  defp build_staff_name(first, nil), do: first
+  defp build_staff_name(nil, last), do: last
+  defp build_staff_name(first, last), do: "#{first} #{last}"
 end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -1,0 +1,71 @@
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails do
+  @moduledoc """
+  Event-driven projection maintaining `provider_session_details`.
+
+  Subscribes to Participation session/attendance events and Provider staff events.
+  Self-heals on every boot by replaying the bootstrap query into the read table.
+  """
+
+  use GenServer
+
+  @session_created_topic "integration:participation:session_created"
+  @session_started_topic "integration:participation:session_started"
+  @session_completed_topic "integration:participation:session_completed"
+  @session_cancelled_topic "integration:participation:session_cancelled"
+  @roster_seeded_topic "integration:participation:roster_seeded"
+  @child_checked_in_topic "integration:participation:child_checked_in"
+  @child_checked_out_topic "integration:participation:child_checked_out"
+  @child_marked_absent_topic "integration:participation:child_marked_absent"
+  @staff_assigned_topic "integration:provider:staff_assigned_to_program"
+  @staff_unassigned_topic "integration:provider:staff_unassigned_from_program"
+
+  @topics [
+    @session_created_topic,
+    @session_started_topic,
+    @session_completed_topic,
+    @session_cancelled_topic,
+    @roster_seeded_topic,
+    @child_checked_in_topic,
+    @child_checked_out_topic,
+    @child_marked_absent_topic,
+    @staff_assigned_topic,
+    @staff_unassigned_topic
+  ]
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Rebuilds the read table from write models. Useful after seeds."
+  def rebuild(name \\ __MODULE__), do: GenServer.call(name, :rebuild, :infinity)
+
+  @impl true
+  def init(_opts) do
+    Enum.each(@topics, &Phoenix.PubSub.subscribe(KlassHero.PubSub, &1))
+    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+  end
+
+  @impl true
+  def handle_continue(:bootstrap, state) do
+    # implementation comes in Task 13
+    {:noreply, %{state | bootstrapped: true}}
+  end
+
+  @impl true
+  def handle_call(:rebuild, _from, state) do
+    # implementation comes in Task 13
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:retry_bootstrap, state) do
+    {:noreply, state, {:continue, :bootstrap}}
+  end
+
+  @impl true
+  def handle_info({:integration_event, _event}, state) do
+    # event clauses come in Tasks 8–12
+    {:noreply, state}
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -123,7 +123,17 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     Repo.insert_all(
       ProviderSessionDetailSchema,
       [attrs],
-      on_conflict: {:replace_all_except, [:session_id, :inserted_at]},
+      on_conflict:
+        {:replace_all_except,
+         [
+           :session_id,
+           :inserted_at,
+           :status,
+           :checked_in_count,
+           :total_count,
+           :cover_staff_id,
+           :cover_staff_name
+         ]},
       conflict_target: [:session_id]
     )
   end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -139,9 +139,63 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     {:noreply, state}
   end
 
+  # Trigger: attendance taker checked a child in for a session
+  # Why: dashboard shows "X / Y checked in" — bump the counter monotonically
+  # Outcome: row's checked_in_count is incremented by 1; if the session row
+  #          does not exist, a warning is logged (mirrors roster_seeded/status
+  #          transition handlers)
+  @impl true
+  def handle_info(
+        {:integration_event,
+         %IntegrationEvent{event_type: :child_checked_in, payload: %{session_id: session_id}} = event},
+        state
+      ) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {updated, _} =
+      from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
+      |> Repo.update_all(inc: [checked_in_count: 1], set: [updated_at: now])
+
+    if updated == 0 do
+      Logger.warning("ProviderSessionDetails child_checked_in skipped: session not found",
+        session_id: session_id,
+        record_id: event.entity_id
+      )
+    end
+
+    {:noreply, state}
+  end
+
+  # Trigger: attendance taker undid a check-in (child_checked_out)
+  # Why: once a child is counted on check-in, they stay counted for the day's
+  #      "how many showed up" view; undo events are intentionally not reflected
+  #      in checked_in_count. Logged at debug to confirm the no-op is deliberate.
+  # Outcome: no state change.
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_checked_out} = event}, state) do
+    Logger.debug("ProviderSessionDetails ignoring child_checked_out (counter is monotonic)",
+      record_id: event.entity_id
+    )
+
+    {:noreply, state}
+  end
+
+  # Trigger: attendance taker marked a child absent
+  # Why: absence is the complement of check-in and does not change the "how
+  #      many showed up" count. Logged at debug to confirm the no-op is deliberate.
+  # Outcome: no state change.
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_marked_absent} = event}, state) do
+    Logger.debug("ProviderSessionDetails ignoring child_marked_absent (no effect on checked_in_count)",
+      record_id: event.entity_id
+    )
+
+    {:noreply, state}
+  end
+
   @impl true
   def handle_info({:integration_event, _event}, state) do
-    # remaining event clauses come in Tasks 11–12; final catch-all arrives in Task 12
+    # remaining event clauses come in Task 12; final catch-all removed there
     {:noreply, state}
   end
 

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -270,8 +270,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
          start_time: start_time,
          end_time: end_time
        }) do
-    {program_title, provider_id} = resolve_program(program_id)
-    {staff_id, staff_name} = resolve_current_assigned_staff(program_id)
+    %{program_title: program_title, provider_id: provider_id, staff_id: staff_id, staff_name: staff_name} =
+      resolve_program_context(program_id)
 
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -445,47 +445,43 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
 
   defp warn_if_missing(_result, _event_name, _metadata), do: :ok
 
-  # Trigger: session_created handler needs program_title + provider_id
-  # Why: the programs write table is the source of truth; reading it directly
-  #      avoids adding a new ACL port just for two fields. Symmetric with the
-  #      bootstrap query that will live in this module (Task 13).
-  # Outcome: {title, provider_id_string} tuple, or {nil, nil} on miss
-  defp resolve_program(program_id) do
-    case Repo.query(
-           "SELECT title, provider_id FROM programs WHERE id = $1",
-           [Ecto.UUID.dump!(program_id)]
-         ) do
-      {:ok, %{rows: [[title, provider_id_bin]]}} ->
-        {title, Ecto.UUID.cast!(provider_id_bin)}
+  # Single LEFT JOIN resolves program title/provider + (optionally) the earliest
+  # active staff assignment's id + name. Returns nil fields when the program is
+  # missing or has no active assignment.
+  defp resolve_program_context(program_id) do
+    sql = """
+    SELECT p.title,
+           p.provider_id,
+           psa.staff_member_id,
+           sm.first_name,
+           sm.last_name
+    FROM programs p
+    LEFT JOIN program_staff_assignments psa
+           ON psa.program_id = p.id
+          AND psa.unassigned_at IS NULL
+    LEFT JOIN staff_members sm ON sm.id = psa.staff_member_id
+    WHERE p.id = $1
+    ORDER BY psa.assigned_at ASC NULLS LAST
+    LIMIT 1
+    """
+
+    case Repo.query(sql, [Ecto.UUID.dump!(program_id)]) do
+      {:ok, %{rows: [[title, provider_id_bin, staff_id_bin, first_name, last_name]]}} ->
+        %{
+          program_title: title,
+          provider_id: Ecto.UUID.cast!(provider_id_bin),
+          staff_id: cast_uuid_or_nil(staff_id_bin),
+          staff_name: build_staff_name(first_name, last_name)
+        }
 
       _ ->
         Logger.warning("session_created: program not found", program_id: program_id)
-        {nil, nil}
+        %{program_title: nil, provider_id: nil, staff_id: nil, staff_name: nil}
     end
   end
 
-  # Trigger: session_created handler needs the currently assigned staff
-  # Why: display at session creation uses the program's active assignment
-  # Outcome: {staff_id_string, "First Last"} tuple, or {nil, nil} if no assignment
-  defp resolve_current_assigned_staff(program_id) do
-    case Repo.query(
-           """
-           SELECT psa.staff_member_id, sm.first_name, sm.last_name
-           FROM program_staff_assignments psa
-           JOIN staff_members sm ON sm.id = psa.staff_member_id
-           WHERE psa.program_id = $1 AND psa.unassigned_at IS NULL
-           ORDER BY psa.assigned_at ASC
-           LIMIT 1
-           """,
-           [Ecto.UUID.dump!(program_id)]
-         ) do
-      {:ok, %{rows: [[staff_id_bin, first_name, last_name]]}} ->
-        {Ecto.UUID.cast!(staff_id_bin), build_staff_name(first_name, last_name)}
-
-      _ ->
-        {nil, nil}
-    end
-  end
+  defp cast_uuid_or_nil(nil), do: nil
+  defp cast_uuid_or_nil(bin), do: Ecto.UUID.cast!(bin)
 
   # Trigger: staff_assigned_to_program handler needs the staff display name
   # Why: the integration event payload carries only ids — the name is looked up

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -131,9 +131,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     {:noreply, state}
   end
 
-  # Trigger: participation seeded the roster for a session (expected attendees known)
-  # Why: dashboard needs total_count to render "X / Y checked in" denominators
-  # Outcome: row's total_count column is set to the seeded_count from the payload
+  # Participation seeded the roster for a session — set total_count so the
+  # dashboard can render "X / Y checked in" denominators.
   @impl true
   def handle_info(
         {:integration_event,
@@ -142,25 +141,16 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
       ) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    {updated, _} =
-      from(d in ProviderSessionDetailSchema, where: d.session_id == ^event.entity_id)
-      |> Repo.update_all(set: [total_count: seeded_count, updated_at: now])
-
-    if updated == 0 do
-      Logger.warning("ProviderSessionDetails roster_seeded skipped: session not found",
-        session_id: event.entity_id,
-        seeded_count: seeded_count
-      )
-    end
+    from(d in ProviderSessionDetailSchema, where: d.session_id == ^event.entity_id)
+    |> Repo.update_all(set: [total_count: seeded_count, updated_at: now])
+    |> warn_if_missing("roster_seeded", session_id: event.entity_id, seeded_count: seeded_count)
 
     {:noreply, state}
   end
 
-  # Trigger: attendance taker checked a child in for a session
-  # Why: dashboard shows "X / Y checked in" — bump the counter monotonically
-  # Outcome: row's checked_in_count is incremented by 1; if the session row
-  #          does not exist, a warning is logged (mirrors roster_seeded/status
-  #          transition handlers)
+  # Bump the monotonic checked_in counter. Check-outs and absences are
+  # intentionally not reflected (see below) — once counted on check-in, a child
+  # stays counted for the "how many showed up" view.
   @impl true
   def handle_info(
         {:integration_event,
@@ -169,16 +159,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
       ) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    {updated, _} =
-      from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
-      |> Repo.update_all(inc: [checked_in_count: 1], set: [updated_at: now])
-
-    if updated == 0 do
-      Logger.warning("ProviderSessionDetails child_checked_in skipped: session not found",
-        session_id: session_id,
-        record_id: event.entity_id
-      )
-    end
+    from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
+    |> Repo.update_all(inc: [checked_in_count: 1], set: [updated_at: now])
+    |> warn_if_missing("child_checked_in", session_id: session_id, record_id: event.entity_id)
 
     {:noreply, state}
   end
@@ -441,28 +424,26 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     end
   end
 
-  # Trigger: any of the session_started/completed/cancelled handlers
-  # Why: the three status-transition handlers share the same update shape;
-  #      centralising keeps the transitions uniform and easy to audit
-  # Outcome: the row's status column (and updated_at) is updated in place.
-  #          If the session row is missing (unknown session_id), a warning is
-  #          logged per spec.
+  # Shared by session_started/completed/cancelled handlers. Missing rows
+  # (unknown session_id) are logged per spec.
   defp update_status(session_id, status) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    {updated, _} =
-      from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
-      |> Repo.update_all(set: [status: status, updated_at: now])
-
-    if updated == 0 do
-      Logger.warning("ProviderSessionDetails status transition skipped: session not found",
-        session_id: session_id,
-        target_status: status
-      )
-    end
-
-    :ok
+    from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
+    |> Repo.update_all(set: [status: status, updated_at: now])
+    |> warn_if_missing("status transition", session_id: session_id, target_status: status)
   end
+
+  # Surfaces zero-row UPDATE results from event handlers so that events arriving
+  # for unknown session_ids are observable rather than silently dropped.
+  defp warn_if_missing({0, _}, event_name, metadata) do
+    Logger.warning(
+      "ProviderSessionDetails #{event_name} skipped: session not found",
+      metadata
+    )
+  end
+
+  defp warn_if_missing(_result, _event_name, _metadata), do: :ok
 
   # Trigger: session_created handler needs program_title + provider_id
   # Why: the programs write table is the source of truth; reading it directly

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -193,11 +193,75 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     {:noreply, state}
   end
 
+  # Trigger: staff_assigned_to_program integration event (provider assigned a
+  #          new staff member to one of their programs)
+  # Why: upcoming sessions should reflect the new assignment on the dashboard.
+  #      Historical (in_progress/completed/cancelled) rows retain their
+  #      pre-existing attribution — bulk update is intentionally scoped to
+  #      :scheduled rows only.
+  # Outcome: all :scheduled rows for the program get current_assigned_staff_id
+  #          and current_assigned_staff_name set to the new staff values.
   @impl true
-  def handle_info({:integration_event, _event}, state) do
-    # remaining event clauses come in Task 12; final catch-all removed there
+  def handle_info(
+        {:integration_event,
+         %IntegrationEvent{
+           event_type: :staff_assigned_to_program,
+           payload: %{staff_member_id: staff_id, program_id: program_id}
+         }},
+        state
+      ) do
+    staff_name = lookup_staff_name(staff_id)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(d in ProviderSessionDetailSchema,
+      where: d.program_id == ^program_id and d.status == :scheduled
+    )
+    |> Repo.update_all(
+      set: [
+        current_assigned_staff_id: staff_id,
+        current_assigned_staff_name: staff_name,
+        updated_at: now
+      ]
+    )
+
     {:noreply, state}
   end
+
+  # Trigger: staff_unassigned_from_program integration event (provider removed
+  #          a staff member's assignment from one of their programs)
+  # Why: upcoming sessions must drop the stale attribution. Historical rows
+  #      intentionally retain their pre-existing staff_id/name as part of the
+  #      session's audit trail — bulk clear is scoped to :scheduled rows only.
+  # Outcome: all :scheduled rows for the program have current_assigned_staff_*
+  #          columns cleared to nil.
+  @impl true
+  def handle_info(
+        {:integration_event,
+         %IntegrationEvent{event_type: :staff_unassigned_from_program, payload: %{program_id: program_id}}},
+        state
+      ) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(d in ProviderSessionDetailSchema,
+      where: d.program_id == ^program_id and d.status == :scheduled
+    )
+    |> Repo.update_all(
+      set: [
+        current_assigned_staff_id: nil,
+        current_assigned_staff_name: nil,
+        updated_at: now
+      ]
+    )
+
+    {:noreply, state}
+  end
+
+  # Final catch-all: the projection subscribes to multiple topics, and some
+  # carry unrelated event types we explicitly do not care about. Silently drop
+  # them — matching the no-op discipline used for child_checked_out and
+  # child_marked_absent above.
+  @impl true
+  def handle_info({:integration_event, _event}, state), do: {:noreply, state}
 
   defp project_session_created(%{
          session_id: session_id,
@@ -308,6 +372,22 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
 
       _ ->
         {nil, nil}
+    end
+  end
+
+  # Trigger: staff_assigned_to_program handler needs the staff display name
+  # Why: the integration event payload carries only ids — the name is looked up
+  #      from the staff_members write table (source of truth); reusing
+  #      build_staff_name/2 keeps the display convention identical to
+  #      resolve_current_assigned_staff/1.
+  # Outcome: "First Last" string, or nil if the staff row cannot be found
+  defp lookup_staff_name(staff_id) do
+    case Repo.query(
+           "SELECT first_name, last_name FROM staff_members WHERE id = $1",
+           [Ecto.UUID.dump!(staff_id)]
+         ) do
+      {:ok, %{rows: [[first_name, last_name]]}} -> build_staff_name(first_name, last_name)
+      _ -> nil
     end
   end
 

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -114,9 +114,34 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     {:noreply, state}
   end
 
+  # Trigger: participation seeded the roster for a session (expected attendees known)
+  # Why: dashboard needs total_count to render "X / Y checked in" denominators
+  # Outcome: row's total_count column is set to the seeded_count from the payload
+  @impl true
+  def handle_info(
+        {:integration_event,
+         %IntegrationEvent{event_type: :roster_seeded, payload: %{seeded_count: seeded_count}} = event},
+        state
+      ) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {updated, _} =
+      from(d in ProviderSessionDetailSchema, where: d.session_id == ^event.entity_id)
+      |> Repo.update_all(set: [total_count: seeded_count, updated_at: now])
+
+    if updated == 0 do
+      Logger.warning("ProviderSessionDetails roster_seeded skipped: session not found",
+        session_id: event.entity_id,
+        seeded_count: seeded_count
+      )
+    end
+
+    {:noreply, state}
+  end
+
   @impl true
   def handle_info({:integration_event, _event}, state) do
-    # remaining event clauses come in Tasks 10–12; final catch-all arrives in Task 12
+    # remaining event clauses come in Tasks 11–12; final catch-all arrives in Task 12
     {:noreply, state}
   end
 

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -263,16 +263,33 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   @impl true
   def handle_info({:integration_event, _event}, state), do: {:noreply, state}
 
-  defp project_session_created(%{
-         session_id: session_id,
-         program_id: program_id,
-         session_date: session_date,
-         start_time: start_time,
-         end_time: end_time
-       }) do
-    %{program_title: program_title, provider_id: provider_id, staff_id: staff_id, staff_name: staff_name} =
-      resolve_program_context(program_id)
+  defp project_session_created(%{session_id: session_id, program_id: program_id} = payload) do
+    case resolve_program_context(program_id) do
+      %{program_title: title, provider_id: provider_id} = ctx
+      when not is_nil(title) and not is_nil(provider_id) ->
+        do_insert_session(payload, ctx)
 
+      _ ->
+        Logger.warning(
+          "ProviderSessionDetails session_created skipped: program not found",
+          session_id: session_id,
+          program_id: program_id
+        )
+
+        :ok
+    end
+  end
+
+  defp do_insert_session(
+         %{
+           session_id: session_id,
+           program_id: program_id,
+           session_date: session_date,
+           start_time: start_time,
+           end_time: end_time
+         },
+         %{program_title: program_title, provider_id: provider_id, staff_id: staff_id, staff_name: staff_name}
+       ) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     attrs = %{
@@ -337,6 +354,10 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   # Outcome: {:ok, count} on success or {:error, reason} on DB failure; the
   #          caller decides whether to retry (handle_continue) or raise (rebuild).
   defp do_bootstrap do
+    # LATERAL subquery picks exactly one active staff assignment per program
+    # (earliest-assigned wins, matching resolve_program_context/1). Without it,
+    # a program with N active staff members would produce N rows per session
+    # and break the upsert's ON CONFLICT target.
     sql = """
     SELECT
       ps.id::text                            AS session_id,
@@ -347,18 +368,22 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
       ps.start_time,
       ps.end_time,
       ps.status::text                        AS status,
-      psa.staff_member_id::text              AS current_assigned_staff_id,
-      sm.first_name                          AS staff_first_name,
-      sm.last_name                           AS staff_last_name,
+      staff.staff_member_id::text            AS current_assigned_staff_id,
+      staff.first_name                       AS staff_first_name,
+      staff.last_name                        AS staff_last_name,
       COALESCE(counts.checked_in, 0)         AS checked_in_count,
       COALESCE(counts.total, 0)              AS total_count
     FROM program_sessions ps
     JOIN programs p ON p.id = ps.program_id
-    LEFT JOIN program_staff_assignments psa
-           ON psa.program_id = ps.program_id
-          AND psa.unassigned_at IS NULL
-    LEFT JOIN staff_members sm
-           ON sm.id = psa.staff_member_id
+    LEFT JOIN LATERAL (
+      SELECT psa.staff_member_id, sm.first_name, sm.last_name
+      FROM program_staff_assignments psa
+      LEFT JOIN staff_members sm ON sm.id = psa.staff_member_id
+      WHERE psa.program_id = ps.program_id
+        AND psa.unassigned_at IS NULL
+      ORDER BY psa.assigned_at ASC
+      LIMIT 1
+    ) staff ON TRUE
     LEFT JOIN (
       SELECT session_id,
              COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out')) AS checked_in,
@@ -475,7 +500,6 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
         }
 
       _ ->
-        Logger.warning("session_created: program not found", program_id: program_id)
         %{program_title: nil, provider_id: nil, staff_id: nil, staff_name: nil}
     end
   end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -51,22 +51,18 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   @impl true
   def init(_opts) do
     Enum.each(@topics, &Phoenix.PubSub.subscribe(KlassHero.PubSub, &1))
-    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+    {:ok, %{}, {:continue, :bootstrap}}
   end
 
   @impl true
   def handle_continue(:bootstrap, state) do
-    # Trigger: GenServer init complete
-    # Why: self-heal the read table from the authoritative write tables on every
-    #      boot. Transient DB failures reschedule via :retry_bootstrap (Task 7);
-    #      persistent failures propagate through repeated retries until the
-    #      supervisor intervenes.
-    # Outcome: read table converges toward a projection of the current write
-    #          state; `bootstrapped: true` marks the projection ready.
+    # Self-heal the read table from write tables on every boot. Transient DB
+    # failures reschedule via :retry_bootstrap; persistent failures propagate
+    # through repeated retries until the supervisor intervenes.
     case do_bootstrap() do
       {:ok, count} ->
         Logger.info("ProviderSessionDetails bootstrap complete", count: count)
-        {:noreply, %{state | bootstrapped: true}}
+        {:noreply, state}
 
       {:error, reason} ->
         Logger.warning("ProviderSessionDetails bootstrap failed; retrying",
@@ -78,16 +74,13 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     end
   end
 
-  # Trigger: external caller requests a full rebuild (e.g. after seeds insert
-  #          into write tables without emitting integration events)
-  # Why: seeds bypass the event bus, so the read table must be refreshed from
-  #      the write tables via the same bootstrap path used on init
-  # Outcome: read table refreshed from write tables; projection marked ready
+  # Seeds bypass the event bus, so `rebuild/1` refreshes the read table from
+  # write tables via the same bootstrap path used on init.
   @impl true
   def handle_call(:rebuild, _from, state) do
     {:ok, count} = do_bootstrap()
     Logger.info("ProviderSessionDetails rebuilt", count: count)
-    {:reply, :ok, %{state | bootstrapped: true}}
+    {:reply, :ok, state}
   end
 
   @impl true

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -8,6 +8,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
 
   use GenServer
 
+  import Ecto.Query
+
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
@@ -85,9 +87,33 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     {:noreply, state}
   end
 
+  # Trigger: session entered the live window (instructor started it)
+  # Why: dashboard badge flips from scheduled → in_progress
+  # Outcome: row's status column updated to :in_progress
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_started} = event}, state) do
+    update_status(event.entity_id, :in_progress)
+    {:noreply, state}
+  end
+
+  # Trigger: session finished (end-of-session finalization)
+  # Why: dashboard badge flips from in_progress → completed
+  # Outcome: row's status column updated to :completed
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_completed} = event}, state) do
+    update_status(event.entity_id, :completed)
+    {:noreply, state}
+  end
+
+  # Trigger: session cancelled (by provider or system)
+  # Why: dashboard badge reflects cancellation, independent of prior status
+  # Outcome: row's status column updated to :cancelled
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_cancelled} = event}, state) do
+    update_status(event.entity_id, :cancelled)
+    {:noreply, state}
+  end
+
   @impl true
   def handle_info({:integration_event, _event}, state) do
-    # other event clauses come in Tasks 9–12
+    # remaining event clauses come in Tasks 10–12; final catch-all arrives in Task 12
     {:noreply, state}
   end
 
@@ -136,6 +162,17 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
          ]},
       conflict_target: [:session_id]
     )
+  end
+
+  # Trigger: any of the session_started/completed/cancelled handlers
+  # Why: the three status-transition handlers share the same update shape;
+  #      centralising keeps the transitions uniform and easy to audit
+  # Outcome: the row's status column (and updated_at) is updated in place
+  defp update_status(session_id, status) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
+    |> Repo.update_all(set: [status: status, updated_at: now])
   end
 
   # Trigger: session_created handler needs program_title + provider_id

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -56,14 +56,38 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
 
   @impl true
   def handle_continue(:bootstrap, state) do
-    # implementation comes in Task 13
-    {:noreply, %{state | bootstrapped: true}}
+    # Trigger: GenServer init complete
+    # Why: self-heal the read table from the authoritative write tables on every
+    #      boot. Transient DB failures reschedule via :retry_bootstrap (Task 7);
+    #      persistent failures propagate through repeated retries until the
+    #      supervisor intervenes.
+    # Outcome: read table converges toward a projection of the current write
+    #          state; `bootstrapped: true` marks the projection ready.
+    case do_bootstrap() do
+      {:ok, count} ->
+        Logger.info("ProviderSessionDetails bootstrap complete", count: count)
+        {:noreply, %{state | bootstrapped: true}}
+
+      {:error, reason} ->
+        Logger.warning("ProviderSessionDetails bootstrap failed; retrying",
+          reason: inspect(reason)
+        )
+
+        Process.send_after(self(), :retry_bootstrap, 1_000)
+        {:noreply, state}
+    end
   end
 
+  # Trigger: external caller requests a full rebuild (e.g. after seeds insert
+  #          into write tables without emitting integration events)
+  # Why: seeds bypass the event bus, so the read table must be refreshed from
+  #      the write tables via the same bootstrap path used on init
+  # Outcome: read table refreshed from write tables; projection marked ready
   @impl true
   def handle_call(:rebuild, _from, state) do
-    # implementation comes in Task 13
-    {:reply, :ok, state}
+    {:ok, count} = do_bootstrap()
+    Logger.info("ProviderSessionDetails rebuilt", count: count)
+    {:reply, :ok, %{state | bootstrapped: true}}
   end
 
   @impl true
@@ -308,6 +332,120 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
          ]},
       conflict_target: [:session_id]
     )
+  end
+
+  # Trigger: handle_continue(:bootstrap) or handle_call(:rebuild)
+  # Why: self-heal the read table from the authoritative write tables. Seeds
+  #      bypass the event bus, and long-running event drift can leave the read
+  #      table out of sync — a single bootstrap query rebuilds every row from
+  #      programs + program_sessions + program_staff_assignments + staff_members
+  #      + aggregated participation_records counts.
+  #
+  # Design notes:
+  #
+  # * The SQL casts UUIDs to ::text so Postgrex returns them as string UUIDs
+  #   (Ecto's :binary_id fields accept the string form directly on insert).
+  # * Staff display uses first_name/last_name columns (staff_members has no
+  #   display_name); we concatenate in Elixir via build_staff_name/2 to match
+  #   the event-handler resolution path.
+  # * Status comes back from SQL as text ("scheduled", "in_progress", ...);
+  #   the schema is Ecto.Enum, so inserting via the schema module requires an
+  #   atom — we convert via String.to_existing_atom/1 (safe: values are the
+  #   fixed four enum members).
+  # * Upsert preserves only identity-ish fields (session_id, inserted_at) and
+  #   cover_staff_* (which cannot be derived from write tables yet — rebuilding
+  #   would otherwise clobber whatever was evolved by a future cover handler).
+  #   Everything else (status, counts, assigned staff) is intentionally
+  #   refreshed, which is the whole point of rebuild/0.
+  #
+  # Outcome: {:ok, count} on success or {:error, reason} on DB failure; the
+  #          caller decides whether to retry (handle_continue) or raise (rebuild).
+  defp do_bootstrap do
+    sql = """
+    SELECT
+      ps.id::text                            AS session_id,
+      ps.program_id::text                    AS program_id,
+      p.title                                AS program_title,
+      p.provider_id::text                    AS provider_id,
+      ps.session_date,
+      ps.start_time,
+      ps.end_time,
+      ps.status::text                        AS status,
+      psa.staff_member_id::text              AS current_assigned_staff_id,
+      sm.first_name                          AS staff_first_name,
+      sm.last_name                           AS staff_last_name,
+      COALESCE(counts.checked_in, 0)         AS checked_in_count,
+      COALESCE(counts.total, 0)              AS total_count
+    FROM program_sessions ps
+    JOIN programs p ON p.id = ps.program_id
+    LEFT JOIN program_staff_assignments psa
+           ON psa.program_id = ps.program_id
+          AND psa.unassigned_at IS NULL
+    LEFT JOIN staff_members sm
+           ON sm.id = psa.staff_member_id
+    LEFT JOIN (
+      SELECT session_id,
+             COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out')) AS checked_in,
+             COUNT(*) AS total
+      FROM participation_records
+      GROUP BY session_id
+    ) counts ON counts.session_id = ps.id
+    """
+
+    case Repo.query(sql) do
+      {:ok, %{rows: []}} ->
+        {:ok, 0}
+
+      {:ok, %{rows: rows}} ->
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+        attrs_list =
+          Enum.map(rows, fn [
+                              session_id,
+                              program_id,
+                              program_title,
+                              provider_id,
+                              session_date,
+                              start_time,
+                              end_time,
+                              status,
+                              staff_id,
+                              staff_first,
+                              staff_last,
+                              checked_in_count,
+                              total_count
+                            ] ->
+            %{
+              session_id: session_id,
+              program_id: program_id,
+              program_title: program_title,
+              provider_id: provider_id,
+              session_date: session_date,
+              start_time: start_time,
+              end_time: end_time,
+              status: String.to_existing_atom(status),
+              current_assigned_staff_id: staff_id,
+              current_assigned_staff_name: build_staff_name(staff_first, staff_last),
+              checked_in_count: checked_in_count,
+              total_count: total_count,
+              inserted_at: now,
+              updated_at: now
+            }
+          end)
+
+        {count, _} =
+          Repo.insert_all(
+            ProviderSessionDetailSchema,
+            attrs_list,
+            on_conflict: {:replace_all_except, [:session_id, :inserted_at, :cover_staff_id, :cover_staff_name]},
+            conflict_target: [:session_id]
+          )
+
+        {:ok, count}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   # Trigger: any of the session_started/completed/cancelled handlers

--- a/lib/klass_hero/provider/application/queries/list_program_sessions.ex
+++ b/lib/klass_hero/provider/application/queries/list_program_sessions.ex
@@ -1,0 +1,13 @@
+defmodule KlassHero.Provider.Application.Queries.ListProgramSessions do
+  @moduledoc "Lists per-session detail rows for a provider's program."
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  @for_querying_session_details Application.compile_env!(
+                                  :klass_hero,
+                                  [:provider, :for_querying_session_details]
+                                )
+
+  @spec run(binary(), binary()) :: [SessionDetail.t()]
+  def run(provider_id, program_id), do: @for_querying_session_details.list_by_program(provider_id, program_id)
+end

--- a/lib/klass_hero/provider/application/queries/list_program_sessions.ex
+++ b/lib/klass_hero/provider/application/queries/list_program_sessions.ex
@@ -8,6 +8,6 @@ defmodule KlassHero.Provider.Application.Queries.ListProgramSessions do
                                   [:provider, :for_querying_session_details]
                                 )
 
-  @spec run(binary(), binary()) :: [SessionDetail.t()]
-  def run(provider_id, program_id), do: @for_querying_session_details.list_by_program(provider_id, program_id)
+  @spec execute(binary(), binary()) :: [SessionDetail.t()]
+  def execute(provider_id, program_id), do: @for_querying_session_details.list_by_program(provider_id, program_id)
 end

--- a/lib/klass_hero/provider/domain/ports/for_querying_session_details.ex
+++ b/lib/klass_hero/provider/domain/ports/for_querying_session_details.ex
@@ -1,0 +1,12 @@
+defmodule KlassHero.Provider.Domain.Ports.ForQueryingSessionDetails do
+  @moduledoc """
+  Read port for per-session detail rows.
+
+  Implementations query the `provider_session_details` projection table
+  (populated by `ProviderSessionDetails` GenServer).
+  """
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  @callback list_by_program(provider_id :: binary(), program_id :: binary()) :: [SessionDetail.t()]
+end

--- a/lib/klass_hero/provider/domain/read_models/session_detail.ex
+++ b/lib/klass_hero/provider/domain/read_models/session_detail.ex
@@ -1,0 +1,40 @@
+defmodule KlassHero.Provider.Domain.ReadModels.SessionDetail do
+  @moduledoc "Display-optimized session detail for the provider dashboard."
+
+  @enforce_keys [:session_id, :program_id, :provider_id, :session_date, :start_time, :end_time, :status]
+  defstruct [
+    :session_id,
+    :program_id,
+    :program_title,
+    :provider_id,
+    :session_date,
+    :start_time,
+    :end_time,
+    :status,
+    :current_assigned_staff_id,
+    :current_assigned_staff_name,
+    :cover_staff_id,
+    :cover_staff_name,
+    checked_in_count: 0,
+    total_count: 0
+  ]
+
+  @type status :: :scheduled | :in_progress | :completed | :cancelled
+
+  @type t :: %__MODULE__{
+          session_id: binary(),
+          program_id: binary(),
+          program_title: String.t() | nil,
+          provider_id: binary(),
+          session_date: Date.t(),
+          start_time: Time.t(),
+          end_time: Time.t(),
+          status: status(),
+          current_assigned_staff_id: binary() | nil,
+          current_assigned_staff_name: String.t() | nil,
+          cover_staff_id: binary() | nil,
+          cover_staff_name: String.t() | nil,
+          checked_in_count: non_neg_integer(),
+          total_count: non_neg_integer()
+        }
+end

--- a/lib/klass_hero_web/components/participation_components.ex
+++ b/lib/klass_hero_web/components/participation_components.ex
@@ -116,7 +116,8 @@ defmodule KlassHeroWeb.ParticipationComponents do
       :completed,
       :checked_in,
       :checked_out,
-      :absent
+      :absent,
+      :cancelled
     ],
     doc: "Status to display"
 
@@ -714,6 +715,8 @@ defmodule KlassHeroWeb.ParticipationComponents do
 
   defp status_color_classes(:expected), do: "bg-yellow-100 text-yellow-700 border border-yellow-300"
 
+  defp status_color_classes(:cancelled), do: "bg-red-100 text-red-700 border border-red-300"
+
   defp status_icon(status) when status in [:registered, :scheduled], do: "hero-clock"
   defp status_icon(:in_progress), do: "hero-play-circle"
   defp status_icon(:completed), do: "hero-check-circle"
@@ -721,6 +724,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
   defp status_icon(:checked_out), do: "hero-arrow-left-circle"
   defp status_icon(:absent), do: "hero-x-circle"
   defp status_icon(:expected), do: "hero-clock"
+  defp status_icon(:cancelled), do: "hero-x-circle"
 
   defp status_label(:registered), do: gettext("Registered")
   defp status_label(:scheduled), do: gettext("Scheduled")
@@ -730,6 +734,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
   defp status_label(:checked_out), do: gettext("Checked Out")
   defp status_label(:absent), do: gettext("Absent")
   defp status_label(:expected), do: gettext("Expected")
+  defp status_label(:cancelled), do: gettext("Cancelled")
 
   # Behavioral note status helpers
 

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1374,7 +1374,6 @@ defmodule KlassHeroWeb.ProviderComponents do
                     title={gettext("View sessions")}
                     phx-click="view_sessions"
                     phx-value-program-id={program.id}
-                    phx-value-program-title={program.name}
                   />
                   <.action_button
                     id={"view-roster-#{program.id}"}
@@ -1421,7 +1420,7 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :icon, :string, required: true
   attr :title, :string, required: true
   attr :disabled, :boolean, default: false
-  attr :rest, :global, include: ~w(id phx-click phx-value-id phx-value-program-id phx-value-program-title)
+  attr :rest, :global, include: ~w(id phx-click phx-value-id phx-value-program-id)
 
   defp action_button(assigns) do
     ~H"""

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -11,6 +11,7 @@ defmodule KlassHeroWeb.ProviderComponents do
     statics: KlassHeroWeb.static_paths()
 
   import KlassHeroWeb.CoreComponents, only: [input: 1]
+  import KlassHeroWeb.ParticipationComponents, only: [participation_status: 1]
   import KlassHeroWeb.UIComponents
 
   alias KlassHeroWeb.Presenters.ProviderPresenter
@@ -1567,6 +1568,92 @@ defmodule KlassHeroWeb.ProviderComponents do
               </div>
             <% end %>
           </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a modal listing every session of a program with date/time, assigned
+  staff, cover staff (reserved), attendance count, and status.
+
+  ## Example
+
+      <.sessions_modal :if={@sessions_modal} modal={@sessions_modal} />
+  """
+  attr :modal, :map, required: true
+
+  def sessions_modal(assigns) do
+    ~H"""
+    <div
+      id="sessions-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="sessions-modal-title"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      phx-window-keydown="close_sessions"
+      phx-key="escape"
+    >
+      <div
+        class="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col"
+        phx-click-away="close_sessions"
+      >
+        <div class="flex items-center justify-between px-6 py-4 border-b">
+          <h2 id="sessions-modal-title" class={Theme.typography(:section_title)}>
+            {gettext("Sessions — %{title}", title: @modal.program_title)}
+          </h2>
+          <button type="button" phx-click="close_sessions" aria-label={gettext("Close")}>
+            <.icon name="hero-x-mark" class="w-5 h-5" />
+          </button>
+        </div>
+
+        <div class="flex-1 overflow-y-auto">
+          <%= if @modal.sessions == [] do %>
+            <div class="text-center py-12">
+              <.icon name="hero-calendar-days" class="w-12 h-12 text-hero-grey-300 mx-auto" />
+              <p class="mt-4 text-hero-grey-500">{gettext("No sessions scheduled yet.")}</p>
+            </div>
+          <% else %>
+            <table class="w-full text-sm">
+              <thead class="bg-hero-grey-50 text-left">
+                <tr>
+                  <th class="px-4 py-3">{gettext("Date / time")}</th>
+                  <th class="px-4 py-3">{gettext("Assigned staff")}</th>
+                  <th class="px-4 py-3">{gettext("Cover")}</th>
+                  <th class="px-4 py-3">{gettext("Attendance")}</th>
+                  <th class="px-4 py-3">{gettext("Status")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr :for={s <- @modal.sessions} class="border-t">
+                  <td class="px-4 py-3">
+                    {Calendar.strftime(s.session_date, "%a, %d %b")}
+                    <span class="text-hero-grey-500">
+                      · {Calendar.strftime(s.start_time, "%H:%M")}–{Calendar.strftime(
+                        s.end_time,
+                        "%H:%M"
+                      )}
+                    </span>
+                  </td>
+                  <td class="px-4 py-3">
+                    {s.current_assigned_staff_name || gettext("Unassigned")}
+                  </td>
+                  <td class="px-4 py-3 text-hero-grey-500">
+                    {s.cover_staff_name || "—"}
+                  </td>
+                  <td class="px-4 py-3">
+                    <span :if={s.status != :cancelled}>
+                      {s.checked_in_count} / {s.total_count}
+                    </span>
+                  </td>
+                  <td class="px-4 py-3">
+                    <.participation_status status={s.status} size={:sm} />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          <% end %>
         </div>
       </div>
     </div>

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1370,6 +1370,13 @@ defmodule KlassHeroWeb.ProviderComponents do
                     <.action_button icon="hero-eye-mini" title={gettext("Preview")} />
                   </.link>
                   <.action_button
+                    icon="hero-calendar-days"
+                    title={gettext("View sessions")}
+                    phx-click="view_sessions"
+                    phx-value-program-id={program.id}
+                    phx-value-program-title={program.name}
+                  />
+                  <.action_button
                     id={"view-roster-#{program.id}"}
                     icon="hero-user-group-mini"
                     title={gettext("View Roster")}
@@ -1414,7 +1421,7 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :icon, :string, required: true
   attr :title, :string, required: true
   attr :disabled, :boolean, default: false
-  attr :rest, :global, include: ~w(id phx-click phx-value-id)
+  attr :rest, :global, include: ~w(id phx-click phx-value-id phx-value-program-id phx-value-program-title)
 
   defp action_button(assigns) do
     ~H"""

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -114,6 +114,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
             import_errors: nil,
             can_message?: false
           )
+          |> assign(:sessions_modal, nil)
           |> assign(program_form: to_form(ProgramCatalog.new_program_changeset()))
           |> assign(enrollment_form: to_form(Enrollment.new_policy_changeset(), as: "enrollment_policy"))
           |> assign(
@@ -583,6 +584,29 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
        import_errors: nil,
        can_message?: false
      )}
+  end
+
+  # Trigger: "View sessions" action button on a row in the programs table
+  # Why: program_id comes from client params (untrusted) — list_by_program is
+  #      scoped to the provider_id from the server-side scope, so cross-provider
+  #      peeking is impossible even if the client spoofs the id
+  # Outcome: modal opens with the program's sessions (empty list is valid)
+  @impl true
+  def handle_event("view_sessions", %{"program-id" => program_id, "program-title" => program_title}, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+    sessions = Provider.list_program_sessions(provider_id, program_id)
+
+    {:noreply,
+     assign(socket, :sessions_modal, %{
+       program_id: program_id,
+       program_title: program_title,
+       sessions: sessions
+     })}
+  end
+
+  @impl true
+  def handle_event("close_sessions", _params, socket) do
+    {:noreply, assign(socket, :sessions_modal, nil)}
   end
 
   @impl true
@@ -1133,6 +1157,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
                   roster_invite_count={@roster_invite_count}
                   import_errors={@import_errors}
                   can_message?={@can_message?}
+                  sessions_modal={@sessions_modal}
                 />
             <% end %>
         <% end %>
@@ -1442,6 +1467,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   attr :roster_invite_count, :integer, default: 0
   attr :import_errors, :any, default: nil
   attr :can_message?, :boolean, default: false
+  attr :sessions_modal, :any, default: nil
 
   defp programs_section(assigns) do
     ~H"""
@@ -1478,6 +1504,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
         import_errors={@import_errors}
         can_message?={@can_message?}
       />
+
+      <.sessions_modal :if={@sessions_modal} modal={@sessions_modal} />
     </div>
     """
   end

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -589,12 +589,21 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   # Trigger: "View sessions" action button on a row in the programs table
   # Why: program_id comes from client params (untrusted) — list_by_program is
   #      scoped to the provider_id from the server-side scope, so cross-provider
-  #      peeking is impossible even if the client spoofs the id
-  # Outcome: modal opens with the program's sessions (empty list is valid)
+  #      peeking is impossible even if the client spoofs the id. The modal's
+  #      title is derived from the authoritative projection result (not client
+  #      params) to avoid displaying a spoofed title.
+  # Outcome: modal opens with the program's sessions (empty list is valid);
+  #          title falls back to a generic label when the program has zero sessions.
   @impl true
-  def handle_event("view_sessions", %{"program-id" => program_id, "program-title" => program_title}, socket) do
+  def handle_event("view_sessions", %{"program-id" => program_id}, socket) do
     provider_id = socket.assigns.current_scope.provider.id
     sessions = Provider.list_program_sessions(provider_id, program_id)
+
+    program_title =
+      case List.first(sessions) do
+        %{program_title: title} -> title
+        nil -> gettext("Program")
+      end
 
     {:noreply,
      assign(socket, :sessions_modal, %{

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -39,7 +39,7 @@ msgstr "Kontakt"
 #: lib/klass_hero_web/components/layouts/app.html.heex:138
 #: lib/klass_hero_web/components/layouts/app.html.heex:217
 #: lib/klass_hero_web/components/layouts/app.html.heex:253
-#: lib/klass_hero_web/components/provider_components.ex:356
+#: lib/klass_hero_web/components/provider_components.ex:357
 #: lib/klass_hero_web/live/dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -223,7 +223,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1315
+#: lib/klass_hero_web/components/provider_components.ex:1316
 #: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -628,7 +628,7 @@ msgstr "Streitbeilegung"
 msgid "Don't have an account?"
 msgstr "Noch kein Konto?"
 
-#: lib/klass_hero_web/components/provider_components.ex:644
+#: lib/klass_hero_web/components/provider_components.ex:645
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
 #: lib/klass_hero_web/live/user_live/login.ex:49
@@ -981,9 +981,9 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Magic Link"
 msgstr "Magic-Link senden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
-#: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:1666
+#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1714
+#: lib/klass_hero_web/components/provider_components.ex:1753
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1485,7 +1485,7 @@ msgstr "Push-, E-Mail-, SMS-Einstellungen"
 
 #: lib/klass_hero_web/components/composite_components.ex:102
 #: lib/klass_hero_web/components/layouts/admin.html.heex:58
-#: lib/klass_hero_web/components/provider_components.ex:89
+#: lib/klass_hero_web/components/provider_components.ex:90
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "OUR MISSION"
 msgstr "UNSERE MISSION"
 
-#: lib/klass_hero_web/components/provider_components.ex:681
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr "Qualifikationen"
@@ -1901,19 +1901,19 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1318
-#: lib/klass_hero_web/components/provider_components.ex:1599
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1319
+#: lib/klass_hero_web/components/provider_components.ex:1686
+#: lib/klass_hero_web/components/provider_components.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1399
+#: lib/klass_hero_web/components/provider_components.ex:1400
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr "Aktive Familien"
 
-#: lib/klass_hero_web/components/provider_components.ex:597
+#: lib/klass_hero_web/components/provider_components.ex:598
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1925,7 +1925,7 @@ msgstr "Teammitglied hinzufügen"
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1309
+#: lib/klass_hero_web/components/provider_components.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1936,7 +1936,7 @@ msgstr "Zugewiesenes Personal"
 msgid "Book Now"
 msgstr "Jetzt buchen - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:175
+#: lib/klass_hero_web/components/provider_components.ex:176
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr "Geschäftsprofil"
@@ -1952,67 +1952,67 @@ msgstr "Gewerbeanmeldung"
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/components/provider_components.ex:540
+#: lib/klass_hero_web/components/provider_components.ex:1381
 #: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:193
+#: lib/klass_hero_web/components/provider_components.ex:194
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:166
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:82
+#: lib/klass_hero_web/components/provider_components.ex:83
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:417
-#: lib/klass_hero_web/components/provider_components.ex:799
+#: lib/klass_hero_web/components/provider_components.ex:418
+#: lib/klass_hero_web/components/provider_components.ex:800
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:68
+#: lib/klass_hero_web/components/provider_components.ex:69
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Übersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:45
-#: lib/klass_hero_web/components/provider_components.ex:1400
-#: lib/klass_hero_web/components/provider_components.ex:1829
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:46
+#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1916
+#: lib/klass_hero_web/components/provider_components.ex:1936
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1369
+#: lib/klass_hero_web/components/provider_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1252
+#: lib/klass_hero_web/components/provider_components.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1306
+#: lib/klass_hero_web/components/provider_components.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
 
-#: lib/klass_hero_web/components/provider_components.ex:382
+#: lib/klass_hero_web/components/provider_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Program Slots"
 msgstr "Programmplätze"
@@ -2027,14 +2027,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:1265
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1312
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1779
+#: lib/klass_hero_web/components/provider_components.ex:1313
+#: lib/klass_hero_web/components/provider_components.ex:1625
+#: lib/klass_hero_web/components/provider_components.ex:1680
+#: lib/klass_hero_web/components/provider_components.ex:1866
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2042,7 +2043,7 @@ msgstr "Nach Namen suchen..."
 msgid "Status"
 msgstr "Status"
 
-#: lib/klass_hero_web/components/provider_components.ex:75
+#: lib/klass_hero_web/components/provider_components.ex:76
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr "Team & Profile"
@@ -2052,30 +2053,31 @@ msgstr "Team & Profile"
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
-#: lib/klass_hero_web/components/provider_components.ex:178
+#: lib/klass_hero_web/components/provider_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1342
+#: lib/klass_hero_web/components/provider_components.ex:1343
+#: lib/klass_hero_web/components/provider_components.ex:1640
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
-#: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:1403
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/klass_hero_web/components/provider_components.ex:374
+#: lib/klass_hero_web/components/provider_components.ex:375
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1374
+#: lib/klass_hero_web/components/provider_components.ex:1375
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -2145,9 +2147,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
 #: lib/klass_hero_web/components/participation_components.ex:635
-#: lib/klass_hero_web/components/provider_components.ex:764
-#: lib/klass_hero_web/components/provider_components.ex:1168
-#: lib/klass_hero_web/components/provider_components.ex:1718
+#: lib/klass_hero_web/components/provider_components.ex:765
+#: lib/klass_hero_web/components/provider_components.ex:1169
+#: lib/klass_hero_web/components/provider_components.ex:1805
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2404,7 +2406,7 @@ msgstr "Programmplätze"
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:749
+#: lib/klass_hero_web/components/provider_components.ex:750
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
 #: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
@@ -2416,8 +2418,8 @@ msgstr "Änderungen speichern"
 msgid "Search for programs..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1485
 #: lib/klass_hero_web/components/provider_components.ex:1486
+#: lib/klass_hero_web/components/provider_components.ex:1487
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2580,12 +2582,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:276
+#: lib/klass_hero_web/components/provider_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:751
+#: lib/klass_hero_web/components/provider_components.ex:752
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr "Teammitglied hinzufügen"
@@ -2605,12 +2607,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr "Alter %{range}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1028
+#: lib/klass_hero_web/components/provider_components.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1894
+#: lib/klass_hero_web/components/provider_components.ex:1981
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
@@ -2622,7 +2624,7 @@ msgid "Approve"
 msgstr "Genehmigen"
 
 #: lib/klass_hero_web/components/participation_components.ex:752
-#: lib/klass_hero_web/components/provider_components.ex:46
+#: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
 #, elixir-autogen, elixir-format
@@ -2634,7 +2636,7 @@ msgstr "Genehmigt"
 msgid "Are you sure you want to approve this document?"
 msgstr "Möchten Sie dieses Kind wirklich entfernen?"
 
-#: lib/klass_hero_web/components/provider_components.ex:559
+#: lib/klass_hero_web/components/provider_components.ex:560
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to remove this team member?"
 msgstr "Möchten Sie dieses Kind wirklich entfernen?"
@@ -2644,7 +2646,7 @@ msgstr "Möchten Sie dieses Kind wirklich entfernen?"
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1152
+#: lib/klass_hero_web/components/provider_components.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
@@ -2666,7 +2668,7 @@ msgstr ""
 msgid "Berlin's leading network for tutors, coaches, and camp providers!"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:653
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2676,7 +2678,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:653
+#: lib/klass_hero_web/components/provider_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2712,18 +2714,18 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:829
+#: lib/klass_hero_web/components/provider_components.ex:830
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:976
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1773
+#: lib/klass_hero_web/components/provider_components.ex:1677
+#: lib/klass_hero_web/components/provider_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2738,7 +2740,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2748,17 +2750,17 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:831
+#: lib/klass_hero_web/components/provider_components.ex:832
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:432
+#: lib/klass_hero_web/components/provider_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2768,7 +2770,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1830
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2794,35 +2796,35 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1096
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:968
+#: lib/klass_hero_web/components/provider_components.ex:969
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1089
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:603
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:1040
 #: lib/klass_hero_web/live/settings/children_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2855,7 +2857,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1738
+#: lib/klass_hero_web/components/provider_components.ex:1825
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2865,39 +2867,39 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:798
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr "Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:595
+#: lib/klass_hero_web/components/provider_components.ex:596
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:910
+#: lib/klass_hero_web/components/provider_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:896
+#: lib/klass_hero_web/components/provider_components.ex:897
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1596
-#: lib/klass_hero_web/components/provider_components.ex:1852
+#: lib/klass_hero_web/components/provider_components.ex:1683
+#: lib/klass_hero_web/components/provider_components.ex:1939
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/components/provider_components.ex:1533
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:940
+#: lib/klass_hero_web/components/provider_components.ex:941
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2907,7 +2909,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1853
+#: lib/klass_hero_web/components/provider_components.ex:1940
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2939,7 +2941,7 @@ msgid "Family Programs"
 msgstr "Familienfortschritt"
 
 #: lib/klass_hero_web/components/program_components.ex:601
-#: lib/klass_hero_web/components/provider_components.ex:1038
+#: lib/klass_hero_web/components/provider_components.ex:1039
 #: lib/klass_hero_web/live/settings/children_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2950,22 +2952,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:2019
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1934
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:682
+#: lib/klass_hero_web/components/provider_components.ex:683
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:623
+#: lib/klass_hero_web/components/provider_components.ex:624
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr "Vorname"
@@ -2990,12 +2992,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1776
+#: lib/klass_hero_web/components/provider_components.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:692
+#: lib/klass_hero_web/components/provider_components.ex:693
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -3005,12 +3007,12 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr "Wichtig:"
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1838
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
@@ -3045,17 +3047,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1549
+#: lib/klass_hero_web/components/provider_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:731
+#: lib/klass_hero_web/components/provider_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1144
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
@@ -3077,22 +3079,22 @@ msgstr ""
 msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:629
+#: lib/klass_hero_web/components/provider_components.ex:630
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:922
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1031
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:849
+#: lib/klass_hero_web/components/provider_components.ex:850
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -3105,43 +3107,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:602
-#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/components/provider_components.ex:1038
 #: lib/klass_hero_web/live/settings/children_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:955
+#: lib/klass_hero_web/components/provider_components.ex:956
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1077
+#: lib/klass_hero_web/components/provider_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:860
+#: lib/klass_hero_web/components/provider_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1014
+#: lib/klass_hero_web/components/provider_components.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:949
+#: lib/klass_hero_web/components/provider_components.ex:950
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -3156,12 +3158,12 @@ msgstr "Mo-Fr, 9-17 Uhr"
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1670
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -3177,17 +3179,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1763
+#: lib/klass_hero_web/components/provider_components.ex:1850
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1079
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1072
+#: lib/klass_hero_web/components/provider_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -3218,18 +3220,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1154
+#: lib/klass_hero_web/components/provider_components.ex:1155
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:291
+#: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:604
-#: lib/klass_hero_web/components/provider_components.ex:1040
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #: lib/klass_hero_web/live/settings/children_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -3240,7 +3242,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2036
+#: lib/klass_hero_web/components/provider_components.ex:2123
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3250,13 +3252,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:966
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:751
-#: lib/klass_hero_web/components/provider_components.ex:261
+#: lib/klass_hero_web/components/provider_components.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr "Ausstehend"
@@ -3281,7 +3283,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:840
+#: lib/klass_hero_web/components/provider_components.ex:841
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -3291,7 +3293,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1004
+#: lib/klass_hero_web/components/provider_components.ex:1005
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr "Programmplätze"
@@ -3330,13 +3332,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1938
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:991
+#: lib/klass_hero_web/components/provider_components.ex:992
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr "Anmeldegebühr:"
@@ -3346,7 +3348,7 @@ msgstr "Anmeldegebühr:"
 msgid "Registration Closed"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/components/provider_components.ex:932
+#: lib/klass_hero_web/components/provider_components.ex:933
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr "Anmeldegebühr:"
@@ -3356,12 +3358,12 @@ msgstr "Anmeldegebühr:"
 msgid "Registration Not Open Yet"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:928
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/components/provider_components.ex:918
+#: lib/klass_hero_web/components/provider_components.ex:919
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3398,7 +3400,7 @@ msgid "Reject"
 msgstr "Ablehnen"
 
 #: lib/klass_hero_web/components/participation_components.ex:753
-#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -3410,17 +3412,17 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:714
-#: lib/klass_hero_web/components/provider_components.ex:1119
-#: lib/klass_hero_web/components/provider_components.ex:1811
-#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:715
+#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:2142
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3430,30 +3432,30 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/components/provider_components.ex:1476
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1861
-#: lib/klass_hero_web/components/provider_components.ex:1873
-#: lib/klass_hero_web/components/provider_components.ex:1884
+#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:1971
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1181
+#: lib/klass_hero_web/components/provider_components.ex:1182
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:857
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3468,7 +3470,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:2120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr "Kind auswählen"
@@ -3485,18 +3487,18 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1937
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:686
+#: lib/klass_hero_web/components/provider_components.ex:687
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:943
+#: lib/klass_hero_web/components/provider_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
@@ -3506,7 +3508,7 @@ msgstr ""
 msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:659
+#: lib/klass_hero_web/components/provider_components.ex:660
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -3523,12 +3525,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:905
+#: lib/klass_hero_web/components/provider_components.ex:906
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:891
+#: lib/klass_hero_web/components/provider_components.ex:892
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3594,7 +3596,7 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:822
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -3604,7 +3606,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1933
+#: lib/klass_hero_web/components/provider_components.ex:2020
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3624,32 +3626,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1695
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
+#: lib/klass_hero_web/components/provider_components.ex:2166
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2041
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1935
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3671,7 +3673,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:246
+#: lib/klass_hero_web/components/provider_components.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified"
 msgstr "Verifiziertes Unternehmen"
@@ -3686,32 +3688,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:640
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr "Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:630
+#: lib/klass_hero_web/components/provider_components.ex:631
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:624
+#: lib/klass_hero_web/components/provider_components.ex:625
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:646
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:823
+#: lib/klass_hero_web/components/provider_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:850
+#: lib/klass_hero_web/components/provider_components.ex:851
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -4425,7 +4427,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/components/provider_components.ex:1752
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -4553,7 +4555,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/components/provider_components.ex:1501
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -4580,7 +4582,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4736,7 +4738,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1747
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
@@ -5372,7 +5374,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:554
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -5592,7 +5594,7 @@ msgstr "Die Teilnahme Ihrer Kinder wird hier angezeigt"
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:393
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Team Members"
 msgstr "Teammitglied hinzufügen"
@@ -5793,7 +5795,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:434
+#: lib/klass_hero_web/components/provider_components.ex:435
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "You've reached your program limit. Upgrade your plan to add more programs."
@@ -5819,3 +5821,38 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "for"
 msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1622
+#, elixir-autogen, elixir-format
+msgid "Assigned staff"
+msgstr "Zugewiesenes Personal"
+
+#: lib/klass_hero_web/components/provider_components.ex:1624
+#, elixir-autogen, elixir-format
+msgid "Attendance"
+msgstr "Anwesenheit"
+
+#: lib/klass_hero_web/components/provider_components.ex:1606
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr "Schließen"
+
+#: lib/klass_hero_web/components/provider_components.ex:1623
+#, elixir-autogen, elixir-format
+msgid "Cover"
+msgstr "Vertretung"
+
+#: lib/klass_hero_web/components/provider_components.ex:1621
+#, elixir-autogen, elixir-format
+msgid "Date / time"
+msgstr "Datum / Uhrzeit"
+
+#: lib/klass_hero_web/components/provider_components.ex:1615
+#, elixir-autogen, elixir-format
+msgid "No sessions scheduled yet."
+msgstr "Noch keine Sessions geplant."
+
+#: lib/klass_hero_web/components/provider_components.ex:1604
+#, elixir-autogen, elixir-format
+msgid "Sessions — %{title}"
+msgstr "Sessions — %{title}"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -11,8 +11,8 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:57
-#: lib/klass_hero_web/components/layouts/app.html.heex:248
+#: lib/klass_hero_web/components/layouts/app.html.heex:44
+#: lib/klass_hero_web/components/layouts/app.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über uns"
@@ -28,19 +28,19 @@ msgstr "Verbindung wird wiederhergestellt"
 msgid "Choose your preferred language for the interface"
 msgstr "Wählen Sie Ihre bevorzugte Sprache für die Benutzeroberfläche"
 
-#: lib/klass_hero_web/components/composite_components.ex:603
-#: lib/klass_hero_web/components/layouts/app.html.heex:65
-#: lib/klass_hero_web/components/layouts/app.html.heex:249
+#: lib/klass_hero_web/components/composite_components.ex:608
+#: lib/klass_hero_web/components/layouts/app.html.heex:52
+#: lib/klass_hero_web/components/layouts/app.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:128
-#: lib/klass_hero_web/components/layouts/app.html.heex:168
-#: lib/klass_hero_web/components/layouts/app.html.heex:255
-#: lib/klass_hero_web/components/layouts/app.html.heex:285
-#: lib/klass_hero_web/components/provider_components.ex:355
-#: lib/klass_hero_web/live/dashboard_live.ex:52
+#: lib/klass_hero_web/components/layouts/app.html.heex:113
+#: lib/klass_hero_web/components/layouts/app.html.heex:138
+#: lib/klass_hero_web/components/layouts/app.html.heex:217
+#: lib/klass_hero_web/components/layouts/app.html.heex:253
+#: lib/klass_hero_web/components/provider_components.ex:356
+#: lib/klass_hero_web/live/dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -60,8 +60,8 @@ msgstr "Laden Sie eine Kopie aller Ihrer persönlichen Daten herunter"
 msgid "Failed to update language preference."
 msgstr "Spracheinstellung konnte nicht aktualisiert werden."
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:41
-#: lib/klass_hero_web/components/layouts/app.html.heex:246
+#: lib/klass_hero_web/components/layouts/app.html.heex:28
+#: lib/klass_hero_web/components/layouts/app.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -76,22 +76,22 @@ msgstr "Spracheinstellung"
 msgid "Language preference updated successfully."
 msgstr "Spracheinstellung erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:205
-#: lib/klass_hero_web/components/layouts/app.html.heex:303
+#: lib/klass_hero_web/components/layouts/app.html.heex:167
+#: lib/klass_hero_web/components/layouts/app.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Login"
 msgstr "Anmelden"
 
-#: lib/klass_hero_web/components/composite_components.ex:601
-#: lib/klass_hero_web/components/composite_components.ex:609
-#: lib/klass_hero_web/components/layouts/app.html.heex:49
-#: lib/klass_hero_web/components/layouts/app.html.heex:247
+#: lib/klass_hero_web/components/composite_components.ex:602
+#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/layouts/app.html.heex:36
+#: lib/klass_hero_web/components/layouts/app.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr "Programme"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:152
-#: lib/klass_hero_web/components/layouts/app.html.heex:277
+#: lib/klass_hero_web/components/layouts/app.html.heex:122
+#: lib/klass_hero_web/components/layouts/app.html.heex:245
 #: lib/klass_hero_web/live/settings_live.ex:17
 #: lib/klass_hero_web/live/settings_live.ex:56
 #, elixir-autogen, elixir-format
@@ -99,15 +99,15 @@ msgid "Settings"
 msgstr "Einstellungen"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:20
-#: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/layouts/app.html.heex:297
+#: lib/klass_hero_web/components/layouts/app.html.heex:159
+#: lib/klass_hero_web/components/layouts/app.html.heex:265
 #: lib/klass_hero_web/live/settings_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Sign Out"
 msgstr "Abmelden"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:211
-#: lib/klass_hero_web/components/layouts/app.html.heex:311
+#: lib/klass_hero_web/components/layouts/app.html.heex:173
+#: lib/klass_hero_web/components/layouts/app.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Sign Up"
 msgstr "Registrieren"
@@ -127,109 +127,104 @@ msgstr "Keine Internetverbindung gefunden"
 msgid "Your Data"
 msgstr "Ihre Daten"
 
-#: lib/klass_hero_web/components/core_components.ex:68
-#: lib/klass_hero_web/components/provider_components.ex:1501
+#: lib/klass_hero_web/components/core_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
 
-#: lib/klass_hero_web/live/booking_live.ex:445
+#: lib/klass_hero_web/live/booking_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr "%{name} (Alter %{age})"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:365
+#: lib/klass_hero_web/live/program_detail_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr "Über dieses Programm"
 
-#: lib/klass_hero_web/live/booking_live.ex:352
+#: lib/klass_hero_web/live/booking_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr "Aktivitätsübersicht"
 
-#: lib/klass_hero_web/live/booking_live.ex:458
+#: lib/klass_hero_web/live/booking_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr "Weiteres Kind hinzufügen"
 
-#: lib/klass_hero_web/live/booking_live.ex:393
+#: lib/klass_hero_web/live/booking_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr "Weiteres Programm hinzufügen"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:197
+#: lib/klass_hero_web/live/program_detail_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr "Alter %{range}"
 
-#: lib/klass_hero_web/live/booking_live.ex:531
+#: lib/klass_hero_web/live/booking_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr "Nach Abschluss der Anmeldung erhalten Sie eine Rechnung per E-Mail"
 
-#: lib/klass_hero_web/live/booking_live.ex:475
+#: lib/klass_hero_web/live/booking_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr "Allergien, medizinische Bedingungen oder besondere Hinweise..."
 
-#: lib/klass_hero_web/live/home_live.ex:235
+#: lib/klass_hero_web/live/home_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr "Buchen Sie Camps, Nachhilfe und Workshops sofort. Unser integrierter Planer hilft Ihnen, den vollen Terminkalender Ihres Kindes zu verwalten."
 
-#: lib/klass_hero_web/live/home_live.ex:245
-#, elixir-autogen, elixir-format
-msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
-msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
-
-#: lib/klass_hero_web/live/booking_live.ex:508
+#: lib/klass_hero_web/live/booking_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr "Bar / Überweisung"
 
-#: lib/klass_hero_web/live/booking_live.ex:533
+#: lib/klass_hero_web/live/booking_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie eingegangen sind"
 
-#: lib/klass_hero_web/live/home_live.ex:243
+#: lib/klass_hero_web/live/home_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr "Gemeinschaftsorientiert"
 
-#: lib/klass_hero_web/live/booking_live.ex:550
+#: lib/klass_hero_web/live/booking_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr "Anmeldung abschließen"
 
-#: lib/klass_hero_web/live/booking_live.ex:499
+#: lib/klass_hero_web/live/booking_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr "Kreditkarte"
 
-#: lib/klass_hero_web/live/booking_live.ex:532
+#: lib/klass_hero_web/live/booking_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr "Kreditkartenzahlungen werden sofort verarbeitet"
 
-#: lib/klass_hero_web/live/booking_live.ex:384
+#: lib/klass_hero_web/live/booking_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr "Dauer:"
 
-#: lib/klass_hero_web/live/home_live.ex:233
+#: lib/klass_hero_web/live/home_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr "Einfache Terminplanung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:521
+#: lib/klass_hero_web/live/program_detail_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1308
-#: lib/klass_hero_web/live/booking_live.ex:347
+#: lib/klass_hero_web/components/provider_components.ex:1315
+#: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr "Anmeldung"
@@ -239,7 +234,7 @@ msgstr "Anmeldung"
 msgid "Enrollment - %{title}"
 msgstr "Anmeldung - %{title}"
 
-#: lib/klass_hero_web/live/booking_live.ex:220
+#: lib/klass_hero_web/live/booking_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support."
@@ -249,7 +244,7 @@ msgstr "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut oder kontaktiere
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr "Anmeldung erfolgreich! Sie erhalten in Kürze eine Bestätigungs-E-Mail."
 
-#: lib/klass_hero_web/live/home_live.ex:225
+#: lib/klass_hero_web/live/home_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr "Jeder Anbieter wird sorgfältig geprüft. Wir stellen die Sicherheit der Kinder an erste Stelle und geben Eltern die nötige Sicherheit."
@@ -270,17 +265,12 @@ msgstr "Entdecken Sie erstklassige Aktivitäten für Ihre Kinder"
 msgid "Featured Programs"
 msgstr "Empfohlene Programme"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:347
-#, elixir-autogen, elixir-format
-msgid "Free cancellation up to 48 hours before start date"
-msgstr "Kostenlose Stornierung bis 48 Stunden vor Beginn"
-
 #: lib/klass_hero_web/live/programs_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
 
-#: lib/klass_hero_web/live/booking_live.ex:529
+#: lib/klass_hero_web/live/booking_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr "Rechnung & Zahlungsbestätigung"
@@ -295,7 +285,7 @@ msgstr "Mehr Programme laden"
 msgid "Loading..."
 msgstr "Laden..."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:405
+#: lib/klass_hero_web/live/program_detail_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -307,22 +297,22 @@ msgstr[1] "Triff die Helden"
 msgid "No programs found"
 msgstr "Keine Programme gefunden"
 
-#: lib/klass_hero_web/live/booking_live.ex:483
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr "Optional: Wichtige Informationen über Ihr Kind, die wir wissen sollten."
 
-#: lib/klass_hero_web/live/booking_live.ex:500
+#: lib/klass_hero_web/live/booking_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr "Sicher bezahlen mit Visa, Mastercard oder anderen Karten"
 
-#: lib/klass_hero_web/live/booking_live.ex:494
+#: lib/klass_hero_web/live/booking_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr "Zahlungsmethode"
 
-#: lib/klass_hero_web/live/booking_live.ex:518
+#: lib/klass_hero_web/live/booking_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr "Zahlungsübersicht"
@@ -332,7 +322,7 @@ msgstr "Zahlungsübersicht"
 msgid "Payment information is invalid. Please check your details."
 msgstr "Zahlungsinformationen ungültig. Bitte überprüfen Sie Ihre Angaben."
 
-#: lib/klass_hero_web/live/booking_live.ex:177
+#: lib/klass_hero_web/live/booking_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr "Bitte wählen Sie ein Kind für die Anmeldung aus."
@@ -344,17 +334,18 @@ msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädag
 
 #: lib/klass_hero_web/live/booking_live.ex:59
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:47
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr "Programm nicht gefunden"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:53
+#: lib/klass_hero_web/live/program_detail_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr "Programm nicht gefunden. Es wurde möglicherweise entfernt oder ist nicht mehr verfügbar."
 
-#: lib/klass_hero_web/live/about_live.ex:149
-#: lib/klass_hero_web/live/home_live.ex:223
+#: lib/klass_hero_web/live/about_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Safety First"
 msgstr "Sicherheit zuerst"
@@ -370,12 +361,12 @@ msgstr "Sicherheit, Qualität und Komfort für moderne Familien."
 msgid "Search programs..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/live/booking_live.ex:429
+#: lib/klass_hero_web/live/booking_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr "Kind auswählen"
 
-#: lib/klass_hero_web/live/booking_live.ex:439
+#: lib/klass_hero_web/live/booking_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr "Ein Kind auswählen"
@@ -390,17 +381,17 @@ msgstr "Dieses Programm ist derzeit ausgebucht. Bitte schauen Sie später wieder
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr "Dieses Programm ist jetzt ausgebucht. Bitte wählen Sie ein anderes Programm."
 
-#: lib/klass_hero_web/live/booking_live.ex:468
+#: lib/klass_hero_web/live/booking_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr "Besondere Anforderungen"
 
-#: lib/klass_hero_web/live/booking_live.ex:377
+#: lib/klass_hero_web/live/booking_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr "Gesamtpreis:"
 
-#: lib/klass_hero_web/live/booking_live.ex:524
+#: lib/klass_hero_web/live/booking_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr "Heute fällig:"
@@ -411,7 +402,7 @@ msgid "Try adjusting your search or filter criteria."
 msgstr "Versuchen Sie, Ihre Such- oder Filterkriterien anzupassen."
 
 #: lib/klass_hero_web/live/booking_live.ex:84
-#: lib/klass_hero_web/live/program_detail_live.ex:60
+#: lib/klass_hero_web/live/program_detail_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Unable to load program. Please try again later."
 msgstr "Programm konnte nicht geladen werden. Bitte versuchen Sie es später erneut."
@@ -426,7 +417,7 @@ msgstr "Alle Programme ansehen →"
 msgid "Why Klass Hero?"
 msgstr "Warum Klass Hero Connect?"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:209
+#: lib/klass_hero_web/live/program_detail_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr "✓ Keine versteckten Gebühren"
@@ -436,7 +427,7 @@ msgstr "✓ Keine versteckten Gebühren"
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Ein Bestätigungslink wurde an Ihre neue E-Mail-Adresse gesendet."
 
-#: lib/klass_hero_web/components/composite_components.ex:602
+#: lib/klass_hero_web/components/composite_components.ex:605
 #: lib/klass_hero_web/live/about_live.ex:10
 #, elixir-autogen, elixir-format
 msgid "About Us"
@@ -453,6 +444,7 @@ msgid "Account Termination"
 msgstr "Kontobeendigung"
 
 #: lib/klass_hero_web/live/contact_live.ex:81
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr "Adresse"
@@ -467,7 +459,7 @@ msgstr "Zustimmung zu den Bedingungen"
 msgid "Already registered?"
 msgstr "Bereits registriert?"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:160
+#: lib/klass_hero_web/live/user_live/registration.ex:159
 #, elixir-autogen, elixir-format
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr "Eine E-Mail wurde an %{email} gesendet. Bitte bestätigen Sie Ihr Konto über den Link."
@@ -507,14 +499,14 @@ msgstr "Wird geändert..."
 msgid "Check out our FAQ section for answers to common questions."
 msgstr "Schauen Sie in unsere FAQ für Antworten auf häufige Fragen."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:66
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:66
+#: lib/klass_hero_web/live/provider/participation_live.ex:67
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr "Kind erfolgreich eingecheckt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:133
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
+#: lib/klass_hero_web/live/provider/participation_live.ex:130
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr "Kind erfolgreich ausgecheckt"
@@ -529,7 +521,7 @@ msgstr "Datenschutz für Kinder"
 msgid "Closed"
 msgstr "Geschlossen"
 
-#: lib/klass_hero_web/live/about_live.ex:195
+#: lib/klass_hero_web/live/about_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Community"
 msgstr "Gemeinschaft"
@@ -561,11 +553,11 @@ msgstr "Wird bestätigt..."
 msgid "Contact Information"
 msgstr "Kontaktdaten"
 
-#: lib/klass_hero_web/components/composite_components.ex:788
+#: lib/klass_hero_web/components/composite_components.ex:808
 #: lib/klass_hero_web/live/contact_live.ex:15
 #: lib/klass_hero_web/live/contact_live.ex:112
 #: lib/klass_hero_web/live/privacy_policy_live.ex:217
-#: lib/klass_hero_web/live/trust_safety_live.ex:227
+#: lib/klass_hero_web/live/trust_safety_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Kontakt"
@@ -631,16 +623,16 @@ msgstr "Deutsch"
 msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
-#: lib/klass_hero_web/live/user_live/login.ex:17
+#: lib/klass_hero_web/live/user_live/login.ex:18
 #, elixir-autogen, elixir-format
 msgid "Don't have an account?"
 msgstr "Noch kein Konto?"
 
-#: lib/klass_hero_web/components/provider_components.ex:637
+#: lib/klass_hero_web/components/provider_components.ex:644
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
-#: lib/klass_hero_web/live/user_live/login.ex:48
-#: lib/klass_hero_web/live/user_live/login.ex:80
+#: lib/klass_hero_web/live/user_live/login.ex:49
+#: lib/klass_hero_web/live/user_live/login.ex:81
 #: lib/klass_hero_web/live/user_live/registration.ex:39
 #: lib/klass_hero_web/live/user_live/settings.ex:155
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:60
@@ -673,20 +665,20 @@ msgstr "Kinder für Programme anmelden"
 msgid "Enter your password to confirm"
 msgstr "Geben Sie Ihr Passwort zur Bestätigung ein"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:81
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:81
+#: lib/klass_hero_web/live/provider/participation_live.ex:82
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr "Einchecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:150
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/live/provider/participation_live.ex:147
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:114
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
+#: lib/klass_hero_web/live/provider/sessions_live.ex:134
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
@@ -696,16 +688,16 @@ msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:355
-#: lib/klass_hero_web/live/provider/participation_live.ex:356
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:306
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:307
+#: lib/klass_hero_web/live/provider/participation_live.ex:328
+#: lib/klass_hero_web/live/provider/participation_live.ex:329
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:283
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Failed to load session data"
 msgstr "Sitzungsdaten konnten nicht geladen werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:91
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:111
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
@@ -735,7 +727,7 @@ msgstr "Wie wir Ihre Daten verwenden"
 msgid "I want to..."
 msgstr "Ich möchte..."
 
-#: lib/klass_hero_web/live/user_live/login.ex:141
+#: lib/klass_hero_web/live/user_live/login.ex:142
 #, elixir-autogen, elixir-format
 msgid "If your email is in our system, you will receive instructions for logging in shortly."
 msgstr "Wenn Ihre E-Mail in unserem System ist, erhalten Sie in Kürze Anweisungen zum Anmelden."
@@ -760,9 +752,9 @@ msgstr "Geistiges Eigentum"
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:69
-#: lib/klass_hero_web/live/provider/sessions_live.ex:319
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
+#: lib/klass_hero_web/live/provider/sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:336
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
@@ -777,7 +769,7 @@ msgstr "Ungültiges Passwort."
 msgid "Keep me logged in on this device"
 msgstr "Auf diesem Gerät angemeldet bleiben"
 
-#: lib/klass_hero_web/components/composite_components.ex:719
+#: lib/klass_hero_web/components/composite_components.ex:739
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr "Zuletzt aktualisiert:"
@@ -793,12 +785,12 @@ msgstr "Haftungsbeschränkung"
 msgid "Log in"
 msgstr "Anmelden"
 
-#: lib/klass_hero_web/live/user_live/login.ex:92
+#: lib/klass_hero_web/live/user_live/login.ex:93
 #, elixir-autogen, elixir-format
 msgid "Log in and stay logged in"
 msgstr "Anmelden und angemeldet bleiben"
 
-#: lib/klass_hero_web/live/user_live/login.ex:95
+#: lib/klass_hero_web/live/user_live/login.ex:96
 #, elixir-autogen, elixir-format
 msgid "Log in only this time"
 msgstr "Nur dieses Mal anmelden"
@@ -820,13 +812,14 @@ msgstr "Anmeldung läuft..."
 msgid "Looking for Quick Answers?"
 msgstr "Suchen Sie schnelle Antworten?"
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:91
+#: lib/klass_hero_web/live/user_live/confirmation.ex:90
 #, elixir-autogen, elixir-format
 msgid "Magic link is invalid or it has expired."
 msgstr "Der Magic-Link ist ungültig oder abgelaufen."
 
 #: lib/klass_hero_web/live/contact_live.ex:162
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
@@ -841,15 +834,15 @@ msgstr "Nachricht erfolgreich gesendet!"
 msgid "Monday - Friday"
 msgstr "Montag - Freitag"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:159
+#: lib/klass_hero_web/live/dashboard_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "My Children"
 msgstr "Meine Kinder"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:20
+#: lib/klass_hero_web/live/provider/sessions_live.ex:35
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:5
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:23
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:24
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
@@ -876,23 +869,23 @@ msgstr "Programme und Dienstleistungen anbieten"
 msgid "Office Hours"
 msgstr "Bürozeiten"
 
-#: lib/klass_hero_web/live/user_live/login.ex:104
+#: lib/klass_hero_web/live/user_live/login.ex:105
 #, elixir-autogen, elixir-format
 msgid "Or use magic link"
 msgstr "Oder Magic-Link verwenden"
 
-#: lib/klass_hero_web/live/user_live/login.ex:63
+#: lib/klass_hero_web/live/user_live/login.ex:64
 #, elixir-autogen, elixir-format
 msgid "Or use password"
 msgstr "Oder Passwort verwenden"
 
 #: lib/klass_hero_web/live/contact_live.ex:154
-#: lib/klass_hero_web/presenters/provider_presenter.ex:110
+#: lib/klass_hero_web/presenters/provider_presenter.ex:129
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Sonstiges"
 
-#: lib/klass_hero_web/live/user_live/login.ex:88
+#: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/settings.ex:170
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:68
 #, elixir-autogen, elixir-format
@@ -905,11 +898,12 @@ msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
 
 #: lib/klass_hero_web/live/contact_live.ex:73
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr "Telefon"
 
-#: lib/klass_hero_web/components/composite_components.ex:656
+#: lib/klass_hero_web/components/composite_components.ex:676
 #: lib/klass_hero_web/live/privacy_policy_live.ex:10
 #: lib/klass_hero_web/live/privacy_policy_live.ex:235
 #, elixir-autogen, elixir-format
@@ -936,16 +930,16 @@ msgstr "Fragen zum Datenschutz?"
 msgid "Questions About These Terms?"
 msgstr "Fragen zu diesen Bedingungen?"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:271
-#: lib/klass_hero_web/live/provider/participation_live.ex:56
-#: lib/klass_hero_web/live/provider/participation_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:56
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
+#: lib/klass_hero_web/live/admin/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/participation_live.ex:57
+#: lib/klass_hero_web/live/provider/participation_live.ex:119
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:57
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr "Eintrag nicht gefunden"
 
-#: lib/klass_hero_web/live/user_live/login.ex:21
+#: lib/klass_hero_web/live/user_live/login.ex:22
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr "Registrieren"
@@ -965,7 +959,8 @@ msgstr "Samstag"
 msgid "Save Password"
 msgstr "Passwort speichern"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:771
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
+#: lib/klass_hero_web/live/settings/children_live.ex:765
 #: lib/klass_hero_web/live/user_live/settings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -981,15 +976,18 @@ msgstr "Thema auswählen..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/live/user_live/login.ex:54
+#: lib/klass_hero_web/live/user_live/login.ex:55
 #, elixir-autogen, elixir-format
 msgid "Send Magic Link"
 msgstr "Magic-Link senden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1620
-#: lib/klass_hero_web/components/provider_components.ex:1621
-#: lib/klass_hero_web/components/provider_components.ex:1661
+#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1627
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #: lib/klass_hero_web/live/contact_live.ex:184
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr "Nachricht senden"
@@ -999,28 +997,29 @@ msgstr "Nachricht senden"
 msgid "Send us a Message"
 msgstr "Schreiben Sie uns eine Nachricht"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:100
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
+#: lib/klass_hero_web/live/provider/sessions_live.ex:120
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:69
 #: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:344
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:295
+#: lib/klass_hero_web/live/provider/participation_live.ex:317
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:77
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
+#: lib/klass_hero_web/live/provider/sessions_live.ex:97
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr "Sitzung erfolgreich gestartet"
 
 #: lib/klass_hero_web/live/contact_live.ex:146
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
@@ -1030,7 +1029,7 @@ msgstr "Betreff"
 msgid "Sunday"
 msgstr "Sonntag"
 
-#: lib/klass_hero_web/components/composite_components.ex:727
+#: lib/klass_hero_web/components/composite_components.ex:747
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr "Inhaltsverzeichnis"
@@ -1040,7 +1039,7 @@ msgstr "Inhaltsverzeichnis"
 msgid "Technical Issue"
 msgstr "Technisches Problem"
 
-#: lib/klass_hero_web/components/composite_components.ex:658
+#: lib/klass_hero_web/components/composite_components.ex:678
 #: lib/klass_hero_web/live/terms_of_service_live.ex:10
 #: lib/klass_hero_web/live/terms_of_service_live.ex:268
 #, elixir-autogen, elixir-format
@@ -1057,7 +1056,7 @@ msgstr "Diese Aktion kann nicht rückgängig gemacht werden. Ihre Kontodaten wer
 msgid "Tip: If you prefer passwords, you can enable them in the user settings."
 msgstr "Tipp: Wenn Sie Passwörter bevorzugen, können Sie diese in den Benutzereinstellungen aktivieren."
 
-#: lib/klass_hero_web/live/user_live/login.ex:31
+#: lib/klass_hero_web/live/user_live/login.ex:32
 #, elixir-autogen, elixir-format
 msgid "To see sent emails, visit"
 msgstr "Um gesendete E-Mails zu sehen, besuchen Sie"
@@ -1077,7 +1076,7 @@ msgstr "Benutzerkonten & Registrierung"
 msgid "User Conduct & Responsibilities"
 msgstr "Nutzerverhalten & Verantwortlichkeiten"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:162
+#: lib/klass_hero_web/live/dashboard_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "View All"
 msgstr "Alle Anzeigen"
@@ -1117,43 +1116,43 @@ msgstr "Wir sind hier, um Ihnen bei allen Fragen zu helfen"
 msgid "Welcome %{email}"
 msgstr "Willkommen %{email}"
 
-#: lib/klass_hero_web/live/user_live/login.ex:12
+#: lib/klass_hero_web/live/user_live/login.ex:13
 #, elixir-autogen, elixir-format
 msgid "Welcome Back"
 msgstr "Willkommen zurück"
 
-#: lib/klass_hero_web/live/user_live/login.ex:29
+#: lib/klass_hero_web/live/user_live/login.ex:30
 #, elixir-autogen, elixir-format
 msgid "You are running the local mail adapter."
 msgstr "Sie verwenden den lokalen E-Mail-Adapter."
 
-#: lib/klass_hero_web/user_auth.ex:369
+#: lib/klass_hero_web/user_auth.ex:368
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated to access this page."
 msgstr "Sie müssen angemeldet sein, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:282
+#: lib/klass_hero_web/user_auth.ex:281
 #, elixir-autogen, elixir-format
 msgid "You must have a parent profile to access this page."
 msgstr "Sie müssen ein Eltern-Profil haben, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:291
+#: lib/klass_hero_web/user_auth.ex:290
 #, elixir-autogen, elixir-format
 msgid "You must have a provider profile to access this page."
 msgstr "Sie müssen ein Anbieter-Profil haben, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:252
-#: lib/klass_hero_web/user_auth.ex:418
+#: lib/klass_hero_web/user_auth.ex:251
+#: lib/klass_hero_web/user_auth.ex:417
 #, elixir-autogen, elixir-format
 msgid "You must log in to access this page."
 msgstr "Sie müssen sich anmelden, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:269
+#: lib/klass_hero_web/user_auth.ex:268
 #, elixir-autogen, elixir-format
 msgid "You must re-authenticate to access this page."
 msgstr "Sie müssen sich erneut authentifizieren, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/live/user_live/login.ex:15
+#: lib/klass_hero_web/live/user_live/login.ex:16
 #, elixir-autogen, elixir-format
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr "Sie müssen sich erneut authentifizieren, um sensible Aktionen auf Ihrem Konto durchzuführen."
@@ -1173,12 +1172,12 @@ msgstr "Ihr Konto wurde gelöscht."
 msgid "Your privacy matters to us"
 msgstr "Ihre Privatsphäre ist uns wichtig"
 
-#: lib/klass_hero_web/live/user_live/login.ex:21
+#: lib/klass_hero_web/live/user_live/login.ex:22
 #, elixir-autogen, elixir-format
 msgid "for an account now."
 msgstr "für ein Konto jetzt."
 
-#: lib/klass_hero_web/live/user_live/login.ex:31
+#: lib/klass_hero_web/live/user_live/login.ex:32
 #, elixir-autogen, elixir-format
 msgid "the mailbox page"
 msgstr "die Postfach-Seite"
@@ -1188,12 +1187,12 @@ msgstr "die Postfach-Seite"
 msgid "to your account now."
 msgstr "zu Ihrem Konto jetzt."
 
-#: lib/klass_hero_web/components/composite_components.ex:611
+#: lib/klass_hero_web/components/composite_components.ex:622
 #, elixir-autogen, elixir-format
 msgid "Afterschool"
 msgstr "Nachmittagsbetreuung"
 
-#: lib/klass_hero_web/components/composite_components.ex:653
+#: lib/klass_hero_web/components/composite_components.ex:673
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr "Alle Rechte vorbehalten."
@@ -1203,32 +1202,27 @@ msgstr "Alle Rechte vorbehalten."
 msgid "Building the future of youth education by connecting communities."
 msgstr "Wir gestalten die Zukunft der Jugendbildung durch die Vernetzung von Gemeinschaften."
 
-#: lib/klass_hero_web/components/composite_components.ex:613
+#: lib/klass_hero_web/components/composite_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "Class Trips"
 msgstr "Klassenfahrten"
 
-#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/composite_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Connect"
 msgstr "Verbinden"
 
-#: lib/klass_hero_web/components/composite_components.ex:614
+#: lib/klass_hero_web/components/composite_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "Enrichment"
 msgstr "Bereicherung"
-
-#: lib/klass_hero_web/components/composite_components.ex:604
-#, elixir-autogen, elixir-format
-msgid "FAQ"
-msgstr "FAQ"
 
 #: lib/klass_hero_web/components/composite_components.ex:599
 #, elixir-autogen, elixir-format
 msgid "Quick Links"
 msgstr "Schnellzugriffe"
 
-#: lib/klass_hero_web/components/composite_components.ex:612
+#: lib/klass_hero_web/components/composite_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "Summer Camps"
 msgstr "Sommercamps"
@@ -1279,7 +1273,7 @@ msgid "Cards, bank accounts, billing info"
 msgstr "Karten, Bankkonten, Rechnungsinformationen"
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:373
+#: lib/klass_hero_web/live/settings/children_live.ex:367
 #: lib/klass_hero_web/live/settings_live.ex:88
 #: lib/klass_hero_web/live/user_live/settings.ex:48
 #: lib/klass_hero_web/live/user_live/settings.ex:347
@@ -1494,7 +1488,7 @@ msgstr "Push-, E-Mail-, SMS-Einstellungen"
 #: lib/klass_hero_web/components/provider_components.ex:89
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:115
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Sessions"
 msgstr "Sitzungen"
@@ -1544,21 +1538,21 @@ msgstr "Willkommen zurück"
 msgid "WhatsApp Community"
 msgstr "WhatsApp-Community"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:188
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:221
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:178
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:15
+#: lib/klass_hero_web/live/provider/participation_live.ex:16
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:284
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:22
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr "Teilnahme verwalten"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:16
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:17
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Participation History"
@@ -1581,7 +1575,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:152
+#: lib/klass_hero_web/live/about_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "All instructors are background-checked and verified"
 msgstr "Alle Lehrkräfte sind hintergrundgeprüft und verifiziert"
@@ -1592,12 +1586,12 @@ msgstr "Alle Lehrkräfte sind hintergrundgeprüft und verifiziert"
 msgid "Arts"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:198
+#: lib/klass_hero_web/live/about_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Building connections between families and local instructors"
 msgstr "Aufbau von Verbindungen zwischen Familien und lokalen Lehrkräften"
 
-#: lib/klass_hero_web/live/about_live.ex:115
+#: lib/klass_hero_web/live/about_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Built for Berlin Families"
 msgstr "Für Berliner Familien entwickelt"
@@ -1607,12 +1601,12 @@ msgstr "Für Berliner Familien entwickelt"
 msgid "Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:278
+#: lib/klass_hero_web/live/home_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Create a Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:288
+#: lib/klass_hero_web/live/home_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Deliver Quality"
 msgstr ""
@@ -1628,12 +1622,12 @@ msgstr ""
 msgid "Education"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:215
+#: lib/klass_hero_web/live/about_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Every instructor goes through rigorous screening to ensure the highest quality"
 msgstr "Jede Lehrkraft durchläuft eine strenge Überprüfung, um höchste Qualität zu gewährleisten"
 
-#: lib/klass_hero_web/live/home_live.ex:513
+#: lib/klass_hero_web/live/home_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Everything you need to know about Klass Hero"
 msgstr ""
@@ -1643,37 +1637,37 @@ msgstr ""
 msgid "For Families"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:259
+#: lib/klass_hero_web/live/home_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "For Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:510
+#: lib/klass_hero_web/live/home_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Frequently Asked Questions"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:123
+#: lib/klass_hero_web/live/about_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr "Von Sport über Kunst, Technologie bis Sprachen – wir machen es einfach, bereichernde Aktivitäten zu entdecken, die zu Zeitplan und Budget Ihrer Familie passen."
 
-#: lib/klass_hero_web/live/about_live.ex:294
+#: lib/klass_hero_web/live/about_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "GET STARTED TODAY"
 msgstr "HEUTE LOSLEGEN"
 
-#: lib/klass_hero_web/live/home_live.ex:298
+#: lib/klass_hero_web/live/home_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:265
+#: lib/klass_hero_web/live/home_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "How to Grow Your Youth Program: Let's Build Together."
 msgstr "Ihr Programm zum Wachsen bringen: Gemeinsam aufbauen."
 
-#: lib/klass_hero_web/live/home_live.ex:268
+#: lib/klass_hero_web/live/home_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Join our community of passionate educators. Tools and support to help you succeed."
 msgstr ""
@@ -1694,17 +1688,17 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:100
+#: lib/klass_hero_web/live/about_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "OUR MISSION"
 msgstr "UNSERE MISSION"
 
-#: lib/klass_hero_web/components/provider_components.ex:674
+#: lib/klass_hero_web/components/provider_components.ex:681
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr "Qualifikationen"
 
-#: lib/klass_hero_web/live/about_live.ex:288
+#: lib/klass_hero_web/live/about_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "Ready to join the movement?"
 msgstr "Bereit, Teil der Bewegung zu werden?"
@@ -1714,12 +1708,12 @@ msgstr "Bereit, Teil der Bewegung zu werden?"
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:300
+#: lib/klass_hero_web/live/home_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Secure payments, insights into your business, and opportunities to expand your impact."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:280
+#: lib/klass_hero_web/live/home_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
@@ -1730,27 +1724,27 @@ msgstr ""
 msgid "Sports"
 msgstr "Sport"
 
-#: lib/klass_hero_web/live/home_live.ex:316
+#: lib/klass_hero_web/live/home_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Start Teaching Today →"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:175
+#: lib/klass_hero_web/live/about_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Supporting local programs and eco-conscious practices"
 msgstr "Unterstützung lokaler Programme und umweltbewusster Praktiken"
 
-#: lib/klass_hero_web/live/about_live.ex:172
+#: lib/klass_hero_web/live/about_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "Nachhaltigkeit"
 
-#: lib/klass_hero_web/live/home_live.ex:290
+#: lib/klass_hero_web/live/home_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Teach your passion with our tools for scheduling, communication, and progress tracking."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:103
+#: lib/klass_hero_web/live/about_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "To modernize how families discover and engage with children's programs in Berlin"
 msgstr "Die Art und Weise zu modernisieren, wie Familien Kinderprogramme in Berlin entdecken und nutzen"
@@ -1760,7 +1754,7 @@ msgstr "Die Art und Weise zu modernisieren, wie Familien Kinderprogramme in Berl
 msgid "Trending in Berlin:"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:118
+#: lib/klass_hero_web/live/about_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr "Wir verstehen die einzigartigen Bedürfnisse der vielfältigen Familien Berlins. Unsere Plattform verbindet Sie mit geprüften, hochwertigen Programmen, die zu Ihren Werten und den Interessen Ihrer Kinder passen."
@@ -1770,21 +1764,21 @@ msgstr "Wir verstehen die einzigartigen Bedürfnisse der vielfältigen Familien 
 msgid "Workshops"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:181
-#: lib/klass_hero_web/live/settings/children_live.ex:402
-#: lib/klass_hero_web/live/settings/children_live.ex:424
-#: lib/klass_hero_web/live/settings/children_live.ex:646
-#: lib/klass_hero_web/live/settings/children_live.ex:780
+#: lib/klass_hero_web/live/dashboard_live.ex:215
+#: lib/klass_hero_web/live/settings/children_live.ex:396
+#: lib/klass_hero_web/live/settings/children_live.ex:418
+#: lib/klass_hero_web/live/settings/children_live.ex:640
+#: lib/klass_hero_web/live/settings/children_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr "Kind Hinzufügen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:71
+#: lib/klass_hero_web/live/dashboard_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Almost there! One more to go!"
 msgstr "Fast geschafft! Noch eine Aktivität!"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:70
+#: lib/klass_hero_web/live/dashboard_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Congratulations! Goal achieved!"
 msgstr "Glückwunsch! Ziel erreicht!"
@@ -1829,12 +1823,12 @@ msgstr "Code Teilen"
 msgid "Weekly Activity Goal"
 msgstr "Wöchentliches Aktivitätsziel"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:72
+#: lib/klass_hero_web/live/dashboard_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "You're just getting started!"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:73
+#: lib/klass_hero_web/live/dashboard_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "You're doing great! Keep it up!"
 msgstr "Du machst das großartig! Weiter so!"
@@ -1907,37 +1901,37 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1311
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1777
+#: lib/klass_hero_web/components/provider_components.ex:1318
+#: lib/klass_hero_web/components/provider_components.ex:1599
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1392
+#: lib/klass_hero_web/components/provider_components.ex:1399
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr "Aktive Familien"
 
-#: lib/klass_hero_web/components/provider_components.ex:590
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1341
+#: lib/klass_hero_web/components/provider_components.ex:597
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:74
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1554
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:81
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1623
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1302
+#: lib/klass_hero_web/components/provider_components.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:324
-#: lib/klass_hero_web/live/program_detail_live.ex:545
+#: lib/klass_hero_web/live/program_detail_live.ex:363
+#: lib/klass_hero_web/live/program_detail_live.ex:579
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Book Now"
 msgstr "Jetzt buchen - %{price}"
@@ -1947,32 +1941,32 @@ msgstr "Jetzt buchen - %{price}"
 msgid "Business Profile"
 msgstr "Geschäftsprofil"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:96
-#: lib/klass_hero_web/presenters/provider_presenter.ex:106
+#: lib/klass_hero_web/presenters/provider_presenter.ex:115
+#: lib/klass_hero_web/presenters/provider_presenter.ex:125
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1324
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:532
-#: lib/klass_hero_web/components/provider_components.ex:1373
-#: lib/klass_hero_web/live/settings/children_live.ex:473
+#: lib/klass_hero_web/components/provider_components.ex:539
+#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
 #: lib/klass_hero_web/components/provider_components.ex:193
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:158
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1129
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:166
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1394
+#: lib/klass_hero_web/components/provider_components.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1982,8 +1976,8 @@ msgstr "Inaktiv"
 msgid "My Programs"
 msgstr "Meine Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:792
+#: lib/klass_hero_web/components/provider_components.ex:417
+#: lib/klass_hero_web/components/provider_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
@@ -1994,53 +1988,53 @@ msgid "Overview"
 msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:45
-#: lib/klass_hero_web/components/provider_components.ex:1393
-#: lib/klass_hero_web/components/provider_components.ex:1824
-#: lib/klass_hero_web/components/provider_components.ex:1844
-#: lib/klass_hero_web/live/admin/sessions_live.ex:322
+#: lib/klass_hero_web/components/provider_components.ex:1400
+#: lib/klass_hero_web/components/provider_components.ex:1829
+#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1362
+#: lib/klass_hero_web/components/provider_components.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1299
+#: lib/klass_hero_web/components/provider_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
 
-#: lib/klass_hero_web/components/provider_components.ex:381
+#: lib/klass_hero_web/components/provider_components.ex:382
 #, elixir-autogen, elixir-format
 msgid "Program Slots"
 msgstr "Programmplätze"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:83
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr "Anbieter-Dashboard"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:337
+#: lib/klass_hero_web/live/program_detail_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1257
+#: lib/klass_hero_web/components/provider_components.ex:1264
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1305
-#: lib/klass_hero_web/components/provider_components.ex:1587
-#: lib/klass_hero_web/components/provider_components.ex:1774
+#: lib/klass_hero_web/components/provider_components.ex:1312
+#: lib/klass_hero_web/components/provider_components.ex:1593
+#: lib/klass_hero_web/components/provider_components.ex:1779
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2053,7 +2047,7 @@ msgstr "Status"
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1321
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -2063,231 +2057,229 @@ msgstr "Team- & Anbieterprofile"
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:50
+#: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:1395
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/klass_hero_web/components/provider_components.ex:373
+#: lib/klass_hero_web/components/provider_components.ex:374
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1367
+#: lib/klass_hero_web/components/provider_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:455
+#: lib/klass_hero_web/live/settings/children_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:542
+#: lib/klass_hero_web/components/messaging_components.ex:664
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:206
+#: lib/klass_hero_web/live/dashboard_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "%{remaining} remaining"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:410
+#: lib/klass_hero_web/live/settings/children_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr "Fügen Sie Ihr erstes Kind hinzu, um mit Aktivitäten und Programmen zu beginnen."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:525
-#: lib/klass_hero_web/live/settings/children_live.ex:721
+#: lib/klass_hero_web/live/settings/children_live.ex:519
+#: lib/klass_hero_web/live/settings/children_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Allergies"
 msgstr "Allergien"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:748
+#: lib/klass_hero_web/live/settings/children_live.ex:742
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr "Aktivitätsanbietern Zugriff auf die Profilinformationen dieses Kindes für die Programmteilnahme erlauben."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:227
+#: lib/klass_hero_web/live/settings/children_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred. Please try again."
 msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:729
+#: lib/klass_hero_web/live/settings/children_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr "Besondere Bedürfnisse oder Unterstützungsbedarf..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:388
+#: lib/klass_hero_web/live/settings/children_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Back to Settings"
 msgstr "Zurück zu Einstellungen"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:190
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
+#: lib/klass_hero_web/live/provider/participation_live.ex:182
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr "Verhaltensnotiz zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:136
+#: lib/klass_hero_web/components/messaging_components.ex:147
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:78
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
 #: lib/klass_hero_web/components/participation_components.ex:635
-#: lib/klass_hero_web/components/provider_components.ex:757
-#: lib/klass_hero_web/components/provider_components.ex:1161
-#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:764
+#: lib/klass_hero_web/components/provider_components.ex:1168
+#: lib/klass_hero_web/components/provider_components.ex:1718
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:197
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:606
-#: lib/klass_hero_web/live/settings/children_live.ex:766
+#: lib/klass_hero_web/live/settings/children_live.ex:600
+#: lib/klass_hero_web/live/settings/children_live.ex:760
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:311
+#: lib/klass_hero_web/live/settings/children_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Child added successfully."
 msgstr "Kind erfolgreich hinzugefügt."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:314
+#: lib/klass_hero_web/live/settings/children_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Child added, but consent update failed. Please try again."
 msgstr "Kind hinzugefügt, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/settings/children_live.ex:89
-#: lib/klass_hero_web/live/settings/children_live.ex:189
+#: lib/klass_hero_web/live/settings/children_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Child not found."
 msgstr "Kind nicht gefunden."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:182
+#: lib/klass_hero_web/live/settings/children_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child removed successfully."
 msgstr "Kind erfolgreich entfernt."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:316
+#: lib/klass_hero_web/live/settings/children_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Child updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:319
+#: lib/klass_hero_web/live/settings/children_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "Child updated, but consent update failed. Please try again."
 msgstr "Kind aktualisiert, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:304
+#: lib/klass_hero_web/live/messaging_live_helper.ex:354
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:137
+#: lib/klass_hero_web/live/messaging_live_helper.ex:164
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:198
+#: lib/klass_hero_web/live/settings/children_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Could not remove child. Please try again."
 msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:503
+#: lib/klass_hero_web/live/settings/children_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:685
+#: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:487
+#: lib/klass_hero_web/live/settings/children_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:648
+#: lib/klass_hero_web/live/settings/children_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr "Kind bearbeiten"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:514
-#: lib/klass_hero_web/live/settings/children_live.ex:714
+#: lib/klass_hero_web/live/settings/children_live.ex:508
+#: lib/klass_hero_web/live/settings/children_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Emergency contact"
 msgstr "Notfallkontakt"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:65
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr "Notiz konnte nicht genehmigt werden"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:237
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Failed to load pending notes"
 msgstr "Ausstehende Notizen konnten nicht geladen werden"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:116
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:271
+#: lib/klass_hero_web/live/provider/participation_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:100
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send broadcast"
 msgstr "Sitzungsdaten konnten nicht geladen werden"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:171
-#, elixir-autogen, elixir-format
-msgid "Failed to send message"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/participation_live.ex:208
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:206
+#: lib/klass_hero_web/live/provider/participation_live.ex:199
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:671
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:677
+#: lib/klass_hero_web/live/settings/children_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:722
+#: lib/klass_hero_web/live/settings/children_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr "Bekannte Allergien auflisten..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:374
+#: lib/klass_hero_web/live/settings/children_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr "Informationen und Einwilligungen Ihrer Kinder verwalten"
@@ -2298,83 +2290,86 @@ msgid "Manage your children's profiles"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:64
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:268
-#: lib/klass_hero_web/components/messaging_components.ex:331
-#: lib/klass_hero_web/components/messaging_components.ex:354
-#: lib/klass_hero_web/live/messaging_live_helper.ex:265
+#: lib/klass_hero_web/components/layouts/app.html.heex:236
+#: lib/klass_hero_web/components/messaging_components.ex:434
+#: lib/klass_hero_web/components/messaging_components.ex:457
+#: lib/klass_hero_web/live/messaging_live_helper.ex:301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr "Nachricht"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:195
+#: lib/klass_hero_web/live/dashboard_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Monthly Booking Usage"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:409
+#: lib/klass_hero_web/live/settings/children_live.ex:403
 #: lib/klass_hero_web/presenters/child_presenter.ex:96
 #, elixir-autogen, elixir-format
 msgid "No children yet"
 msgstr "Noch keine Kinder"
 
-#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:399
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:263
-#: lib/klass_hero_web/components/messaging_components.ex:552
+#: lib/klass_hero_web/components/messaging_components.ex:368
+#: lib/klass_hero_web/components/messaging_components.ex:674
+#: lib/klass_hero_web/components/messaging_components.ex:685
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:92
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:56
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr "Notiz genehmigt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:196
-#: lib/klass_hero_web/live/provider/participation_live.ex:263
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:194
+#: lib/klass_hero_web/live/provider/participation_live.ex:188
+#: lib/klass_hero_web/live/provider/participation_live.ex:250
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:105
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:257
+#: lib/klass_hero_web/live/provider/participation_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:541
+#: lib/klass_hero_web/components/messaging_components.ex:663
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:715
+#: lib/klass_hero_web/live/settings/children_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr "Telefonnummer oder Name"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:221
+#: lib/klass_hero_web/live/settings/children_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Please check the form for errors."
 msgstr "Bitte überprüfen Sie das Formular auf Fehler."
 
-#: lib/klass_hero_web/live/booking_live.ex:194
+#: lib/klass_hero_web/live/booking_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr ""
@@ -2399,19 +2394,19 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:300
+#: lib/klass_hero_web/live/messaging_live_helper.ex:350
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
 msgstr "Programmplätze"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:745
+#: lib/klass_hero_web/live/settings/children_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:742
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
-#: lib/klass_hero_web/live/settings/children_live.ex:782
+#: lib/klass_hero_web/components/provider_components.ex:749
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
+#: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
@@ -2421,70 +2416,78 @@ msgstr "Änderungen speichern"
 msgid "Search for programs..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1479
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1485
+#: lib/klass_hero_web/components/provider_components.ex:1486
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:222
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:266
+#: lib/klass_hero_web/components/messaging_components.ex:371
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:226
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending..."
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:536
-#: lib/klass_hero_web/live/settings/children_live.ex:728
+#: lib/klass_hero_web/live/settings/children_live.ex:530
+#: lib/klass_hero_web/live/settings/children_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr "Unterstützungsbedarf"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:219
+#: lib/klass_hero_web/components/messaging_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:375
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:326
+#: lib/klass_hero_web/live/provider/participation_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
 
-#: lib/klass_hero_web/live/booking_live.ex:421
-#: lib/klass_hero_web/live/dashboard_live.ex:216
+#: lib/klass_hero_web/live/booking_live.ex:418
+#: lib/klass_hero_web/live/dashboard_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Upgrade"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:165
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:200
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr "Sie haben bereits eine Notiz für diesen Eintrag eingereicht"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:143
+#: lib/klass_hero_web/live/messaging_live_helper.ex:170
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:144
+#: lib/klass_hero_web/live/settings/children_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to delete this child."
 msgstr "Sie haben keine Berechtigung, dieses Kind zu löschen."
@@ -2494,54 +2497,57 @@ msgstr "Sie haben keine Berechtigung, dieses Kind zu löschen."
 msgid "You don't have permission to edit this child."
 msgstr "Sie haben keine Berechtigung, dieses Kind zu bearbeiten."
 
-#: lib/klass_hero_web/live/booking_live.ex:408
+#: lib/klass_hero_web/live/booking_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "You have %{remaining} of %{total} bookings remaining this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:200
+#: lib/klass_hero_web/live/dashboard_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "You have used %{used} of %{cap} bookings this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:184
+#: lib/klass_hero_web/live/booking_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "You've reached your monthly booking limit. Upgrade to Active tier for unlimited bookings."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:402
+#: lib/klass_hero_web/live/booking_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Your Booking Plan"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:304
+#: lib/klass_hero_web/components/messaging_components.ex:408
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:307
+#: lib/klass_hero_web/components/messaging_components.ex:410
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:25
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:86
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your subscription tier doesn't support broadcasts"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:152
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:414
-#: lib/klass_hero_web/live/dashboard_live.ex:209
+#: lib/klass_hero_web/live/booking_live.ex:411
+#: lib/klass_hero_web/live/dashboard_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "tier"
 msgstr ""
@@ -2553,23 +2559,23 @@ msgid_plural "%{count} documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:586
-#: lib/klass_hero_web/components/program_components.ex:594
+#: lib/klass_hero_web/components/program_components.ex:575
+#: lib/klass_hero_web/components/program_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/klass_hero_web/components/program_components.ex:571
 #: lib/klass_hero_web/components/program_components.ex:582
-#: lib/klass_hero_web/components/program_components.ex:593
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:607
+#: lib/klass_hero_web/components/program_components.ex:596
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr ""
@@ -2579,32 +2585,32 @@ msgstr ""
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:744
+#: lib/klass_hero_web/components/provider_components.ex:751
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1363
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:566
+#: lib/klass_hero_web/components/program_components.ex:555
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:570
+#: lib/klass_hero_web/components/program_components.ex:559
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Ages %{min}+"
 msgstr "Alter %{range}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1889
+#: lib/klass_hero_web/components/provider_components.ex:1894
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
@@ -2615,9 +2621,9 @@ msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:752
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/live/admin/sessions_live.ex:319
+#: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Approved"
@@ -2628,22 +2634,23 @@ msgstr "Genehmigt"
 msgid "Are you sure you want to approve this document?"
 msgstr "Möchten Sie dieses Kind wirklich entfernen?"
 
-#: lib/klass_hero_web/components/provider_components.ex:552
+#: lib/klass_hero_web/components/provider_components.ex:559
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to remove this team member?"
 msgstr "Möchten Sie dieses Kind wirklich entfernen?"
 
-#: lib/klass_hero_web/live/home_live.ex:484
+#: lib/klass_hero_web/live/home_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1145
+#: lib/klass_hero_web/components/provider_components.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1125
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1199
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
 #: lib/klass_hero_web/live/provider/subscription_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
@@ -2659,27 +2666,27 @@ msgstr ""
 msgid "Berlin's leading network for tutors, coaches, and camp providers!"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:652
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:251
+#: lib/klass_hero_web/live/dashboard_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:646
+#: lib/klass_hero_web/components/provider_components.ex:653
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:252
+#: lib/klass_hero_web/live/about_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Built by Parents and Educators for More Learning Opportunities"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:481
+#: lib/klass_hero_web/live/home_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
@@ -2689,33 +2696,34 @@ msgstr ""
 msgid "Business"
 msgstr "Business-Plan"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1147
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business Description"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1134
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1155
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:822
+#: lib/klass_hero_web/components/provider_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:968
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1584
-#: lib/klass_hero_web/components/provider_components.ex:1768
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1773
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2730,27 +2738,27 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1133
+#: lib/klass_hero_web/components/provider_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1209
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1283
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:721
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:824
+#: lib/klass_hero_web/components/provider_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:429
+#: lib/klass_hero_web/components/provider_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2760,12 +2768,12 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1825
+#: lib/klass_hero_web/components/provider_components.ex:1830
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:413
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -2775,45 +2783,46 @@ msgstr ""
 msgid "Could not load verification documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:690
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:646
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:654
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:668
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:961
+#: lib/klass_hero_web/components/provider_components.ex:968
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1081
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:614
-#: lib/klass_hero_web/components/provider_components.ex:1032
-#: lib/klass_hero_web/live/settings/children_live.ex:698
+#: lib/klass_hero_web/components/program_components.ex:603
+#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/live/settings/children_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1996
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2841,12 +2850,12 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:435
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1733
+#: lib/klass_hero_web/components/provider_components.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2856,39 +2865,39 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:790
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr "Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:588
+#: lib/klass_hero_web/components/provider_components.ex:595
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:903
+#: lib/klass_hero_web/components/provider_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:896
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1596
+#: lib/klass_hero_web/components/provider_components.ex:1852
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1526
+#: lib/klass_hero_web/components/provider_components.ex:1532
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:933
+#: lib/klass_hero_web/components/provider_components.ex:940
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2898,8 +2907,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1848
-#: lib/klass_hero_web/live/admin/emails_live.ex:221
+#: lib/klass_hero_web/components/provider_components.ex:1853
+#: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr "Fehlgeschlagen"
@@ -2914,24 +2923,24 @@ msgstr "Notiz konnte nicht genehmigt werden"
 msgid "Failed to reject document."
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:628
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:444
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to upload document."
 msgstr "Sitzungsdaten konnten nicht geladen werden"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:232
+#: lib/klass_hero_web/live/dashboard_live.ex:266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Family Programs"
 msgstr "Familienfortschritt"
 
-#: lib/klass_hero_web/components/program_components.ex:612
-#: lib/klass_hero_web/components/provider_components.ex:1031
-#: lib/klass_hero_web/live/settings/children_live.ex:697
+#: lib/klass_hero_web/components/program_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:1038
+#: lib/klass_hero_web/live/settings/children_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
@@ -2941,196 +2950,198 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1929
+#: lib/klass_hero_web/components/provider_components.ex:1932
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1931
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:675
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:616
+#: lib/klass_hero_web/components/provider_components.ex:623
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:693
+#: lib/klass_hero_web/live/settings/children_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:621
+#: lib/klass_hero_web/components/program_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:630
+#: lib/klass_hero_web/components/program_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:626
+#: lib/klass_hero_web/components/program_components.ex:614
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1771
+#: lib/klass_hero_web/components/provider_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:685
+#: lib/klass_hero_web/components/provider_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:108
+#: lib/klass_hero_web/presenters/provider_presenter.ex:127
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1705
+#: lib/klass_hero_web/components/provider_components.ex:1710
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr "Wichtig:"
 
-#: lib/klass_hero_web/components/provider_components.ex:1746
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:699
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} families."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:263
+#: lib/klass_hero_web/live/about_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "In 2025, Shane connected with his friend Max Pergl, a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom, offering more to the community, but without the time to manage bookings, payments, and compliance on their own."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:107
+#: lib/klass_hero_web/presenters/provider_presenter.ex:126
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Insurance Certificate"
 msgstr "Versicherung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:643
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:640
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:617
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1543
+#: lib/klass_hero_web/components/provider_components.ex:1549
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:724
+#: lib/klass_hero_web/components/provider_components.ex:731
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1212
+#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:268
+#: lib/klass_hero_web/live/about_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:707
+#: lib/klass_hero_web/live/settings/children_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:273
+#: lib/klass_hero_web/live/about_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:622
+#: lib/klass_hero_web/components/provider_components.ex:629
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:914
+#: lib/klass_hero_web/components/provider_components.ex:921
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1024
+#: lib/klass_hero_web/components/provider_components.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:842
+#: lib/klass_hero_web/components/provider_components.ex:849
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:390
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:613
-#: lib/klass_hero_web/components/provider_components.ex:1030
-#: lib/klass_hero_web/live/settings/children_live.ex:696
+#: lib/klass_hero_web/components/program_components.ex:602
+#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/live/settings/children_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1013
+#: lib/klass_hero_web/components/provider_components.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:948
+#: lib/klass_hero_web/components/provider_components.ex:955
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:853
+#: lib/klass_hero_web/components/provider_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1007
+#: lib/klass_hero_web/components/provider_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:942
+#: lib/klass_hero_web/components/provider_components.ex:949
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/components/provider_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -3145,38 +3156,38 @@ msgstr "Mo-Fr, 9-17 Uhr"
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:1960
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1577
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:168
+#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:686
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:706
+#: lib/klass_hero_web/live/settings/children_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1763
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1072
+#: lib/klass_hero_web/components/provider_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/components/provider_components.ex:1072
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -3186,7 +3197,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:240
+#: lib/klass_hero_web/live/dashboard_live.ex:274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs booked yet"
 msgstr "Keine Programme gefunden"
@@ -3196,7 +3207,7 @@ msgstr "Keine Programme gefunden"
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1362
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1411
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -3207,7 +3218,7 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1147
+#: lib/klass_hero_web/components/provider_components.ex:1154
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
@@ -3217,44 +3228,45 @@ msgstr ""
 msgid "Not Verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:615
-#: lib/klass_hero_web/components/provider_components.ex:1033
-#: lib/klass_hero_web/live/settings/children_live.ex:695
+#: lib/klass_hero_web/components/program_components.ex:604
+#: lib/klass_hero_web/components/provider_components.ex:1040
+#: lib/klass_hero_web/live/settings/children_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:479
+#: lib/klass_hero_web/live/home_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:537
+#: lib/klass_hero_web/components/program_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:958
+#: lib/klass_hero_web/components/provider_components.ex:965
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/participation_components.ex:751
 #: lib/klass_hero_web/components/provider_components.ex:261
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:380
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:858
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:955
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1035
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:884
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:945
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:980
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1052
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -3269,87 +3281,87 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:833
+#: lib/klass_hero_web/components/provider_components.ex:840
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:376
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:405
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:997
+#: lib/klass_hero_web/components/provider_components.ex:1004
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr "Programmplätze"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1870
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1937
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr "Benutzer erfolgreich bestätigt."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1877
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1944
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:506
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:542
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:545
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:895
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:529
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:565
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:568
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr "Programm nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:883
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:909
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:385
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:499
+#: lib/klass_hero_web/live/home_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:728
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/participation_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:984
+#: lib/klass_hero_web/components/provider_components.ex:991
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:157
+#: lib/klass_hero_web/live/program_detail_live.ex:190
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closed"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/components/provider_components.ex:925
+#: lib/klass_hero_web/components/provider_components.ex:932
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Not Open Yet"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/components/provider_components.ex:920
+#: lib/klass_hero_web/components/provider_components.ex:927
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr "Anmeldegebühr:"
 
-#: lib/klass_hero_web/components/provider_components.ex:911
+#: lib/klass_hero_web/components/provider_components.ex:918
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3359,7 +3371,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:129
+#: lib/klass_hero_web/live/program_detail_live.ex:162
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration is closed"
 msgstr "Anmeldegebühr:"
@@ -3369,12 +3381,12 @@ msgstr "Anmeldegebühr:"
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:78
+#: lib/klass_hero_web/live/program_detail_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:125
+#: lib/klass_hero_web/live/program_detail_live.ex:158
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration opens %{date}"
 msgstr "Anmeldegebühr:"
@@ -3385,7 +3397,7 @@ msgstr "Anmeldegebühr:"
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:753
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
@@ -3398,16 +3410,17 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:707
-#: lib/klass_hero_web/components/provider_components.ex:1112
-#: lib/klass_hero_web/components/provider_components.ex:1806
-#: lib/klass_hero_web/components/provider_components.ex:2052
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1188
+#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:1119
+#: lib/klass_hero_web/components/provider_components.ex:1811
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1804
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3417,105 +3430,105 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:631
+#: lib/klass_hero_web/components/provider_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1469
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:154
+#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1856
-#: lib/klass_hero_web/components/provider_components.ex:1868
-#: lib/klass_hero_web/components/provider_components.ex:1879
+#: lib/klass_hero_web/components/provider_components.ex:1861
+#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1174
+#: lib/klass_hero_web/components/provider_components.ex:1181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:849
+#: lib/klass_hero_web/components/provider_components.ex:856
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:192
+#: lib/klass_hero_web/live/program_detail_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:705
+#: lib/klass_hero_web/live/settings/children_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2030
+#: lib/klass_hero_web/components/provider_components.ex:2033
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr "Kind auswählen"
 
 #: lib/klass_hero_web/live/booking_live.ex:136
-#: lib/klass_hero_web/live/booking_live.ex:204
+#: lib/klass_hero_web/live/booking_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:848
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:910
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:874
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
-#: lib/klass_hero_web/live/admin/emails_live.ex:220
+#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:679
+#: lib/klass_hero_web/components/provider_components.ex:686
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:936
+#: lib/klass_hero_web/components/provider_components.ex:943
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:258
+#: lib/klass_hero_web/live/about_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:659
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1041
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:235
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:299
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:315
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:268
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:898
+#: lib/klass_hero_web/components/provider_components.ex:905
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:884
+#: lib/klass_hero_web/components/provider_components.ex:891
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3526,72 +3539,72 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:386
+#: lib/klass_hero_web/live/booking_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:109
+#: lib/klass_hero_web/presenters/provider_presenter.ex:128
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:977
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:978
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:296
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1007
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1008
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1148
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:249
+#: lib/klass_hero_web/live/about_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:620
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:902
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:927
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:815
+#: lib/klass_hero_web/components/provider_components.ex:822
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:278
+#: lib/klass_hero_web/live/about_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1930
+#: lib/klass_hero_web/components/provider_components.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3601,42 +3614,42 @@ msgstr ""
 msgid "Unable to load document preview."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:574
+#: lib/klass_hero_web/components/program_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:634
+#: lib/klass_hero_web/components/program_components.ex:622
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
+#: lib/klass_hero_web/components/provider_components.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1985
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:1954
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3649,8 +3662,8 @@ msgstr ""
 msgid "Verification document not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:177
-#: lib/klass_hero_web/components/layouts/app.html.heex:288
+#: lib/klass_hero_web/components/layouts/app.html.heex:147
+#: lib/klass_hero_web/components/layouts/app.html.heex:256
 #: lib/klass_hero_web/live/admin/verifications_live.ex:40
 #: lib/klass_hero_web/live/admin/verifications_live.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:189
@@ -3663,42 +3676,42 @@ msgstr ""
 msgid "Verified"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/live/about_live.ex:128
+#: lib/klass_hero_web/live/about_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:316
+#: lib/klass_hero_web/user_auth.ex:315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:632
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr "Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:623
+#: lib/klass_hero_web/components/provider_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:617
+#: lib/klass_hero_web/components/provider_components.ex:624
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:645
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:843
+#: lib/klass_hero_web/components/provider_components.ex:850
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3733,8 +3746,8 @@ msgid_plural "%{count} team seats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/about_live.ex:73
-#: lib/klass_hero_web/live/trust_safety_live.ex:55
+#: lib/klass_hero_web/live/about_live.ex:71
+#: lib/klass_hero_web/live/trust_safety_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
@@ -3750,7 +3763,7 @@ msgstr ""
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:236
+#: lib/klass_hero_web/live/trust_safety_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "And at Klass Hero, both come standard."
 msgstr ""
@@ -3761,7 +3774,7 @@ msgstr ""
 msgid "Applicants complete a video screening to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:104
+#: lib/klass_hero_web/live/trust_safety_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. Our platform is built to connect families, schools, and organizations with qualified, vetted, and safety-verified educators and activity providers."
 msgstr ""
@@ -3781,8 +3794,8 @@ msgstr ""
 msgid "Business Plus"
 msgstr "Business-Plan"
 
-#: lib/klass_hero_web/live/about_live.ex:71
-#: lib/klass_hero_web/live/trust_safety_live.ex:53
+#: lib/klass_hero_web/live/about_live.ex:69
+#: lib/klass_hero_web/live/trust_safety_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
@@ -3797,8 +3810,8 @@ msgstr ""
 msgid "Choose your plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:83
-#: lib/klass_hero_web/live/trust_safety_live.ex:61
+#: lib/klass_hero_web/live/about_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3808,7 +3821,7 @@ msgstr ""
 msgid "Could not change subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:75
+#: lib/klass_hero_web/live/trust_safety_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Create long-term trust across our community"
 msgstr ""
@@ -3819,7 +3832,7 @@ msgstr ""
 msgid "Current Plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1297
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Current Plan: %{plan}"
 msgstr ""
@@ -3835,18 +3848,18 @@ msgstr ""
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:82
+#: lib/klass_hero_web/live/trust_safety_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:159
+#: lib/klass_hero_web/live/trust_safety_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Every educator and enrichment professional on Klass Hero completes a 6-step verification process before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:85
-#: lib/klass_hero_web/live/trust_safety_live.ex:63
+#: lib/klass_hero_web/live/about_live.ex:83
+#: lib/klass_hero_web/live/trust_safety_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
@@ -3878,7 +3891,7 @@ msgstr ""
 msgid "Free"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:138
+#: lib/klass_hero_web/live/trust_safety_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
@@ -3893,12 +3906,12 @@ msgstr ""
 msgid "Get started for free"
 msgstr "Kostenlos starten"
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:216
+#: lib/klass_hero_web/live/trust_safety_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Have Questions?"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:156
+#: lib/klass_hero_web/live/trust_safety_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
@@ -3909,7 +3922,7 @@ msgstr ""
 msgid "Identity & Age Verification"
 msgstr "Identitäts- und Altersverifizierung"
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:219
+#: lib/klass_hero_web/live/trust_safety_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "If you'd like to learn more about our Trust & Safety standards or provider verification process, we're happy to help."
 msgstr ""
@@ -3920,27 +3933,27 @@ msgstr ""
 msgid "Invalid subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1307
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
 #, elixir-autogen, elixir-format
 msgid "Manage Plan →"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:186
+#: lib/klass_hero_web/live/trust_safety_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality & Accountability"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:116
+#: lib/klass_hero_web/live/trust_safety_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Our Commitment to Child Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:509
+#: lib/klass_hero_web/live/booking_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
@@ -3950,12 +3963,12 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:520
+#: lib/klass_hero_web/live/booking_live.ex:517
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program fee:"
 msgstr "Programmname"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1711
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3965,7 +3978,7 @@ msgstr ""
 msgid "Promotional content"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:72
+#: lib/klass_hero_web/live/trust_safety_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Protect children and families"
 msgstr ""
@@ -3976,17 +3989,17 @@ msgstr ""
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:205
+#: lib/klass_hero_web/live/trust_safety_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Providers who fail to uphold our expectations may be suspended or removed from the platform."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:83
+#: lib/klass_hero_web/live/trust_safety_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:228
+#: lib/klass_hero_web/live/booking_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
@@ -4006,7 +4019,7 @@ msgstr ""
 msgid "Subscription Plans"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:73
+#: lib/klass_hero_web/live/trust_safety_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Support schools and institutions with reliable providers"
 msgstr ""
@@ -4021,35 +4034,36 @@ msgstr ""
 msgid "Switched to %{plan}"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:101
+#: lib/klass_hero_web/live/trust_safety_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "TRUST & SAFETY"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:84
+#: lib/klass_hero_web/live/trust_safety_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Taking action when standards are not met"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:212
+#: lib/klass_hero_web/live/booking_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:661
-#: lib/klass_hero_web/components/layouts/app.html.heex:73
-#: lib/klass_hero_web/components/layouts/app.html.heex:250
+#: lib/klass_hero_web/components/composite_components.ex:612
+#: lib/klass_hero_web/components/composite_components.ex:681
+#: lib/klass_hero_web/components/layouts/app.html.heex:60
+#: lib/klass_hero_web/components/layouts/app.html.heex:212
 #: lib/klass_hero_web/live/trust_safety_live.ex:12
 #, elixir-autogen, elixir-format
 msgid "Trust & Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:189
+#: lib/klass_hero_web/live/trust_safety_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Trust doesn't stop at onboarding. Klass Hero continuously works to maintain a safe and high-quality ecosystem by:"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:233
+#: lib/klass_hero_web/live/trust_safety_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Trust is earned. Safety is non-negotiable."
 msgstr ""
@@ -4059,17 +4073,17 @@ msgstr ""
 msgid "Unlimited programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1300
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to unlock more features"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:74
+#: lib/klass_hero_web/live/trust_safety_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:135
+#: lib/klass_hero_web/live/trust_safety_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
@@ -4085,7 +4099,7 @@ msgstr ""
 msgid "Video Screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:119
+#: lib/klass_hero_web/live/trust_safety_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "We believe that children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
 msgstr ""
@@ -4106,87 +4120,87 @@ msgstr ""
 msgid "month"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:523
+#: lib/klass_hero_web/live/home_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:521
+#: lib/klass_hero_web/live/home_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:212
+#: lib/klass_hero_web/live/about_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Our 6-Step Vetting Process"
 msgstr "Unser 6-Schritte-Überprüfungsverfahren"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:140
+#: lib/klass_hero_web/live/settings/children_live.ex:139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Could not check enrollments. Please try again."
 msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:619
+#: lib/klass_hero_web/live/settings/children_live.ex:613
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:573
+#: lib/klass_hero_web/live/settings/children_live.ex:567
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:591
+#: lib/klass_hero_web/live/settings/children_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:578
+#: lib/klass_hero_web/live/settings/children_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:155
+#: lib/klass_hero_web/live/settings/children_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "This deletion request has expired. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:660
+#: lib/klass_hero_web/live/home_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "1st cancellation (90 days): Warning only"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:661
+#: lib/klass_hero_web/live/home_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "2nd cancellation: €50 penalty"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:639
+#: lib/klass_hero_web/live/home_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "3-7 days before: Usually 75% refund (you keep 25%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:662
+#: lib/klass_hero_web/live/home_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "3rd cancellation: €100 penalty + 14-day suspension"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:663
+#: lib/klass_hero_web/live/home_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "4+ cancellations: Account termination"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:638
+#: lib/klass_hero_web/live/home_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "7+ days before: Usually full refund (you keep nothing)"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:269
+#: lib/klass_hero_web/live/admin/sessions_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:734
+#: lib/klass_hero_web/components/participation_components.ex:735
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -4202,22 +4216,22 @@ msgstr ""
 msgid "All Statuses"
 msgstr "Alle Status"
 
-#: lib/klass_hero_web/live/home_live.ex:596
+#: lib/klass_hero_web/live/home_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:568
+#: lib/klass_hero_web/live/home_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:284
+#: lib/klass_hero_web/live/admin/sessions_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
-#: lib/klass_hero_web/live/home_live.ex:592
+#: lib/klass_hero_web/live/home_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
@@ -4227,7 +4241,7 @@ msgstr ""
 msgid "Attendance corrected successfully"
 msgstr "Anwesenheit erfolgreich korrigiert"
 
-#: lib/klass_hero_web/live/home_live.ex:614
+#: lib/klass_hero_web/live/home_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -4247,47 +4261,48 @@ msgstr "Zurück zu Sitzungen"
 msgid "Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:564
+#: lib/klass_hero_web/live/home_live.ex:573
 #, elixir-autogen, elixir-format
 msgid "Business Account: You keep €901 (€60 commission + €39 monthly fee)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:554
+#: lib/klass_hero_web/live/home_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Business Account: €39/month + 6% per booking (for providers/teams earning €600+/month)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:537
+#: lib/klass_hero_web/live/home_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:756
+#: lib/klass_hero_web/live/home_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:710
+#: lib/klass_hero_web/live/home_live.ex:719
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Can I change my booking date?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:730
+#: lib/klass_hero_web/live/home_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Can I get a refund if the provider cancels?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:531
+#: lib/klass_hero_web/live/home_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:592
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:614
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr ""
@@ -4312,15 +4327,15 @@ msgstr "Auschecken"
 msgid "Check-out time"
 msgstr "Auscheckzeit"
 
-#: lib/klass_hero_web/components/participation_components.ex:732
-#: lib/klass_hero_web/live/admin/sessions_live.ex:301
+#: lib/klass_hero_web/components/participation_components.ex:733
+#: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr "Eingecheckt"
 
-#: lib/klass_hero_web/components/participation_components.ex:733
-#: lib/klass_hero_web/live/admin/sessions_live.ex:302
+#: lib/klass_hero_web/components/participation_components.ex:734
+#: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:53
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:53
@@ -4333,37 +4348,37 @@ msgstr "Ausgecheckt"
 msgid "Child"
 msgstr "Kind"
 
-#: lib/klass_hero_web/live/home_live.ex:629
+#: lib/klass_hero_web/live/home_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Clear policies protect everyone."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:758
+#: lib/klass_hero_web/live/home_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/components/participation_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr "Abgeschlossen"
 
-#: lib/klass_hero_web/live/home_live.ex:649
+#: lib/klass_hero_web/live/home_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Contact all booked parents immediately and offer alternative dates. Include us in CC/BCC (support@mail.klasshero.com)."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:712
+#: lib/klass_hero_web/live/home_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:632
+#: lib/klass_hero_web/live/home_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Contact them immediately - often you can find an alternative date. Include us in CC/BCC (support@mail.klasshero.com) so we're informed."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:738
+#: lib/klass_hero_web/live/home_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Contact us immediately at support@mail.klasshero.com or call +49 (0) 152 2426 0416. You'll receive 100% refund + family credit, and the provider faces serious penalties."
 msgstr ""
@@ -4373,47 +4388,50 @@ msgstr ""
 msgid "Correct"
 msgstr "Korrigieren"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:589
+#: lib/klass_hero_web/live/dashboard_live.ex:177
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:591
+#: lib/klass_hero_web/live/home_live.ex:600
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:748
+#: lib/klass_hero_web/live/home_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:668
+#: lib/klass_hero_web/live/home_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Death in family"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:700
+#: lib/klass_hero_web/live/home_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:621
+#: lib/klass_hero_web/live/home_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:722
+#: lib/klass_hero_web/live/home_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/live/home_live.ex:559
+#: lib/klass_hero_web/live/home_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Example: If you earn €1,000 in bookings"
 msgstr ""
@@ -4423,73 +4441,73 @@ msgstr ""
 msgid "Explain why this correction is needed..."
 msgstr "Erklären Sie, warum diese Korrektur nötig ist..."
 
-#: lib/klass_hero_web/live/home_live.ex:619
+#: lib/klass_hero_web/live/home_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:586
+#: lib/klass_hero_web/live/home_live.ex:595
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:670
+#: lib/klass_hero_web/live/home_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Government closure"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:597
+#: lib/klass_hero_web/live/home_live.ex:606
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:576
+#: lib/klass_hero_web/live/home_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:630
+#: lib/klass_hero_web/live/home_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "If Parent Cancels:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:647
+#: lib/klass_hero_web/live/home_live.ex:656
 #, elixir-autogen, elixir-format
 msgid "If You Must Cancel:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:674
+#: lib/klass_hero_web/live/home_live.ex:683
 #, elixir-autogen, elixir-format
 msgid "If you fail to show up without prior notice:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:676
+#: lib/klass_hero_web/live/home_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Immediate account suspension"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:730
-#: lib/klass_hero_web/live/admin/sessions_live.ex:300
+#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/live/admin/sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "In Progress"
 msgstr "In Bearbeitung"
 
-#: lib/klass_hero_web/live/home_live.ex:600
+#: lib/klass_hero_web/live/home_live.ex:609
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:690
+#: lib/klass_hero_web/live/home_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:682
+#: lib/klass_hero_web/live/home_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Keep your reliability high - parents can see your cancellation rate on your profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:594
+#: lib/klass_hero_web/live/home_live.ex:603
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
@@ -4505,17 +4523,17 @@ msgstr "Klass Hero"
 msgid "Klass Hero Admin"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:640
+#: lib/klass_hero_web/live/home_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Less than 3 days: Usually 25-50% refund (you keep 50-75%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:667
+#: lib/klass_hero_web/live/home_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Medical emergency"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:671
+#: lib/klass_hero_web/live/home_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Minimum enrollment not met (camps only - notify 14 days before)"
 msgstr ""
@@ -4525,27 +4543,28 @@ msgstr ""
 msgid "No change"
 msgstr "Keine Änderung"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:270
+#: lib/klass_hero_web/live/admin/sessions_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr "Keine Änderungen erkannt"
 
-#: lib/klass_hero_web/live/home_live.ex:612
+#: lib/klass_hero_web/live/home_live.ex:621
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1494
+#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:665
+#: lib/klass_hero_web/live/home_live.ex:674
 #, elixir-autogen, elixir-format
 msgid "No penalties for legitimate reasons:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:613
+#: lib/klass_hero_web/live/home_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
@@ -4556,77 +4575,78 @@ msgstr ""
 msgid "Notes"
 msgstr "Notizen"
 
-#: lib/klass_hero_web/live/home_live.ex:605
+#: lib/klass_hero_web/live/home_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1659
+#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:581
+#: lib/klass_hero_web/live/home_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:678
+#: lib/klass_hero_web/live/home_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Parent gets 100% refund + family credit"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:585
+#: lib/klass_hero_web/live/home_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:611
+#: lib/klass_hero_web/live/home_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:589
+#: lib/klass_hero_web/live/home_live.ex:598
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:679
+#: lib/klass_hero_web/live/home_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Permanent ban if no valid emergency"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:606
+#: lib/klass_hero_web/live/home_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:541
+#: lib/klass_hero_web/live/home_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:539
+#: lib/klass_hero_web/live/home_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:549
+#: lib/klass_hero_web/live/home_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "Professional: More tools and opportunities for €9/month + 12% per booking (only when you get bookings)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:562
+#: lib/klass_hero_web/live/home_live.ex:571
 #, elixir-autogen, elixir-format
 msgid "Professional: You keep €871 (€120 commission + €9 monthly fee)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:658
+#: lib/klass_hero_web/live/home_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Provider Cancellation Penalties:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:673
+#: lib/klass_hero_web/live/home_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Provider No-Show:"
 msgstr ""
@@ -4636,7 +4656,7 @@ msgstr ""
 msgid "Providers"
 msgstr "Anbieter-Dashboard"
 
-#: lib/klass_hero_web/live/home_live.ex:618
+#: lib/klass_hero_web/live/home_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
@@ -4646,22 +4666,22 @@ msgstr ""
 msgid "Reason for correction"
 msgstr "Grund für die Korrektur"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:274
+#: lib/klass_hero_web/live/admin/sessions_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr "Datensatz wurde von jemand anderem geändert. Bitte aktualisieren."
 
-#: lib/klass_hero_web/live/home_live.ex:636
+#: lib/klass_hero_web/live/home_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Refunds are automatic based on our cancellation policy:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:536
+#: lib/klass_hero_web/live/home_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:593
+#: lib/klass_hero_web/live/home_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
@@ -4671,22 +4691,22 @@ msgstr ""
 msgid "Save Correction"
 msgstr "Korrektur speichern"
 
-#: lib/klass_hero_web/components/participation_components.ex:729
+#: lib/klass_hero_web/components/participation_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Geplant"
 
-#: lib/klass_hero_web/live/home_live.ex:620
+#: lib/klass_hero_web/live/home_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:669
+#: lib/klass_hero_web/live/home_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Severe weather"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:578
+#: lib/klass_hero_web/live/home_live.ex:587
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -4696,127 +4716,129 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:544
+#: lib/klass_hero_web/live/home_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 20% commission per booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:561
+#: lib/klass_hero_web/live/home_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Starter: You keep €800 (€200 commission)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:643
+#: lib/klass_hero_web/live/home_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Stripe processes all refunds - funds returned to parent's original payment method within 5-10 business days. Any amounts you keep remain in your balance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:616
+#: lib/klass_hero_web/live/home_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1655
+#: lib/klass_hero_web/components/provider_components.ex:1660
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:585
+#: lib/klass_hero_web/live/dashboard_live.ex:164
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:608
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:604
+#: lib/klass_hero_web/live/home_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:534
+#: lib/klass_hero_web/live/home_live.ex:543
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:627
+#: lib/klass_hero_web/live/home_live.ex:636
 #, elixir-autogen, elixir-format
 msgid "What happens if a parent cancels or I need to cancel?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:720
+#: lib/klass_hero_web/live/home_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:736
+#: lib/klass_hero_web/live/home_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "What if the provider doesn't show up?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:579
+#: lib/klass_hero_web/live/home_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:654
+#: lib/klass_hero_web/live/home_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "When you cancel, parents get 100% refund automatically. The amount is deducted from your next payout."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:746
+#: lib/klass_hero_web/live/home_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:608
+#: lib/klass_hero_web/live/home_live.ex:617
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:538
+#: lib/klass_hero_web/live/home_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:692
+#: lib/klass_hero_web/live/home_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:533
+#: lib/klass_hero_web/live/home_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:731
+#: lib/klass_hero_web/live/home_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Yes, always 100% refund if provider cancels. No exceptions."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:702
+#: lib/klass_hero_web/live/home_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:587
+#: lib/klass_hero_web/live/home_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:610
+#: lib/klass_hero_web/live/home_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:583
+#: lib/klass_hero_web/live/home_live.ex:592
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:677
+#: lib/klass_hero_web/live/home_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "€200 penalty (deducted from balance or invoiced)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:77
+#: lib/klass_hero_web/components/participation_components.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr "%{checked_in} / %{capacity} eingecheckt"
@@ -4831,12 +4853,12 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:339
+#: lib/klass_hero_web/live/provider/sessions_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:150
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:152
 #, elixir-autogen, elixir-format
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
@@ -4847,8 +4869,8 @@ msgstr ""
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:159
-#: lib/klass_hero_web/components/layouts/app.html.heex:281
+#: lib/klass_hero_web/components/layouts/app.html.heex:129
+#: lib/klass_hero_web/components/layouts/app.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
@@ -4868,7 +4890,7 @@ msgstr "Anbieter-Dashboard"
 msgid "Allergies: %{details}"
 msgstr "Allergien: %{details}"
 
-#: lib/klass_hero_web/components/participation_components.ex:232
+#: lib/klass_hero_web/components/participation_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr "Wichtige Notizen zur heutigen Sitzung..."
@@ -4878,13 +4900,13 @@ msgstr "Wichtige Notizen zur heutigen Sitzung..."
 msgid "Archive"
 msgstr "Aktive Familien"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:216
+#: lib/klass_hero_web/live/admin/emails_live.ex:215
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:88
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr ""
@@ -4905,7 +4927,7 @@ msgstr "Zurück zu Einstellungen"
 msgid "Behavioral Note"
 msgstr "Verhaltensnotiz"
 
-#: lib/klass_hero_web/components/messaging_components.ex:506
+#: lib/klass_hero_web/components/messaging_components.ex:628
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4922,7 +4944,7 @@ msgstr "Einchecken"
 msgid "Check Out"
 msgstr "Auschecken"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:280
+#: lib/klass_hero_web/live/admin/sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr ""
@@ -4942,7 +4964,7 @@ msgstr "Auschecken-Notizen (optional)"
 msgid "Check-out:"
 msgstr "Auschecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:216
+#: lib/klass_hero_web/components/participation_components.ex:217
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr "Eingecheckt um %{time}"
@@ -4963,13 +4985,13 @@ msgid "Clear selection"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:76
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:200
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:202
 #, elixir-autogen, elixir-format
 msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:295
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
@@ -5009,7 +5031,7 @@ msgstr ""
 msgid "Content is being fetched..."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:204
+#: lib/klass_hero_web/live/messaging_live_helper.ex:240
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Could not start private conversation"
 msgstr ""
@@ -5026,8 +5048,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:313
-#: lib/klass_hero_web/live/provider/sessions_live.ex:314
+#: lib/klass_hero_web/live/provider/sessions_live.ex:330
+#: lib/klass_hero_web/live/provider/sessions_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -5070,12 +5092,12 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:338
+#: lib/klass_hero_web/live/provider/sessions_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr "Erwartet"
@@ -5085,7 +5107,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "Notiz konnte nicht genehmigt werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:273
+#: lib/klass_hero_web/live/provider/sessions_live.ex:290
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
@@ -5100,7 +5122,7 @@ msgstr "Notiz konnte nicht abgelehnt werden"
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:332
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr "Notiz konnte nicht abgelehnt werden"
@@ -5141,8 +5163,8 @@ msgstr "Ein: %{time}"
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:282
-#: lib/klass_hero_web/live/provider/sessions_live.ex:334
+#: lib/klass_hero_web/live/admin/sessions_live.ex:278
+#: lib/klass_hero_web/live/provider/sessions_live.ex:351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr "Ungültiges Datumsformat"
@@ -5168,7 +5190,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:312
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:342
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -5178,8 +5200,8 @@ msgstr ""
 msgid "Joined"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:28
-#: lib/klass_hero_web/components/layouts/app.html.heex:240
+#: lib/klass_hero_web/components/layouts/app.html.heex:15
+#: lib/klass_hero_web/components/layouts/app.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Klass Hero Logo"
 msgstr "Klass Hero Logo"
@@ -5189,7 +5211,7 @@ msgstr "Klass Hero Logo"
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:70
+#: lib/klass_hero_web/components/participation_components.ex:71
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr "Ort noch offen"
@@ -5210,7 +5232,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:309
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
@@ -5230,7 +5252,7 @@ msgstr ""
 msgid "No participation records yet"
 msgstr "Noch keine Teilnahmeeinträge"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:92
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs assigned yet."
 msgstr "Keine Programme gefunden"
@@ -5246,7 +5268,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:324
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
@@ -5266,7 +5288,7 @@ msgstr "Beobachtung zur Teilnahme des Kindes..."
 msgid "Out: %{time}"
 msgstr "Aus: %{time}"
 
-#: lib/klass_hero_web/components/participation_components.ex:178
+#: lib/klass_hero_web/components/participation_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr "Teilnahme-Einchecken"
@@ -5287,7 +5309,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:341
+#: lib/klass_hero_web/live/provider/sessions_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -5304,7 +5326,7 @@ msgstr "Absenden"
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:133
+#: lib/klass_hero_web/live/provider/sessions_live.ex:153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program is required"
 msgstr "Programme"
@@ -5319,7 +5341,7 @@ msgstr "Anbieter-Dashboard"
 msgid "Provider observation"
 msgstr "Beobachtung des Anbieters"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:215
+#: lib/klass_hero_web/live/admin/emails_live.ex:214
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
@@ -5335,12 +5357,12 @@ msgstr "Grund für die Ablehnung (optional)"
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/components/messaging_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:211
+#: lib/klass_hero_web/live/messaging_live_helper.ex:247
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
@@ -5350,7 +5372,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:546
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -5385,44 +5407,44 @@ msgstr "Thema auswählen..."
 msgid "Send Reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:219
+#: lib/klass_hero_web/live/admin/emails_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Sending"
 msgstr "Wird gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:57
+#: lib/klass_hero_web/components/participation_components.ex:58
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sitzung"
 
-#: lib/klass_hero_web/components/participation_components.ex:231
+#: lib/klass_hero_web/components/participation_components.ex:232
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr "Sitzungsnotizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:187
+#: lib/klass_hero_web/components/participation_components.ex:188
 #: lib/klass_hero_web/components/participation_components.ex:319
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:253
+#: lib/klass_hero_web/live/provider/sessions_live.ex:270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich gestartet"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:962
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:273
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
@@ -5432,7 +5454,7 @@ msgstr "Sitzung starten"
 msgid "Submit Note"
 msgstr "Notiz absenden"
 
-#: lib/klass_hero_web/components/participation_components.ex:247
+#: lib/klass_hero_web/components/participation_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr "Teilnahme bestätigen"
@@ -5442,12 +5464,12 @@ msgstr "Teilnahme bestätigen"
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:39
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:322
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5472,8 +5494,8 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:323
-#: lib/klass_hero_web/live/provider/sessions_live.ex:324
+#: lib/klass_hero_web/live/provider/sessions_live.ex:340
+#: lib/klass_hero_web/live/provider/sessions_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -5488,15 +5510,15 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:140
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:58
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
+#: lib/klass_hero_web/live/provider/sessions_live.ex:160
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:214
+#: lib/klass_hero_web/live/admin/emails_live.ex:213
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"
@@ -5507,14 +5529,14 @@ msgstr "Ungelesen"
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:428
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:683
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:456
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:306
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr "Teilnahme anzeigen"
@@ -5524,7 +5546,7 @@ msgstr "Teilnahme anzeigen"
 msgid "View your children's participation records"
 msgstr "Sehen Sie die Teilnahmeeinträge Ihrer Kinder ein"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:82
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome, %{name}"
 msgstr "Willkommen %{email}"
@@ -5540,12 +5562,12 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:327
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr "Sie haben keine Sitzungen geplant für %{date}"
 
-#: lib/klass_hero_web/user_auth.ex:300
+#: lib/klass_hero_web/user_auth.ex:299
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You must be a staff member to access this page."
 msgstr "Sie müssen angemeldet sein, um auf diese Seite zuzugreifen."
@@ -5565,12 +5587,12 @@ msgstr "Ihr Konto wurde erstellt! Richten Sie Ihr Passwort in den Einstellungen 
 msgid "Your children's participation will appear here"
 msgstr "Die Teilnahme Ihrer Kinder wird hier angezeigt"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:130
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:391
+#: lib/klass_hero_web/components/provider_components.ex:392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Team Members"
 msgstr "Teammitglied hinzufügen"
@@ -5580,12 +5602,220 @@ msgstr "Teammitglied hinzufügen"
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:239
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
+#, elixir-autogen, elixir-format
+msgid "+1234567890"
+msgstr ""
+
+#: lib/klass_hero_web/components/composite_components.ex:852
+#, elixir-autogen, elixir-format
+msgid "About the Provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:250
+#, elixir-autogen, elixir-format
+msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
+msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:214
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Business Name"
+msgstr "Business-Plan"
+
+#: lib/klass_hero_web/components/participation_components.ex:737
+#, elixir-autogen, elixir-format
+msgid "Cancelled"
+msgstr "Abgesagt"
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Categories"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1179
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Complete Profile"
+msgstr "Anmeldung abschließen"
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Complete Your Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "Complete Your Provider Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1162
+#, elixir-autogen, elixir-format
+msgid "Complete your provider profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "Drag and drop or click to upload"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:504
+#, elixir-autogen, elixir-format
+msgid "Failed to upload files. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:689
+#, elixir-autogen, elixir-format, fuzzy
+msgid "File is too large (max %{mb} MB)"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:502
+#, elixir-autogen, elixir-format, fuzzy
+msgid "File is too large (max %{mb} MB)."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:692
+#, elixir-autogen, elixir-format, fuzzy
+msgid "File type not accepted (images only)"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#, elixir-autogen, elixir-format
+msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
+#, elixir-autogen, elixir-format
+msgid "Manage your business"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:499
+#, elixir-autogen, elixir-format
+msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:677
+#: lib/klass_hero_web/components/messaging_components.ex:681
+#, elixir-autogen, elixir-format
+msgid "Photo"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:494
+#, elixir-autogen, elixir-format
+msgid "Please enter a message or attach a photo."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Profile completed! Klass Hero will review your profile shortly."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:36
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider not found"
+msgstr "Programm nicht gefunden"
+
+#: lib/klass_hero_web/components/messaging_components.ex:276
+#, elixir-autogen, elixir-format
+msgid "Remove attachment"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1328
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sessions Completed"
+msgstr "Sitzungen"
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:505
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:47
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:88
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Tell parents about your organization and what makes you unique..."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:696
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many files (max %{max})"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:497
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many files (max %{max})."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#, elixir-autogen, elixir-format
+msgid "Upgrade plan to message parents"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Upgrade plan to send broadcasts"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:700
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Upload error"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:699
+#, elixir-autogen, elixir-format
+msgid "Upload failed"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1093
+#, elixir-autogen, elixir-format
+msgid "View your assignments"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
+#, elixir-autogen, elixir-format
+msgid "Website"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:434
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:866
+#, elixir-autogen, elixir-format
+msgid "You've reached your program limit. Upgrade your plan to add more programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:248
+#, elixir-autogen, elixir-format
+msgid "Your business address"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Your business or organization name"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Your profile is already complete."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:89
+#: lib/klass_hero_web/live/messaging_live_helper.ex:338
+#, elixir-autogen, elixir-format, fuzzy
+msgid "for"
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1515
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -981,9 +981,9 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Magic Link"
 msgstr "Magic-Link senden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
-#: lib/klass_hero_web/components/provider_components.ex:1714
-#: lib/klass_hero_web/components/provider_components.ex:1753
+#: lib/klass_hero_web/components/provider_components.ex:1720
+#: lib/klass_hero_web/components/provider_components.ex:1721
+#: lib/klass_hero_web/components/provider_components.ex:1760
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1902,13 +1902,13 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1319
-#: lib/klass_hero_web/components/provider_components.ex:1686
-#: lib/klass_hero_web/components/provider_components.ex:1869
+#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1400
+#: lib/klass_hero_web/components/provider_components.ex:1407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr "Aktive Familien"
@@ -1953,7 +1953,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:540
-#: lib/klass_hero_web/components/provider_components.ex:1381
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -1966,7 +1966,7 @@ msgstr "Bearbeiten"
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1988,9 +1988,9 @@ msgid "Overview"
 msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1401
-#: lib/klass_hero_web/components/provider_components.ex:1916
-#: lib/klass_hero_web/components/provider_components.ex:1936
+#: lib/klass_hero_web/components/provider_components.ex:1408
+#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1943
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
@@ -2033,9 +2033,9 @@ msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1313
-#: lib/klass_hero_web/components/provider_components.ex:1625
-#: lib/klass_hero_web/components/provider_components.ex:1680
-#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1632
+#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1873
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2059,14 +2059,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
 #: lib/klass_hero_web/components/provider_components.ex:1343
-#: lib/klass_hero_web/components/provider_components.ex:1640
+#: lib/klass_hero_web/components/provider_components.ex:1647
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1403
+#: lib/klass_hero_web/components/provider_components.ex:1410
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -2077,7 +2077,7 @@ msgstr "Unbekannt"
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1375
+#: lib/klass_hero_web/components/provider_components.ex:1382
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -2149,7 +2149,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:635
 #: lib/klass_hero_web/components/provider_components.ex:765
 #: lib/klass_hero_web/components/provider_components.ex:1169
-#: lib/klass_hero_web/components/provider_components.ex:1805
+#: lib/klass_hero_web/components/provider_components.ex:1812
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2418,8 +2418,8 @@ msgstr "Änderungen speichern"
 msgid "Search for programs..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1486
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1493
+#: lib/klass_hero_web/components/provider_components.ex:1494
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2612,7 +2612,7 @@ msgstr "Alter %{range}"
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
@@ -2724,8 +2724,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1677
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:1684
+#: lib/klass_hero_web/components/provider_components.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2770,7 +2770,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1825
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2888,13 +2888,13 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1939
+#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1946
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1533
+#: lib/klass_hero_web/components/provider_components.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1940
+#: lib/klass_hero_web/components/provider_components.ex:1947
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2952,12 +2952,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:2026
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2028
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -3007,12 +3007,12 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1797
+#: lib/klass_hero_web/components/provider_components.ex:1804
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr "Wichtig:"
 
-#: lib/klass_hero_web/components/provider_components.ex:1838
+#: lib/klass_hero_web/components/provider_components.ex:1845
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1550
+#: lib/klass_hero_web/components/provider_components.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -3158,12 +3158,12 @@ msgstr "Mo-Fr, 9-17 Uhr"
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2054
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1670
+#: lib/klass_hero_web/components/provider_components.ex:1677
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -3179,7 +3179,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -3242,7 +3242,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2123
+#: lib/klass_hero_web/components/provider_components.ex:2130
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3332,7 +3332,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1938
+#: lib/klass_hero_web/components/provider_components.ex:1945
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3414,15 +3414,15 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:1120
-#: lib/klass_hero_web/components/provider_components.ex:1898
-#: lib/klass_hero_web/components/provider_components.ex:2142
+#: lib/klass_hero_web/components/provider_components.ex:1905
+#: lib/klass_hero_web/components/provider_components.ex:2149
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1891
+#: lib/klass_hero_web/components/provider_components.ex:1898
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3437,15 +3437,15 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1476
+#: lib/klass_hero_web/components/provider_components.ex:1483
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
-#: lib/klass_hero_web/components/provider_components.ex:1960
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:1955
+#: lib/klass_hero_web/components/provider_components.ex:1967
+#: lib/klass_hero_web/components/provider_components.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
@@ -3470,7 +3470,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2120
+#: lib/klass_hero_web/components/provider_components.ex:2127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr "Kind auswählen"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1937
+#: lib/klass_hero_web/components/provider_components.ex:1944
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3606,7 +3606,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2027
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3626,32 +3626,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2166
+#: lib/klass_hero_web/components/provider_components.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2075
+#: lib/klass_hero_web/components/provider_components.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2041
+#: lib/klass_hero_web/components/provider_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2038
+#: lib/klass_hero_web/components/provider_components.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -4427,7 +4427,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1752
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -4555,7 +4555,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1501
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -4582,7 +4582,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1747
+#: lib/klass_hero_web/components/provider_components.ex:1754
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
@@ -5822,37 +5822,42 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1622
+#: lib/klass_hero_web/components/provider_components.ex:1629
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1624
+#: lib/klass_hero_web/components/provider_components.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1606
+#: lib/klass_hero_web/components/provider_components.ex:1613
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1623
+#: lib/klass_hero_web/components/provider_components.ex:1630
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1621
+#: lib/klass_hero_web/components/provider_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1622
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1604
+#: lib/klass_hero_web/components/provider_components.ex:1611
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
+
+#: lib/klass_hero_web/components/provider_components.ex:1374
+#, elixir-autogen, elixir-format
+msgid "View sessions"
+msgstr "Sessions anzeigen"

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1905
+#: lib/klass_hero_web/components/provider_components.ex:1910
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1906
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:1922
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1907
+#: lib/klass_hero_web/components/provider_components.ex:1912
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1908
+#: lib/klass_hero_web/components/provider_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1921
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1920
+#: lib/klass_hero_web/components/provider_components.ex:1923
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1910
+#: lib/klass_hero_web/components/provider_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1916
+#: lib/klass_hero_web/components/provider_components.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1996
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1910
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1911
+#: lib/klass_hero_web/components/provider_components.ex:1998
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1922
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1912
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:2000
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1914
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1921
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1915
+#: lib/klass_hero_web/components/provider_components.ex:2002
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:1996
+#: lib/klass_hero_web/components/provider_components.ex:2003
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1997
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2005
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2000
+#: lib/klass_hero_web/components/provider_components.ex:2007
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2001
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2008
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2006
+#: lib/klass_hero_web/components/provider_components.ex:2013
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:57
-#: lib/klass_hero_web/components/layouts/app.html.heex:248
+#: lib/klass_hero_web/components/layouts/app.html.heex:44
+#: lib/klass_hero_web/components/layouts/app.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -28,19 +28,19 @@ msgstr ""
 msgid "Choose your preferred language for the interface"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:603
-#: lib/klass_hero_web/components/layouts/app.html.heex:65
-#: lib/klass_hero_web/components/layouts/app.html.heex:249
+#: lib/klass_hero_web/components/composite_components.ex:608
+#: lib/klass_hero_web/components/layouts/app.html.heex:52
+#: lib/klass_hero_web/components/layouts/app.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:128
-#: lib/klass_hero_web/components/layouts/app.html.heex:168
-#: lib/klass_hero_web/components/layouts/app.html.heex:255
-#: lib/klass_hero_web/components/layouts/app.html.heex:285
-#: lib/klass_hero_web/components/provider_components.ex:355
-#: lib/klass_hero_web/live/dashboard_live.ex:52
+#: lib/klass_hero_web/components/layouts/app.html.heex:113
+#: lib/klass_hero_web/components/layouts/app.html.heex:138
+#: lib/klass_hero_web/components/layouts/app.html.heex:217
+#: lib/klass_hero_web/components/layouts/app.html.heex:253
+#: lib/klass_hero_web/components/provider_components.ex:356
+#: lib/klass_hero_web/live/dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -60,8 +60,8 @@ msgstr ""
 msgid "Failed to update language preference."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:41
-#: lib/klass_hero_web/components/layouts/app.html.heex:246
+#: lib/klass_hero_web/components/layouts/app.html.heex:28
+#: lib/klass_hero_web/components/layouts/app.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -76,22 +76,22 @@ msgstr ""
 msgid "Language preference updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:205
-#: lib/klass_hero_web/components/layouts/app.html.heex:303
+#: lib/klass_hero_web/components/layouts/app.html.heex:167
+#: lib/klass_hero_web/components/layouts/app.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Login"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:601
-#: lib/klass_hero_web/components/composite_components.ex:609
-#: lib/klass_hero_web/components/layouts/app.html.heex:49
-#: lib/klass_hero_web/components/layouts/app.html.heex:247
+#: lib/klass_hero_web/components/composite_components.ex:602
+#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/layouts/app.html.heex:36
+#: lib/klass_hero_web/components/layouts/app.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:152
-#: lib/klass_hero_web/components/layouts/app.html.heex:277
+#: lib/klass_hero_web/components/layouts/app.html.heex:122
+#: lib/klass_hero_web/components/layouts/app.html.heex:245
 #: lib/klass_hero_web/live/settings_live.ex:17
 #: lib/klass_hero_web/live/settings_live.ex:56
 #, elixir-autogen, elixir-format
@@ -99,15 +99,15 @@ msgid "Settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:20
-#: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/layouts/app.html.heex:297
+#: lib/klass_hero_web/components/layouts/app.html.heex:159
+#: lib/klass_hero_web/components/layouts/app.html.heex:265
 #: lib/klass_hero_web/live/settings_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Sign Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:211
-#: lib/klass_hero_web/components/layouts/app.html.heex:311
+#: lib/klass_hero_web/components/layouts/app.html.heex:173
+#: lib/klass_hero_web/components/layouts/app.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Sign Up"
 msgstr ""
@@ -127,109 +127,104 @@ msgstr ""
 msgid "Your Data"
 msgstr ""
 
-#: lib/klass_hero_web/components/core_components.ex:68
-#: lib/klass_hero_web/components/provider_components.ex:1501
+#: lib/klass_hero_web/components/core_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:445
+#: lib/klass_hero_web/live/booking_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:365
+#: lib/klass_hero_web/live/program_detail_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:352
+#: lib/klass_hero_web/live/booking_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:458
+#: lib/klass_hero_web/live/booking_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:393
+#: lib/klass_hero_web/live/booking_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:197
+#: lib/klass_hero_web/live/program_detail_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:531
+#: lib/klass_hero_web/live/booking_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:475
+#: lib/klass_hero_web/live/booking_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:235
+#: lib/klass_hero_web/live/home_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:245
-#, elixir-autogen, elixir-format
-msgid "Built for the Berlin international community. Connect with local families and trusted educators nearby."
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:508
+#: lib/klass_hero_web/live/booking_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:533
+#: lib/klass_hero_web/live/booking_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:243
+#: lib/klass_hero_web/live/home_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:550
+#: lib/klass_hero_web/live/booking_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:499
+#: lib/klass_hero_web/live/booking_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:532
+#: lib/klass_hero_web/live/booking_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:384
+#: lib/klass_hero_web/live/booking_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:233
+#: lib/klass_hero_web/live/home_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:521
+#: lib/klass_hero_web/live/program_detail_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1308
-#: lib/klass_hero_web/live/booking_live.ex:347
+#: lib/klass_hero_web/components/provider_components.ex:1315
+#: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr ""
@@ -239,7 +234,7 @@ msgstr ""
 msgid "Enrollment - %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:220
+#: lib/klass_hero_web/live/booking_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr ""
@@ -249,7 +244,7 @@ msgstr ""
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:225
+#: lib/klass_hero_web/live/home_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
@@ -270,17 +265,12 @@ msgstr ""
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:347
-#, elixir-autogen, elixir-format
-msgid "Free cancellation up to 48 hours before start date"
-msgstr ""
-
 #: lib/klass_hero_web/live/programs_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:529
+#: lib/klass_hero_web/live/booking_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
@@ -295,7 +285,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:405
+#: lib/klass_hero_web/live/program_detail_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -307,22 +297,22 @@ msgstr[1] ""
 msgid "No programs found"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:483
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:500
+#: lib/klass_hero_web/live/booking_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:494
+#: lib/klass_hero_web/live/booking_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:518
+#: lib/klass_hero_web/live/booking_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
@@ -332,7 +322,7 @@ msgstr ""
 msgid "Payment information is invalid. Please check your details."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:177
+#: lib/klass_hero_web/live/booking_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr ""
@@ -344,17 +334,18 @@ msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:59
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:47
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:53
+#: lib/klass_hero_web/live/program_detail_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:149
-#: lib/klass_hero_web/live/home_live.ex:223
+#: lib/klass_hero_web/live/about_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Safety First"
 msgstr ""
@@ -370,12 +361,12 @@ msgstr ""
 msgid "Search programs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:429
+#: lib/klass_hero_web/live/booking_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:439
+#: lib/klass_hero_web/live/booking_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr ""
@@ -390,17 +381,17 @@ msgstr ""
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:468
+#: lib/klass_hero_web/live/booking_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:377
+#: lib/klass_hero_web/live/booking_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:524
+#: lib/klass_hero_web/live/booking_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
@@ -411,7 +402,7 @@ msgid "Try adjusting your search or filter criteria."
 msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:84
-#: lib/klass_hero_web/live/program_detail_live.ex:60
+#: lib/klass_hero_web/live/program_detail_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Unable to load program. Please try again later."
 msgstr ""
@@ -426,7 +417,7 @@ msgstr ""
 msgid "Why Klass Hero?"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:209
+#: lib/klass_hero_web/live/program_detail_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -436,7 +427,7 @@ msgstr ""
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:602
+#: lib/klass_hero_web/components/composite_components.ex:605
 #: lib/klass_hero_web/live/about_live.ex:10
 #, elixir-autogen, elixir-format
 msgid "About Us"
@@ -453,6 +444,7 @@ msgid "Account Termination"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:81
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -467,7 +459,7 @@ msgstr ""
 msgid "Already registered?"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:160
+#: lib/klass_hero_web/live/user_live/registration.ex:159
 #, elixir-autogen, elixir-format
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr ""
@@ -507,14 +499,14 @@ msgstr ""
 msgid "Check out our FAQ section for answers to common questions."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:66
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:66
+#: lib/klass_hero_web/live/provider/participation_live.ex:67
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:133
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
+#: lib/klass_hero_web/live/provider/participation_live.ex:130
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -529,7 +521,7 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:195
+#: lib/klass_hero_web/live/about_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Community"
 msgstr ""
@@ -561,11 +553,11 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:788
+#: lib/klass_hero_web/components/composite_components.ex:808
 #: lib/klass_hero_web/live/contact_live.ex:15
 #: lib/klass_hero_web/live/contact_live.ex:112
 #: lib/klass_hero_web/live/privacy_policy_live.ex:217
-#: lib/klass_hero_web/live/trust_safety_live.ex:227
+#: lib/klass_hero_web/live/trust_safety_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr ""
@@ -631,16 +623,16 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:17
+#: lib/klass_hero_web/live/user_live/login.ex:18
 #, elixir-autogen, elixir-format
 msgid "Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:637
+#: lib/klass_hero_web/components/provider_components.ex:644
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
-#: lib/klass_hero_web/live/user_live/login.ex:48
-#: lib/klass_hero_web/live/user_live/login.ex:80
+#: lib/klass_hero_web/live/user_live/login.ex:49
+#: lib/klass_hero_web/live/user_live/login.ex:81
 #: lib/klass_hero_web/live/user_live/registration.ex:39
 #: lib/klass_hero_web/live/user_live/settings.ex:155
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:60
@@ -673,20 +665,20 @@ msgstr ""
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:81
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:81
+#: lib/klass_hero_web/live/provider/participation_live.ex:82
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:150
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/live/provider/participation_live.ex:147
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:114
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
+#: lib/klass_hero_web/live/provider/sessions_live.ex:134
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -696,16 +688,16 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:355
-#: lib/klass_hero_web/live/provider/participation_live.ex:356
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:306
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:307
+#: lib/klass_hero_web/live/provider/participation_live.ex:328
+#: lib/klass_hero_web/live/provider/participation_live.ex:329
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:283
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Failed to load session data"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:91
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:111
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -735,7 +727,7 @@ msgstr ""
 msgid "I want to..."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:141
+#: lib/klass_hero_web/live/user_live/login.ex:142
 #, elixir-autogen, elixir-format
 msgid "If your email is in our system, you will receive instructions for logging in shortly."
 msgstr ""
@@ -760,9 +752,9 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:69
-#: lib/klass_hero_web/live/provider/sessions_live.ex:319
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
+#: lib/klass_hero_web/live/provider/sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:336
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -777,7 +769,7 @@ msgstr ""
 msgid "Keep me logged in on this device"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:719
+#: lib/klass_hero_web/components/composite_components.ex:739
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr ""
@@ -793,12 +785,12 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:92
+#: lib/klass_hero_web/live/user_live/login.ex:93
 #, elixir-autogen, elixir-format
 msgid "Log in and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:95
+#: lib/klass_hero_web/live/user_live/login.ex:96
 #, elixir-autogen, elixir-format
 msgid "Log in only this time"
 msgstr ""
@@ -820,13 +812,14 @@ msgstr ""
 msgid "Looking for Quick Answers?"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:91
+#: lib/klass_hero_web/live/user_live/confirmation.ex:90
 #, elixir-autogen, elixir-format
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:162
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -841,15 +834,15 @@ msgstr ""
 msgid "Monday - Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:159
+#: lib/klass_hero_web/live/dashboard_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "My Children"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:20
+#: lib/klass_hero_web/live/provider/sessions_live.ex:35
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:5
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:23
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:24
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -876,23 +869,23 @@ msgstr ""
 msgid "Office Hours"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:104
+#: lib/klass_hero_web/live/user_live/login.ex:105
 #, elixir-autogen, elixir-format
 msgid "Or use magic link"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:63
+#: lib/klass_hero_web/live/user_live/login.ex:64
 #, elixir-autogen, elixir-format
 msgid "Or use password"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:154
-#: lib/klass_hero_web/presenters/provider_presenter.ex:110
+#: lib/klass_hero_web/presenters/provider_presenter.ex:129
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:88
+#: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/settings.ex:170
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:68
 #, elixir-autogen, elixir-format
@@ -905,11 +898,12 @@ msgid "Payment Terms"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:73
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:656
+#: lib/klass_hero_web/components/composite_components.ex:676
 #: lib/klass_hero_web/live/privacy_policy_live.ex:10
 #: lib/klass_hero_web/live/privacy_policy_live.ex:235
 #, elixir-autogen, elixir-format
@@ -936,16 +930,16 @@ msgstr ""
 msgid "Questions About These Terms?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:271
-#: lib/klass_hero_web/live/provider/participation_live.ex:56
-#: lib/klass_hero_web/live/provider/participation_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:56
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
+#: lib/klass_hero_web/live/admin/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/participation_live.ex:57
+#: lib/klass_hero_web/live/provider/participation_live.ex:119
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:57
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:21
+#: lib/klass_hero_web/live/user_live/login.ex:22
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr ""
@@ -965,7 +959,8 @@ msgstr ""
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:771
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
+#: lib/klass_hero_web/live/settings/children_live.ex:765
 #: lib/klass_hero_web/live/user_live/settings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -981,15 +976,18 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:54
+#: lib/klass_hero_web/live/user_live/login.ex:55
 #, elixir-autogen, elixir-format
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1620
-#: lib/klass_hero_web/components/provider_components.ex:1621
-#: lib/klass_hero_web/components/provider_components.ex:1661
+#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1627
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #: lib/klass_hero_web/live/contact_live.ex:184
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr ""
@@ -999,28 +997,29 @@ msgstr ""
 msgid "Send us a Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:100
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
+#: lib/klass_hero_web/live/provider/sessions_live.ex:120
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:69
 #: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:344
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:295
+#: lib/klass_hero_web/live/provider/participation_live.ex:317
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:77
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
+#: lib/klass_hero_web/live/provider/sessions_live.ex:97
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:146
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -1030,7 +1029,7 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:727
+#: lib/klass_hero_web/components/composite_components.ex:747
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr ""
@@ -1040,7 +1039,7 @@ msgstr ""
 msgid "Technical Issue"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:658
+#: lib/klass_hero_web/components/composite_components.ex:678
 #: lib/klass_hero_web/live/terms_of_service_live.ex:10
 #: lib/klass_hero_web/live/terms_of_service_live.ex:268
 #, elixir-autogen, elixir-format
@@ -1057,7 +1056,7 @@ msgstr ""
 msgid "Tip: If you prefer passwords, you can enable them in the user settings."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:31
+#: lib/klass_hero_web/live/user_live/login.ex:32
 #, elixir-autogen, elixir-format
 msgid "To see sent emails, visit"
 msgstr ""
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "User Conduct & Responsibilities"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:162
+#: lib/klass_hero_web/live/dashboard_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "View All"
 msgstr ""
@@ -1117,43 +1116,43 @@ msgstr ""
 msgid "Welcome %{email}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:12
+#: lib/klass_hero_web/live/user_live/login.ex:13
 #, elixir-autogen, elixir-format
 msgid "Welcome Back"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:29
+#: lib/klass_hero_web/live/user_live/login.ex:30
 #, elixir-autogen, elixir-format
 msgid "You are running the local mail adapter."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:369
+#: lib/klass_hero_web/user_auth.ex:368
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:282
+#: lib/klass_hero_web/user_auth.ex:281
 #, elixir-autogen, elixir-format
 msgid "You must have a parent profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:291
+#: lib/klass_hero_web/user_auth.ex:290
 #, elixir-autogen, elixir-format
 msgid "You must have a provider profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:252
-#: lib/klass_hero_web/user_auth.ex:418
+#: lib/klass_hero_web/user_auth.ex:251
+#: lib/klass_hero_web/user_auth.ex:417
 #, elixir-autogen, elixir-format
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:269
+#: lib/klass_hero_web/user_auth.ex:268
 #, elixir-autogen, elixir-format
 msgid "You must re-authenticate to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:15
+#: lib/klass_hero_web/live/user_live/login.ex:16
 #, elixir-autogen, elixir-format
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
@@ -1173,12 +1172,12 @@ msgstr ""
 msgid "Your privacy matters to us"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:21
+#: lib/klass_hero_web/live/user_live/login.ex:22
 #, elixir-autogen, elixir-format
 msgid "for an account now."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:31
+#: lib/klass_hero_web/live/user_live/login.ex:32
 #, elixir-autogen, elixir-format
 msgid "the mailbox page"
 msgstr ""
@@ -1188,12 +1187,12 @@ msgstr ""
 msgid "to your account now."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:611
+#: lib/klass_hero_web/components/composite_components.ex:622
 #, elixir-autogen, elixir-format
 msgid "Afterschool"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:653
+#: lib/klass_hero_web/components/composite_components.ex:673
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr ""
@@ -1203,24 +1202,19 @@ msgstr ""
 msgid "Building the future of youth education by connecting communities."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:613
+#: lib/klass_hero_web/components/composite_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "Class Trips"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/composite_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Connect"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:614
+#: lib/klass_hero_web/components/composite_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "Enrichment"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:604
-#, elixir-autogen, elixir-format
-msgid "FAQ"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:599
@@ -1228,7 +1222,7 @@ msgstr ""
 msgid "Quick Links"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:612
+#: lib/klass_hero_web/components/composite_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "Summer Camps"
 msgstr ""
@@ -1279,7 +1273,7 @@ msgid "Cards, bank accounts, billing info"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:373
+#: lib/klass_hero_web/live/settings/children_live.ex:367
 #: lib/klass_hero_web/live/settings_live.ex:88
 #: lib/klass_hero_web/live/user_live/settings.ex:48
 #: lib/klass_hero_web/live/user_live/settings.ex:347
@@ -1494,7 +1488,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:89
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:115
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Sessions"
 msgstr ""
@@ -1544,21 +1538,21 @@ msgstr ""
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:188
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:221
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:178
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:15
+#: lib/klass_hero_web/live/provider/participation_live.ex:16
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:284
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:22
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:16
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:17
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Participation History"
@@ -1581,7 +1575,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:152
+#: lib/klass_hero_web/live/about_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "All instructors are background-checked and verified"
 msgstr ""
@@ -1592,12 +1586,12 @@ msgstr ""
 msgid "Arts"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:198
+#: lib/klass_hero_web/live/about_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Building connections between families and local instructors"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:115
+#: lib/klass_hero_web/live/about_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Built for Berlin Families"
 msgstr ""
@@ -1607,12 +1601,12 @@ msgstr ""
 msgid "Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:278
+#: lib/klass_hero_web/live/home_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Create a Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:288
+#: lib/klass_hero_web/live/home_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Deliver Quality"
 msgstr ""
@@ -1628,12 +1622,12 @@ msgstr ""
 msgid "Education"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:215
+#: lib/klass_hero_web/live/about_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Every instructor goes through rigorous screening to ensure the highest quality"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:513
+#: lib/klass_hero_web/live/home_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Everything you need to know about Klass Hero"
 msgstr ""
@@ -1643,37 +1637,37 @@ msgstr ""
 msgid "For Families"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:259
+#: lib/klass_hero_web/live/home_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "For Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:510
+#: lib/klass_hero_web/live/home_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Frequently Asked Questions"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:123
+#: lib/klass_hero_web/live/about_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:294
+#: lib/klass_hero_web/live/about_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "GET STARTED TODAY"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:298
+#: lib/klass_hero_web/live/home_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:265
+#: lib/klass_hero_web/live/home_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "How to Grow Your Youth Program: Let's Build Together."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:268
+#: lib/klass_hero_web/live/home_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Join our community of passionate educators. Tools and support to help you succeed."
 msgstr ""
@@ -1694,17 +1688,17 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:100
+#: lib/klass_hero_web/live/about_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "OUR MISSION"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:674
+#: lib/klass_hero_web/components/provider_components.ex:681
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:288
+#: lib/klass_hero_web/live/about_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "Ready to join the movement?"
 msgstr ""
@@ -1714,12 +1708,12 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:300
+#: lib/klass_hero_web/live/home_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Secure payments, insights into your business, and opportunities to expand your impact."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:280
+#: lib/klass_hero_web/live/home_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
@@ -1730,27 +1724,27 @@ msgstr ""
 msgid "Sports"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:316
+#: lib/klass_hero_web/live/home_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Start Teaching Today →"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:175
+#: lib/klass_hero_web/live/about_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Supporting local programs and eco-conscious practices"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:172
+#: lib/klass_hero_web/live/about_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:290
+#: lib/klass_hero_web/live/home_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Teach your passion with our tools for scheduling, communication, and progress tracking."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:103
+#: lib/klass_hero_web/live/about_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "To modernize how families discover and engage with children's programs in Berlin"
 msgstr ""
@@ -1760,7 +1754,7 @@ msgstr ""
 msgid "Trending in Berlin:"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:118
+#: lib/klass_hero_web/live/about_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr ""
@@ -1770,21 +1764,21 @@ msgstr ""
 msgid "Workshops"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:181
-#: lib/klass_hero_web/live/settings/children_live.ex:402
-#: lib/klass_hero_web/live/settings/children_live.ex:424
-#: lib/klass_hero_web/live/settings/children_live.ex:646
-#: lib/klass_hero_web/live/settings/children_live.ex:780
+#: lib/klass_hero_web/live/dashboard_live.ex:215
+#: lib/klass_hero_web/live/settings/children_live.ex:396
+#: lib/klass_hero_web/live/settings/children_live.ex:418
+#: lib/klass_hero_web/live/settings/children_live.ex:640
+#: lib/klass_hero_web/live/settings/children_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:71
+#: lib/klass_hero_web/live/dashboard_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Almost there! One more to go!"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:70
+#: lib/klass_hero_web/live/dashboard_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Congratulations! Goal achieved!"
 msgstr ""
@@ -1829,12 +1823,12 @@ msgstr ""
 msgid "Weekly Activity Goal"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:72
+#: lib/klass_hero_web/live/dashboard_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "You're just getting started!"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:73
+#: lib/klass_hero_web/live/dashboard_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "You're doing great! Keep it up!"
 msgstr ""
@@ -1907,37 +1901,37 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1311
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1777
+#: lib/klass_hero_web/components/provider_components.ex:1318
+#: lib/klass_hero_web/components/provider_components.ex:1599
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1392
+#: lib/klass_hero_web/components/provider_components.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:590
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1341
+#: lib/klass_hero_web/components/provider_components.ex:597
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:74
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1554
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:81
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1623
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1302
+#: lib/klass_hero_web/components/provider_components.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:324
-#: lib/klass_hero_web/live/program_detail_live.ex:545
+#: lib/klass_hero_web/live/program_detail_live.ex:363
+#: lib/klass_hero_web/live/program_detail_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr ""
@@ -1947,32 +1941,32 @@ msgstr ""
 msgid "Business Profile"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:96
-#: lib/klass_hero_web/presenters/provider_presenter.ex:106
+#: lib/klass_hero_web/presenters/provider_presenter.ex:115
+#: lib/klass_hero_web/presenters/provider_presenter.ex:125
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1324
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:532
-#: lib/klass_hero_web/components/provider_components.ex:1373
-#: lib/klass_hero_web/live/settings/children_live.ex:473
+#: lib/klass_hero_web/components/provider_components.ex:539
+#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:193
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:158
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1129
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:166
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1394
+#: lib/klass_hero_web/components/provider_components.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1982,8 +1976,8 @@ msgstr ""
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:792
+#: lib/klass_hero_web/components/provider_components.ex:417
+#: lib/klass_hero_web/components/provider_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
@@ -1994,53 +1988,53 @@ msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:45
-#: lib/klass_hero_web/components/provider_components.ex:1393
-#: lib/klass_hero_web/components/provider_components.ex:1824
-#: lib/klass_hero_web/components/provider_components.ex:1844
-#: lib/klass_hero_web/live/admin/sessions_live.ex:322
+#: lib/klass_hero_web/components/provider_components.ex:1400
+#: lib/klass_hero_web/components/provider_components.ex:1829
+#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1362
+#: lib/klass_hero_web/components/provider_components.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1299
+#: lib/klass_hero_web/components/provider_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:381
+#: lib/klass_hero_web/components/provider_components.ex:382
 #, elixir-autogen, elixir-format
 msgid "Program Slots"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:83
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:337
+#: lib/klass_hero_web/live/program_detail_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1257
+#: lib/klass_hero_web/components/provider_components.ex:1264
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1305
-#: lib/klass_hero_web/components/provider_components.ex:1587
-#: lib/klass_hero_web/components/provider_components.ex:1774
+#: lib/klass_hero_web/components/provider_components.ex:1312
+#: lib/klass_hero_web/components/provider_components.ex:1593
+#: lib/klass_hero_web/components/provider_components.ex:1779
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2053,7 +2047,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1321
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2063,231 +2057,229 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:50
+#: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:1395
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:373
+#: lib/klass_hero_web/components/provider_components.ex:374
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1367
+#: lib/klass_hero_web/components/provider_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:455
+#: lib/klass_hero_web/live/settings/children_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:542
+#: lib/klass_hero_web/components/messaging_components.ex:664
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:206
+#: lib/klass_hero_web/live/dashboard_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "%{remaining} remaining"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:410
+#: lib/klass_hero_web/live/settings/children_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:525
-#: lib/klass_hero_web/live/settings/children_live.ex:721
+#: lib/klass_hero_web/live/settings/children_live.ex:519
+#: lib/klass_hero_web/live/settings/children_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Allergies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:748
+#: lib/klass_hero_web/live/settings/children_live.ex:742
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:227
+#: lib/klass_hero_web/live/settings/children_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:729
+#: lib/klass_hero_web/live/settings/children_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:388
+#: lib/klass_hero_web/live/settings/children_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:190
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
+#: lib/klass_hero_web/live/provider/participation_live.ex:182
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:136
+#: lib/klass_hero_web/components/messaging_components.ex:147
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:78
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
 #: lib/klass_hero_web/components/participation_components.ex:635
-#: lib/klass_hero_web/components/provider_components.ex:757
-#: lib/klass_hero_web/components/provider_components.ex:1161
-#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:764
+#: lib/klass_hero_web/components/provider_components.ex:1168
+#: lib/klass_hero_web/components/provider_components.ex:1718
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:197
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:606
-#: lib/klass_hero_web/live/settings/children_live.ex:766
+#: lib/klass_hero_web/live/settings/children_live.ex:600
+#: lib/klass_hero_web/live/settings/children_live.ex:760
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:311
+#: lib/klass_hero_web/live/settings/children_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Child added successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:314
+#: lib/klass_hero_web/live/settings/children_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Child added, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:89
-#: lib/klass_hero_web/live/settings/children_live.ex:189
+#: lib/klass_hero_web/live/settings/children_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Child not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:182
+#: lib/klass_hero_web/live/settings/children_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child removed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:316
+#: lib/klass_hero_web/live/settings/children_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Child updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:319
+#: lib/klass_hero_web/live/settings/children_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:304
+#: lib/klass_hero_web/live/messaging_live_helper.ex:354
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:137
+#: lib/klass_hero_web/live/messaging_live_helper.ex:164
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:198
+#: lib/klass_hero_web/live/settings/children_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Could not remove child. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:503
+#: lib/klass_hero_web/live/settings/children_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:685
+#: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:487
+#: lib/klass_hero_web/live/settings/children_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:648
+#: lib/klass_hero_web/live/settings/children_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:514
-#: lib/klass_hero_web/live/settings/children_live.ex:714
+#: lib/klass_hero_web/live/settings/children_live.ex:508
+#: lib/klass_hero_web/live/settings/children_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:65
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:237
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Failed to load pending notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:116
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:271
+#: lib/klass_hero_web/live/provider/participation_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:100
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:171
-#, elixir-autogen, elixir-format
-msgid "Failed to send message"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/participation_live.ex:208
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:206
+#: lib/klass_hero_web/live/provider/participation_live.ex:199
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:671
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:677
+#: lib/klass_hero_web/live/settings/children_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:722
+#: lib/klass_hero_web/live/settings/children_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:374
+#: lib/klass_hero_web/live/settings/children_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr ""
@@ -2298,83 +2290,86 @@ msgid "Manage your children's profiles"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:64
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:268
-#: lib/klass_hero_web/components/messaging_components.ex:331
-#: lib/klass_hero_web/components/messaging_components.ex:354
-#: lib/klass_hero_web/live/messaging_live_helper.ex:265
+#: lib/klass_hero_web/components/layouts/app.html.heex:236
+#: lib/klass_hero_web/components/messaging_components.ex:434
+#: lib/klass_hero_web/components/messaging_components.ex:457
+#: lib/klass_hero_web/live/messaging_live_helper.ex:301
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:195
+#: lib/klass_hero_web/live/dashboard_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Monthly Booking Usage"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:409
+#: lib/klass_hero_web/live/settings/children_live.ex:403
 #: lib/klass_hero_web/presenters/child_presenter.ex:96
 #, elixir-autogen, elixir-format
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:399
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:263
-#: lib/klass_hero_web/components/messaging_components.ex:552
+#: lib/klass_hero_web/components/messaging_components.ex:368
+#: lib/klass_hero_web/components/messaging_components.ex:674
+#: lib/klass_hero_web/components/messaging_components.ex:685
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:92
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:56
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:196
-#: lib/klass_hero_web/live/provider/participation_live.ex:263
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:194
+#: lib/klass_hero_web/live/provider/participation_live.ex:188
+#: lib/klass_hero_web/live/provider/participation_live.ex:250
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:105
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:257
+#: lib/klass_hero_web/live/provider/participation_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:541
+#: lib/klass_hero_web/components/messaging_components.ex:663
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:715
+#: lib/klass_hero_web/live/settings/children_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:221
+#: lib/klass_hero_web/live/settings/children_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Please check the form for errors."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:194
+#: lib/klass_hero_web/live/booking_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr ""
@@ -2399,19 +2394,19 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:300
+#: lib/klass_hero_web/live/messaging_live_helper.ex:350
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:745
+#: lib/klass_hero_web/live/settings/children_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:742
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
-#: lib/klass_hero_web/live/settings/children_live.ex:782
+#: lib/klass_hero_web/components/provider_components.ex:749
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
+#: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
@@ -2421,70 +2416,78 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1479
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1485
+#: lib/klass_hero_web/components/provider_components.ex:1486
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:222
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:266
+#: lib/klass_hero_web/components/messaging_components.ex:371
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:226
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:536
-#: lib/klass_hero_web/live/settings/children_live.ex:728
+#: lib/klass_hero_web/live/settings/children_live.ex:530
+#: lib/klass_hero_web/live/settings/children_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:219
+#: lib/klass_hero_web/components/messaging_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:375
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:326
+#: lib/klass_hero_web/live/provider/participation_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:421
-#: lib/klass_hero_web/live/dashboard_live.ex:216
+#: lib/klass_hero_web/live/booking_live.ex:418
+#: lib/klass_hero_web/live/dashboard_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Upgrade"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:165
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:200
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:143
+#: lib/klass_hero_web/live/messaging_live_helper.ex:170
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:144
+#: lib/klass_hero_web/live/settings/children_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to delete this child."
 msgstr ""
@@ -2494,54 +2497,57 @@ msgstr ""
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:408
+#: lib/klass_hero_web/live/booking_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "You have %{remaining} of %{total} bookings remaining this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:200
+#: lib/klass_hero_web/live/dashboard_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "You have used %{used} of %{cap} bookings this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:184
+#: lib/klass_hero_web/live/booking_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "You've reached your monthly booking limit. Upgrade to Active tier for unlimited bookings."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:402
+#: lib/klass_hero_web/live/booking_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Your Booking Plan"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:304
+#: lib/klass_hero_web/components/messaging_components.ex:408
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:307
+#: lib/klass_hero_web/components/messaging_components.ex:410
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:25
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:86
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your subscription tier doesn't support broadcasts"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:152
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:414
-#: lib/klass_hero_web/live/dashboard_live.ex:209
+#: lib/klass_hero_web/live/booking_live.ex:411
+#: lib/klass_hero_web/live/dashboard_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "tier"
 msgstr ""
@@ -2553,23 +2559,23 @@ msgid_plural "%{count} documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:586
-#: lib/klass_hero_web/components/program_components.ex:594
+#: lib/klass_hero_web/components/program_components.ex:575
+#: lib/klass_hero_web/components/program_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/klass_hero_web/components/program_components.ex:571
 #: lib/klass_hero_web/components/program_components.ex:582
-#: lib/klass_hero_web/components/program_components.ex:593
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:607
+#: lib/klass_hero_web/components/program_components.ex:596
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr ""
@@ -2579,32 +2585,32 @@ msgstr ""
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:744
+#: lib/klass_hero_web/components/provider_components.ex:751
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1363
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:566
+#: lib/klass_hero_web/components/program_components.ex:555
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:570
+#: lib/klass_hero_web/components/program_components.ex:559
 #, elixir-autogen, elixir-format
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1889
+#: lib/klass_hero_web/components/provider_components.ex:1894
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2615,9 +2621,9 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:752
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/live/admin/sessions_live.ex:319
+#: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Approved"
@@ -2628,22 +2634,23 @@ msgstr ""
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:552
+#: lib/klass_hero_web/components/provider_components.ex:559
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:484
+#: lib/klass_hero_web/live/home_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1145
+#: lib/klass_hero_web/components/provider_components.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1125
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1199
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
 #: lib/klass_hero_web/live/provider/subscription_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
@@ -2659,27 +2666,27 @@ msgstr ""
 msgid "Berlin's leading network for tutors, coaches, and camp providers!"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:652
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:251
+#: lib/klass_hero_web/live/dashboard_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:646
+#: lib/klass_hero_web/components/provider_components.ex:653
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:252
+#: lib/klass_hero_web/live/about_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Built by Parents and Educators for More Learning Opportunities"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:481
+#: lib/klass_hero_web/live/home_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
@@ -2689,33 +2696,34 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1147
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1221
 #, elixir-autogen, elixir-format
 msgid "Business Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1134
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1155
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:822
+#: lib/klass_hero_web/components/provider_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:968
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1584
-#: lib/klass_hero_web/components/provider_components.ex:1768
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1773
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2730,27 +2738,27 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1133
+#: lib/klass_hero_web/components/provider_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1209
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1283
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:721
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:824
+#: lib/klass_hero_web/components/provider_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:429
+#: lib/klass_hero_web/components/provider_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2760,12 +2768,12 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1825
+#: lib/klass_hero_web/components/provider_components.ex:1830
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:413
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
@@ -2775,45 +2783,46 @@ msgstr ""
 msgid "Could not load verification documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:690
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:646
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:654
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:668
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:961
+#: lib/klass_hero_web/components/provider_components.ex:968
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1081
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:614
-#: lib/klass_hero_web/components/provider_components.ex:1032
-#: lib/klass_hero_web/live/settings/children_live.ex:698
+#: lib/klass_hero_web/components/program_components.ex:603
+#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/live/settings/children_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1996
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2841,12 +2850,12 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:435
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1733
+#: lib/klass_hero_web/components/provider_components.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2856,39 +2865,39 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:790
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:588
+#: lib/klass_hero_web/components/provider_components.ex:595
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:903
+#: lib/klass_hero_web/components/provider_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:896
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1596
+#: lib/klass_hero_web/components/provider_components.ex:1852
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1526
+#: lib/klass_hero_web/components/provider_components.ex:1532
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:933
+#: lib/klass_hero_web/components/provider_components.ex:940
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2898,8 +2907,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1848
-#: lib/klass_hero_web/live/admin/emails_live.ex:221
+#: lib/klass_hero_web/components/provider_components.ex:1853
+#: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -2914,24 +2923,24 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:628
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:444
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:232
+#: lib/klass_hero_web/live/dashboard_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:612
-#: lib/klass_hero_web/components/provider_components.ex:1031
-#: lib/klass_hero_web/live/settings/children_live.ex:697
+#: lib/klass_hero_web/components/program_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:1038
+#: lib/klass_hero_web/live/settings/children_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
@@ -2941,196 +2950,198 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1929
+#: lib/klass_hero_web/components/provider_components.ex:1932
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1931
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:675
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:616
+#: lib/klass_hero_web/components/provider_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:693
+#: lib/klass_hero_web/live/settings/children_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:621
+#: lib/klass_hero_web/components/program_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:630
+#: lib/klass_hero_web/components/program_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:626
+#: lib/klass_hero_web/components/program_components.ex:614
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1771
+#: lib/klass_hero_web/components/provider_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:685
+#: lib/klass_hero_web/components/provider_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:108
+#: lib/klass_hero_web/presenters/provider_presenter.ex:127
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1705
+#: lib/klass_hero_web/components/provider_components.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1746
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:699
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} families."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:263
+#: lib/klass_hero_web/live/about_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "In 2025, Shane connected with his friend Max Pergl, a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom, offering more to the community, but without the time to manage bookings, payments, and compliance on their own."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:107
+#: lib/klass_hero_web/presenters/provider_presenter.ex:126
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:643
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:640
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:617
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1543
+#: lib/klass_hero_web/components/provider_components.ex:1549
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:724
+#: lib/klass_hero_web/components/provider_components.ex:731
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1212
+#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:268
+#: lib/klass_hero_web/live/about_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:707
+#: lib/klass_hero_web/live/settings/children_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:273
+#: lib/klass_hero_web/live/about_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:622
+#: lib/klass_hero_web/components/provider_components.ex:629
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:914
+#: lib/klass_hero_web/components/provider_components.ex:921
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1024
+#: lib/klass_hero_web/components/provider_components.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:842
+#: lib/klass_hero_web/components/provider_components.ex:849
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:390
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:613
-#: lib/klass_hero_web/components/provider_components.ex:1030
-#: lib/klass_hero_web/live/settings/children_live.ex:696
+#: lib/klass_hero_web/components/program_components.ex:602
+#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/live/settings/children_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1013
+#: lib/klass_hero_web/components/provider_components.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:948
+#: lib/klass_hero_web/components/provider_components.ex:955
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:853
+#: lib/klass_hero_web/components/provider_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1007
+#: lib/klass_hero_web/components/provider_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:942
+#: lib/klass_hero_web/components/provider_components.ex:949
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/components/provider_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -3145,38 +3156,38 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:1960
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1577
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:168
+#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:686
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:706
+#: lib/klass_hero_web/live/settings/children_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1763
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1072
+#: lib/klass_hero_web/components/provider_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/components/provider_components.ex:1072
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -3186,7 +3197,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:240
+#: lib/klass_hero_web/live/dashboard_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr ""
@@ -3196,7 +3207,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1362
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1411
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -3207,7 +3218,7 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1147
+#: lib/klass_hero_web/components/provider_components.ex:1154
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
@@ -3217,44 +3228,45 @@ msgstr ""
 msgid "Not Verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:615
-#: lib/klass_hero_web/components/provider_components.ex:1033
-#: lib/klass_hero_web/live/settings/children_live.ex:695
+#: lib/klass_hero_web/components/program_components.ex:604
+#: lib/klass_hero_web/components/provider_components.ex:1040
+#: lib/klass_hero_web/live/settings/children_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:479
+#: lib/klass_hero_web/live/home_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:537
+#: lib/klass_hero_web/components/program_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:958
+#: lib/klass_hero_web/components/provider_components.ex:965
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/participation_components.ex:751
 #: lib/klass_hero_web/components/provider_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:380
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:858
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:955
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1035
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:884
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:945
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:980
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1052
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -3269,87 +3281,87 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:833
+#: lib/klass_hero_web/components/provider_components.ex:840
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:376
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:997
+#: lib/klass_hero_web/components/provider_components.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1870
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1937
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1877
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1944
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:506
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:542
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:545
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:895
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:529
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:565
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:568
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:883
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:385
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:499
+#: lib/klass_hero_web/live/home_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:728
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/participation_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:984
+#: lib/klass_hero_web/components/provider_components.ex:991
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:157
+#: lib/klass_hero_web/live/program_detail_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:925
+#: lib/klass_hero_web/components/provider_components.ex:932
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:920
+#: lib/klass_hero_web/components/provider_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:911
+#: lib/klass_hero_web/components/provider_components.ex:918
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3359,7 +3371,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:129
+#: lib/klass_hero_web/live/program_detail_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr ""
@@ -3369,12 +3381,12 @@ msgstr ""
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:78
+#: lib/klass_hero_web/live/program_detail_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:125
+#: lib/klass_hero_web/live/program_detail_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr ""
@@ -3385,7 +3397,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:753
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
@@ -3398,16 +3410,17 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:707
-#: lib/klass_hero_web/components/provider_components.ex:1112
-#: lib/klass_hero_web/components/provider_components.ex:1806
-#: lib/klass_hero_web/components/provider_components.ex:2052
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1188
+#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:1119
+#: lib/klass_hero_web/components/provider_components.ex:1811
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1804
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3417,105 +3430,105 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:631
+#: lib/klass_hero_web/components/provider_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1469
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:154
+#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1856
-#: lib/klass_hero_web/components/provider_components.ex:1868
-#: lib/klass_hero_web/components/provider_components.ex:1879
+#: lib/klass_hero_web/components/provider_components.ex:1861
+#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1174
+#: lib/klass_hero_web/components/provider_components.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:849
+#: lib/klass_hero_web/components/provider_components.ex:856
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:192
+#: lib/klass_hero_web/live/program_detail_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:705
+#: lib/klass_hero_web/live/settings/children_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2030
+#: lib/klass_hero_web/components/provider_components.ex:2033
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:136
-#: lib/klass_hero_web/live/booking_live.ex:204
+#: lib/klass_hero_web/live/booking_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:848
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:910
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:874
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
-#: lib/klass_hero_web/live/admin/emails_live.ex:220
+#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:679
+#: lib/klass_hero_web/components/provider_components.ex:686
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:936
+#: lib/klass_hero_web/components/provider_components.ex:943
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:258
+#: lib/klass_hero_web/live/about_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:659
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1041
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:235
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:299
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:315
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:268
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:898
+#: lib/klass_hero_web/components/provider_components.ex:905
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:884
+#: lib/klass_hero_web/components/provider_components.ex:891
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3526,72 +3539,72 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:386
+#: lib/klass_hero_web/live/booking_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:109
+#: lib/klass_hero_web/presenters/provider_presenter.ex:128
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:977
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:978
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:296
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1007
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1008
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1148
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:249
+#: lib/klass_hero_web/live/about_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:620
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:902
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:927
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:815
+#: lib/klass_hero_web/components/provider_components.ex:822
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:278
+#: lib/klass_hero_web/live/about_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1930
+#: lib/klass_hero_web/components/provider_components.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3601,42 +3614,42 @@ msgstr ""
 msgid "Unable to load document preview."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:574
+#: lib/klass_hero_web/components/program_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:634
+#: lib/klass_hero_web/components/program_components.ex:622
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
+#: lib/klass_hero_web/components/provider_components.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1985
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:1954
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3649,8 +3662,8 @@ msgstr ""
 msgid "Verification document not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:177
-#: lib/klass_hero_web/components/layouts/app.html.heex:288
+#: lib/klass_hero_web/components/layouts/app.html.heex:147
+#: lib/klass_hero_web/components/layouts/app.html.heex:256
 #: lib/klass_hero_web/live/admin/verifications_live.ex:40
 #: lib/klass_hero_web/live/admin/verifications_live.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:189
@@ -3663,42 +3676,42 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:128
+#: lib/klass_hero_web/live/about_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:316
+#: lib/klass_hero_web/user_auth.ex:315
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:632
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:623
+#: lib/klass_hero_web/components/provider_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:617
+#: lib/klass_hero_web/components/provider_components.ex:624
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:645
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:843
+#: lib/klass_hero_web/components/provider_components.ex:850
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3733,8 +3746,8 @@ msgid_plural "%{count} team seats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/about_live.ex:73
-#: lib/klass_hero_web/live/trust_safety_live.ex:55
+#: lib/klass_hero_web/live/about_live.ex:71
+#: lib/klass_hero_web/live/trust_safety_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
@@ -3750,7 +3763,7 @@ msgstr ""
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:236
+#: lib/klass_hero_web/live/trust_safety_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "And at Klass Hero, both come standard."
 msgstr ""
@@ -3761,7 +3774,7 @@ msgstr ""
 msgid "Applicants complete a video screening to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:104
+#: lib/klass_hero_web/live/trust_safety_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. Our platform is built to connect families, schools, and organizations with qualified, vetted, and safety-verified educators and activity providers."
 msgstr ""
@@ -3781,8 +3794,8 @@ msgstr ""
 msgid "Business Plus"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:71
-#: lib/klass_hero_web/live/trust_safety_live.ex:53
+#: lib/klass_hero_web/live/about_live.ex:69
+#: lib/klass_hero_web/live/trust_safety_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
@@ -3797,8 +3810,8 @@ msgstr ""
 msgid "Choose your plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:83
-#: lib/klass_hero_web/live/trust_safety_live.ex:61
+#: lib/klass_hero_web/live/about_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3808,7 +3821,7 @@ msgstr ""
 msgid "Could not change subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:75
+#: lib/klass_hero_web/live/trust_safety_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Create long-term trust across our community"
 msgstr ""
@@ -3819,7 +3832,7 @@ msgstr ""
 msgid "Current Plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1297
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Current Plan: %{plan}"
 msgstr ""
@@ -3835,18 +3848,18 @@ msgstr ""
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:82
+#: lib/klass_hero_web/live/trust_safety_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:159
+#: lib/klass_hero_web/live/trust_safety_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Every educator and enrichment professional on Klass Hero completes a 6-step verification process before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:85
-#: lib/klass_hero_web/live/trust_safety_live.ex:63
+#: lib/klass_hero_web/live/about_live.ex:83
+#: lib/klass_hero_web/live/trust_safety_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
@@ -3878,7 +3891,7 @@ msgstr ""
 msgid "Free"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:138
+#: lib/klass_hero_web/live/trust_safety_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
@@ -3893,12 +3906,12 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:216
+#: lib/klass_hero_web/live/trust_safety_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Have Questions?"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:156
+#: lib/klass_hero_web/live/trust_safety_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
@@ -3909,7 +3922,7 @@ msgstr ""
 msgid "Identity & Age Verification"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:219
+#: lib/klass_hero_web/live/trust_safety_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "If you'd like to learn more about our Trust & Safety standards or provider verification process, we're happy to help."
 msgstr ""
@@ -3920,27 +3933,27 @@ msgstr ""
 msgid "Invalid subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1307
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
 #, elixir-autogen, elixir-format
 msgid "Manage Plan →"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:186
+#: lib/klass_hero_web/live/trust_safety_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality & Accountability"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:116
+#: lib/klass_hero_web/live/trust_safety_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Our Commitment to Child Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:509
+#: lib/klass_hero_web/live/booking_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
@@ -3950,12 +3963,12 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:520
+#: lib/klass_hero_web/live/booking_live.ex:517
 #, elixir-autogen, elixir-format
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1711
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3965,7 +3978,7 @@ msgstr ""
 msgid "Promotional content"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:72
+#: lib/klass_hero_web/live/trust_safety_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Protect children and families"
 msgstr ""
@@ -3976,17 +3989,17 @@ msgstr ""
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:205
+#: lib/klass_hero_web/live/trust_safety_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Providers who fail to uphold our expectations may be suspended or removed from the platform."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:83
+#: lib/klass_hero_web/live/trust_safety_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:228
+#: lib/klass_hero_web/live/booking_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
@@ -4006,7 +4019,7 @@ msgstr ""
 msgid "Subscription Plans"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:73
+#: lib/klass_hero_web/live/trust_safety_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Support schools and institutions with reliable providers"
 msgstr ""
@@ -4021,35 +4034,36 @@ msgstr ""
 msgid "Switched to %{plan}"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:101
+#: lib/klass_hero_web/live/trust_safety_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "TRUST & SAFETY"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:84
+#: lib/klass_hero_web/live/trust_safety_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Taking action when standards are not met"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:212
+#: lib/klass_hero_web/live/booking_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:661
-#: lib/klass_hero_web/components/layouts/app.html.heex:73
-#: lib/klass_hero_web/components/layouts/app.html.heex:250
+#: lib/klass_hero_web/components/composite_components.ex:612
+#: lib/klass_hero_web/components/composite_components.ex:681
+#: lib/klass_hero_web/components/layouts/app.html.heex:60
+#: lib/klass_hero_web/components/layouts/app.html.heex:212
 #: lib/klass_hero_web/live/trust_safety_live.ex:12
 #, elixir-autogen, elixir-format
 msgid "Trust & Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:189
+#: lib/klass_hero_web/live/trust_safety_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Trust doesn't stop at onboarding. Klass Hero continuously works to maintain a safe and high-quality ecosystem by:"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:233
+#: lib/klass_hero_web/live/trust_safety_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Trust is earned. Safety is non-negotiable."
 msgstr ""
@@ -4059,17 +4073,17 @@ msgstr ""
 msgid "Unlimited programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1300
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to unlock more features"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:74
+#: lib/klass_hero_web/live/trust_safety_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:135
+#: lib/klass_hero_web/live/trust_safety_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
@@ -4085,7 +4099,7 @@ msgstr ""
 msgid "Video Screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:119
+#: lib/klass_hero_web/live/trust_safety_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "We believe that children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
 msgstr ""
@@ -4106,87 +4120,87 @@ msgstr ""
 msgid "month"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:523
+#: lib/klass_hero_web/live/home_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:521
+#: lib/klass_hero_web/live/home_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:212
+#: lib/klass_hero_web/live/about_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Our 6-Step Vetting Process"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:140
+#: lib/klass_hero_web/live/settings/children_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Could not check enrollments. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:619
+#: lib/klass_hero_web/live/settings/children_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Remove Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:573
+#: lib/klass_hero_web/live/settings/children_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Remove Child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:591
+#: lib/klass_hero_web/live/settings/children_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:578
+#: lib/klass_hero_web/live/settings/children_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:155
+#: lib/klass_hero_web/live/settings/children_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "This deletion request has expired. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:660
+#: lib/klass_hero_web/live/home_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "1st cancellation (90 days): Warning only"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:661
+#: lib/klass_hero_web/live/home_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "2nd cancellation: €50 penalty"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:639
+#: lib/klass_hero_web/live/home_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "3-7 days before: Usually 75% refund (you keep 25%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:662
+#: lib/klass_hero_web/live/home_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "3rd cancellation: €100 penalty + 14-day suspension"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:663
+#: lib/klass_hero_web/live/home_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "4+ cancellations: Account termination"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:638
+#: lib/klass_hero_web/live/home_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "7+ days before: Usually full refund (you keep nothing)"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:269
+#: lib/klass_hero_web/live/admin/sessions_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:734
+#: lib/klass_hero_web/components/participation_components.ex:735
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -4202,22 +4216,22 @@ msgstr ""
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:596
+#: lib/klass_hero_web/live/home_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:568
+#: lib/klass_hero_web/live/home_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:284
+#: lib/klass_hero_web/live/admin/sessions_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:592
+#: lib/klass_hero_web/live/home_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
@@ -4227,7 +4241,7 @@ msgstr ""
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:614
+#: lib/klass_hero_web/live/home_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -4247,47 +4261,48 @@ msgstr ""
 msgid "Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:564
+#: lib/klass_hero_web/live/home_live.ex:573
 #, elixir-autogen, elixir-format
 msgid "Business Account: You keep €901 (€60 commission + €39 monthly fee)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:554
+#: lib/klass_hero_web/live/home_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Business Account: €39/month + 6% per booking (for providers/teams earning €600+/month)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:537
+#: lib/klass_hero_web/live/home_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:756
+#: lib/klass_hero_web/live/home_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:710
+#: lib/klass_hero_web/live/home_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Can I change my booking date?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:730
+#: lib/klass_hero_web/live/home_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Can I get a refund if the provider cancels?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:531
+#: lib/klass_hero_web/live/home_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:592
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:614
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr ""
@@ -4312,15 +4327,15 @@ msgstr ""
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:732
-#: lib/klass_hero_web/live/admin/sessions_live.ex:301
+#: lib/klass_hero_web/components/participation_components.ex:733
+#: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:733
-#: lib/klass_hero_web/live/admin/sessions_live.ex:302
+#: lib/klass_hero_web/components/participation_components.ex:734
+#: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:53
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:53
@@ -4333,37 +4348,37 @@ msgstr ""
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:629
+#: lib/klass_hero_web/live/home_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Clear policies protect everyone."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:758
+#: lib/klass_hero_web/live/home_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/components/participation_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:649
+#: lib/klass_hero_web/live/home_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Contact all booked parents immediately and offer alternative dates. Include us in CC/BCC (support@mail.klasshero.com)."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:712
+#: lib/klass_hero_web/live/home_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:632
+#: lib/klass_hero_web/live/home_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Contact them immediately - often you can find an alternative date. Include us in CC/BCC (support@mail.klasshero.com) so we're informed."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:738
+#: lib/klass_hero_web/live/home_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Contact us immediately at support@mail.klasshero.com or call +49 (0) 152 2426 0416. You'll receive 100% refund + family credit, and the provider faces serious penalties."
 msgstr ""
@@ -4373,47 +4388,50 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:589
+#: lib/klass_hero_web/live/dashboard_live.ex:177
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:591
+#: lib/klass_hero_web/live/home_live.ex:600
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:748
+#: lib/klass_hero_web/live/home_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:668
+#: lib/klass_hero_web/live/home_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Death in family"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:700
+#: lib/klass_hero_web/live/home_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:621
+#: lib/klass_hero_web/live/home_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:722
+#: lib/klass_hero_web/live/home_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:559
+#: lib/klass_hero_web/live/home_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Example: If you earn €1,000 in bookings"
 msgstr ""
@@ -4423,73 +4441,73 @@ msgstr ""
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:619
+#: lib/klass_hero_web/live/home_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:586
+#: lib/klass_hero_web/live/home_live.ex:595
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:670
+#: lib/klass_hero_web/live/home_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Government closure"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:597
+#: lib/klass_hero_web/live/home_live.ex:606
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:576
+#: lib/klass_hero_web/live/home_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:630
+#: lib/klass_hero_web/live/home_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "If Parent Cancels:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:647
+#: lib/klass_hero_web/live/home_live.ex:656
 #, elixir-autogen, elixir-format
 msgid "If You Must Cancel:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:674
+#: lib/klass_hero_web/live/home_live.ex:683
 #, elixir-autogen, elixir-format
 msgid "If you fail to show up without prior notice:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:676
+#: lib/klass_hero_web/live/home_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Immediate account suspension"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:730
-#: lib/klass_hero_web/live/admin/sessions_live.ex:300
+#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/live/admin/sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:600
+#: lib/klass_hero_web/live/home_live.ex:609
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:690
+#: lib/klass_hero_web/live/home_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:682
+#: lib/klass_hero_web/live/home_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Keep your reliability high - parents can see your cancellation rate on your profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:594
+#: lib/klass_hero_web/live/home_live.ex:603
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
@@ -4505,17 +4523,17 @@ msgstr ""
 msgid "Klass Hero Admin"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:640
+#: lib/klass_hero_web/live/home_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Less than 3 days: Usually 25-50% refund (you keep 50-75%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:667
+#: lib/klass_hero_web/live/home_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Medical emergency"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:671
+#: lib/klass_hero_web/live/home_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Minimum enrollment not met (camps only - notify 14 days before)"
 msgstr ""
@@ -4525,27 +4543,28 @@ msgstr ""
 msgid "No change"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:270
+#: lib/klass_hero_web/live/admin/sessions_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:612
+#: lib/klass_hero_web/live/home_live.ex:621
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1494
+#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:665
+#: lib/klass_hero_web/live/home_live.ex:674
 #, elixir-autogen, elixir-format
 msgid "No penalties for legitimate reasons:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:613
+#: lib/klass_hero_web/live/home_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
@@ -4556,77 +4575,78 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:605
+#: lib/klass_hero_web/live/home_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1659
+#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:581
+#: lib/klass_hero_web/live/home_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:678
+#: lib/klass_hero_web/live/home_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Parent gets 100% refund + family credit"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:585
+#: lib/klass_hero_web/live/home_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:611
+#: lib/klass_hero_web/live/home_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:589
+#: lib/klass_hero_web/live/home_live.ex:598
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:679
+#: lib/klass_hero_web/live/home_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Permanent ban if no valid emergency"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:606
+#: lib/klass_hero_web/live/home_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:541
+#: lib/klass_hero_web/live/home_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:539
+#: lib/klass_hero_web/live/home_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:549
+#: lib/klass_hero_web/live/home_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "Professional: More tools and opportunities for €9/month + 12% per booking (only when you get bookings)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:562
+#: lib/klass_hero_web/live/home_live.ex:571
 #, elixir-autogen, elixir-format
 msgid "Professional: You keep €871 (€120 commission + €9 monthly fee)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:658
+#: lib/klass_hero_web/live/home_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Provider Cancellation Penalties:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:673
+#: lib/klass_hero_web/live/home_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Provider No-Show:"
 msgstr ""
@@ -4636,7 +4656,7 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:618
+#: lib/klass_hero_web/live/home_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
@@ -4646,22 +4666,22 @@ msgstr ""
 msgid "Reason for correction"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:274
+#: lib/klass_hero_web/live/admin/sessions_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:636
+#: lib/klass_hero_web/live/home_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Refunds are automatic based on our cancellation policy:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:536
+#: lib/klass_hero_web/live/home_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:593
+#: lib/klass_hero_web/live/home_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
@@ -4671,22 +4691,22 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:729
+#: lib/klass_hero_web/components/participation_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:620
+#: lib/klass_hero_web/live/home_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:669
+#: lib/klass_hero_web/live/home_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Severe weather"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:578
+#: lib/klass_hero_web/live/home_live.ex:587
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -4696,127 +4716,129 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:544
+#: lib/klass_hero_web/live/home_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 20% commission per booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:561
+#: lib/klass_hero_web/live/home_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Starter: You keep €800 (€200 commission)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:643
+#: lib/klass_hero_web/live/home_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Stripe processes all refunds - funds returned to parent's original payment method within 5-10 business days. Any amounts you keep remain in your balance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:616
+#: lib/klass_hero_web/live/home_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1655
+#: lib/klass_hero_web/components/provider_components.ex:1660
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:585
+#: lib/klass_hero_web/live/dashboard_live.ex:164
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:608
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:604
+#: lib/klass_hero_web/live/home_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:534
+#: lib/klass_hero_web/live/home_live.ex:543
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:627
+#: lib/klass_hero_web/live/home_live.ex:636
 #, elixir-autogen, elixir-format
 msgid "What happens if a parent cancels or I need to cancel?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:720
+#: lib/klass_hero_web/live/home_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:736
+#: lib/klass_hero_web/live/home_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "What if the provider doesn't show up?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:579
+#: lib/klass_hero_web/live/home_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:654
+#: lib/klass_hero_web/live/home_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "When you cancel, parents get 100% refund automatically. The amount is deducted from your next payout."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:746
+#: lib/klass_hero_web/live/home_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:608
+#: lib/klass_hero_web/live/home_live.ex:617
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:538
+#: lib/klass_hero_web/live/home_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:692
+#: lib/klass_hero_web/live/home_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:533
+#: lib/klass_hero_web/live/home_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:731
+#: lib/klass_hero_web/live/home_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Yes, always 100% refund if provider cancels. No exceptions."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:702
+#: lib/klass_hero_web/live/home_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:587
+#: lib/klass_hero_web/live/home_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:610
+#: lib/klass_hero_web/live/home_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:583
+#: lib/klass_hero_web/live/home_live.ex:592
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:677
+#: lib/klass_hero_web/live/home_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "€200 penalty (deducted from balance or invoiced)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:77
+#: lib/klass_hero_web/components/participation_components.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr ""
@@ -4831,12 +4853,12 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:339
+#: lib/klass_hero_web/live/provider/sessions_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:150
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:152
 #, elixir-autogen, elixir-format
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
@@ -4847,8 +4869,8 @@ msgstr ""
 msgid "Add Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:159
-#: lib/klass_hero_web/components/layouts/app.html.heex:281
+#: lib/klass_hero_web/components/layouts/app.html.heex:129
+#: lib/klass_hero_web/components/layouts/app.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -4868,7 +4890,7 @@ msgstr ""
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:232
+#: lib/klass_hero_web/components/participation_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
@@ -4878,13 +4900,13 @@ msgstr ""
 msgid "Archive"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:216
+#: lib/klass_hero_web/live/admin/emails_live.ex:215
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:88
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr ""
@@ -4905,7 +4927,7 @@ msgstr ""
 msgid "Behavioral Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:506
+#: lib/klass_hero_web/components/messaging_components.ex:628
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4922,7 +4944,7 @@ msgstr ""
 msgid "Check Out"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:280
+#: lib/klass_hero_web/live/admin/sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr ""
@@ -4942,7 +4964,7 @@ msgstr ""
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:216
+#: lib/klass_hero_web/components/participation_components.ex:217
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
@@ -4963,13 +4985,13 @@ msgid "Clear selection"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:76
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:200
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:202
 #, elixir-autogen, elixir-format
 msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:295
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -5009,7 +5031,7 @@ msgstr ""
 msgid "Content is being fetched..."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:204
+#: lib/klass_hero_web/live/messaging_live_helper.ex:240
 #, elixir-autogen, elixir-format
 msgid "Could not start private conversation"
 msgstr ""
@@ -5026,8 +5048,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:313
-#: lib/klass_hero_web/live/provider/sessions_live.ex:314
+#: lib/klass_hero_web/live/provider/sessions_live.ex:330
+#: lib/klass_hero_web/live/provider/sessions_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -5070,12 +5092,12 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:338
+#: lib/klass_hero_web/live/provider/sessions_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -5085,7 +5107,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:273
+#: lib/klass_hero_web/live/provider/sessions_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -5100,7 +5122,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:332
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -5141,8 +5163,8 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:282
-#: lib/klass_hero_web/live/provider/sessions_live.ex:334
+#: lib/klass_hero_web/live/admin/sessions_live.ex:278
+#: lib/klass_hero_web/live/provider/sessions_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -5168,7 +5190,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:312
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
@@ -5178,8 +5200,8 @@ msgstr ""
 msgid "Joined"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:28
-#: lib/klass_hero_web/components/layouts/app.html.heex:240
+#: lib/klass_hero_web/components/layouts/app.html.heex:15
+#: lib/klass_hero_web/components/layouts/app.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Klass Hero Logo"
 msgstr ""
@@ -5189,7 +5211,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:70
+#: lib/klass_hero_web/components/participation_components.ex:71
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr ""
@@ -5210,7 +5232,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:309
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -5230,7 +5252,7 @@ msgstr ""
 msgid "No participation records yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:92
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "No programs assigned yet."
 msgstr ""
@@ -5246,7 +5268,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:324
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -5266,7 +5288,7 @@ msgstr ""
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:178
+#: lib/klass_hero_web/components/participation_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
@@ -5287,7 +5309,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:341
+#: lib/klass_hero_web/live/provider/sessions_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -5304,7 +5326,7 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:133
+#: lib/klass_hero_web/live/provider/sessions_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr ""
@@ -5319,7 +5341,7 @@ msgstr ""
 msgid "Provider observation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:215
+#: lib/klass_hero_web/live/admin/emails_live.ex:214
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
@@ -5335,12 +5357,12 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/components/messaging_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:211
+#: lib/klass_hero_web/live/messaging_live_helper.ex:247
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
@@ -5350,7 +5372,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:546
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr ""
@@ -5385,44 +5407,44 @@ msgstr ""
 msgid "Send Reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:219
+#: lib/klass_hero_web/live/admin/emails_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:57
+#: lib/klass_hero_web/components/participation_components.ex:58
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:231
+#: lib/klass_hero_web/components/participation_components.ex:232
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:187
+#: lib/klass_hero_web/components/participation_components.ex:188
 #: lib/klass_hero_web/components/participation_components.ex:319
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:253
+#: lib/klass_hero_web/live/provider/sessions_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:962
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:273
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -5432,7 +5454,7 @@ msgstr ""
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:247
+#: lib/klass_hero_web/components/participation_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
@@ -5442,12 +5464,12 @@ msgstr ""
 msgid "Support: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:39
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:322
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5472,8 +5494,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:323
-#: lib/klass_hero_web/live/provider/sessions_live.ex:324
+#: lib/klass_hero_web/live/provider/sessions_live.ex:340
+#: lib/klass_hero_web/live/provider/sessions_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -5488,15 +5510,15 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:140
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:58
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
+#: lib/klass_hero_web/live/provider/sessions_live.ex:160
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:214
+#: lib/klass_hero_web/live/admin/emails_live.ex:213
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"
@@ -5507,14 +5529,14 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:428
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:683
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:456
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:306
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -5524,7 +5546,7 @@ msgstr ""
 msgid "View your children's participation records"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:82
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Welcome, %{name}"
 msgstr ""
@@ -5540,12 +5562,12 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:327
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:300
+#: lib/klass_hero_web/user_auth.ex:299
 #, elixir-autogen, elixir-format
 msgid "You must be a staff member to access this page."
 msgstr ""
@@ -5565,12 +5587,12 @@ msgstr ""
 msgid "Your children's participation will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:130
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:391
+#: lib/klass_hero_web/components/provider_components.ex:392
 #, elixir-autogen, elixir-format
 msgid "Team Members"
 msgstr ""
@@ -5580,12 +5602,220 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:239
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
+#, elixir-autogen, elixir-format
+msgid "+1234567890"
+msgstr ""
+
+#: lib/klass_hero_web/components/composite_components.ex:852
+#, elixir-autogen, elixir-format
+msgid "About the Provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:250
+#, elixir-autogen, elixir-format
+msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:214
+#, elixir-autogen, elixir-format
+msgid "Business Name"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:737
+#, elixir-autogen, elixir-format
+msgid "Cancelled"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#, elixir-autogen, elixir-format
+msgid "Categories"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1179
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
+#, elixir-autogen, elixir-format
+msgid "Complete Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:40
+#, elixir-autogen, elixir-format
+msgid "Complete Your Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "Complete Your Provider Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1162
+#, elixir-autogen, elixir-format
+msgid "Complete your provider profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "Drag and drop or click to upload"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:504
+#, elixir-autogen, elixir-format
+msgid "Failed to upload files. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:689
+#, elixir-autogen, elixir-format
+msgid "File is too large (max %{mb} MB)"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:502
+#, elixir-autogen, elixir-format
+msgid "File is too large (max %{mb} MB)."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:692
+#, elixir-autogen, elixir-format
+msgid "File type not accepted (images only)"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#, elixir-autogen, elixir-format
+msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
+#, elixir-autogen, elixir-format
+msgid "Manage your business"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:499
+#, elixir-autogen, elixir-format
+msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:677
+#: lib/klass_hero_web/components/messaging_components.ex:681
+#, elixir-autogen, elixir-format
+msgid "Photo"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:494
+#, elixir-autogen, elixir-format
+msgid "Please enter a message or attach a photo."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Profile completed! Klass Hero will review your profile shortly."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:36
+#, elixir-autogen, elixir-format
+msgid "Provider not found"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:276
+#, elixir-autogen, elixir-format
+msgid "Remove attachment"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1328
+#, elixir-autogen, elixir-format
+msgid "Sessions Completed"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:505
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:47
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:88
+#, elixir-autogen, elixir-format
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#, elixir-autogen, elixir-format
+msgid "Tell parents about your organization and what makes you unique..."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:696
+#, elixir-autogen, elixir-format
+msgid "Too many files (max %{max})"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:497
+#, elixir-autogen, elixir-format
+msgid "Too many files (max %{max})."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#, elixir-autogen, elixir-format
+msgid "Upgrade plan to message parents"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Upgrade plan to send broadcasts"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:700
+#, elixir-autogen, elixir-format
+msgid "Upload error"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:699
+#, elixir-autogen, elixir-format
+msgid "Upload failed"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1093
+#, elixir-autogen, elixir-format
+msgid "View your assignments"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
+#, elixir-autogen, elixir-format
+msgid "Website"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:434
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:866
+#, elixir-autogen, elixir-format
+msgid "You've reached your program limit. Upgrade your plan to add more programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:248
+#, elixir-autogen, elixir-format
+msgid "Your business address"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Your business or organization name"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Your profile is already complete."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:89
+#: lib/klass_hero_web/live/messaging_live_helper.ex:338
+#, elixir-autogen, elixir-format
+msgid "for"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -39,7 +39,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:138
 #: lib/klass_hero_web/components/layouts/app.html.heex:217
 #: lib/klass_hero_web/components/layouts/app.html.heex:253
-#: lib/klass_hero_web/components/provider_components.ex:356
+#: lib/klass_hero_web/components/provider_components.ex:357
 #: lib/klass_hero_web/live/dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1315
+#: lib/klass_hero_web/components/provider_components.ex:1316
 #: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -628,7 +628,7 @@ msgstr ""
 msgid "Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:644
+#: lib/klass_hero_web/components/provider_components.ex:645
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
 #: lib/klass_hero_web/live/user_live/login.ex:49
@@ -981,9 +981,9 @@ msgstr ""
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
-#: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:1666
+#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1714
+#: lib/klass_hero_web/components/provider_components.ex:1753
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1485,7 +1485,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:102
 #: lib/klass_hero_web/components/layouts/admin.html.heex:58
-#: lib/klass_hero_web/components/provider_components.ex:89
+#: lib/klass_hero_web/components/provider_components.ex:90
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "OUR MISSION"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:681
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr ""
@@ -1901,19 +1901,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1318
-#: lib/klass_hero_web/components/provider_components.ex:1599
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1319
+#: lib/klass_hero_web/components/provider_components.ex:1686
+#: lib/klass_hero_web/components/provider_components.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1399
+#: lib/klass_hero_web/components/provider_components.ex:1400
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:597
+#: lib/klass_hero_web/components/provider_components.ex:598
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1309
+#: lib/klass_hero_web/components/provider_components.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1936,7 +1936,7 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:175
+#: lib/klass_hero_web/components/provider_components.ex:176
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
@@ -1952,67 +1952,67 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/components/provider_components.ex:540
+#: lib/klass_hero_web/components/provider_components.ex:1381
 #: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:193
+#: lib/klass_hero_web/components/provider_components.ex:194
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:166
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:82
+#: lib/klass_hero_web/components/provider_components.ex:83
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:417
-#: lib/klass_hero_web/components/provider_components.ex:799
+#: lib/klass_hero_web/components/provider_components.ex:418
+#: lib/klass_hero_web/components/provider_components.ex:800
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:68
+#: lib/klass_hero_web/components/provider_components.ex:69
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:45
-#: lib/klass_hero_web/components/provider_components.ex:1400
-#: lib/klass_hero_web/components/provider_components.ex:1829
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:46
+#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1916
+#: lib/klass_hero_web/components/provider_components.ex:1936
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1369
+#: lib/klass_hero_web/components/provider_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1252
+#: lib/klass_hero_web/components/provider_components.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1306
+#: lib/klass_hero_web/components/provider_components.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:382
+#: lib/klass_hero_web/components/provider_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Program Slots"
 msgstr ""
@@ -2027,14 +2027,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:1265
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1312
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1779
+#: lib/klass_hero_web/components/provider_components.ex:1313
+#: lib/klass_hero_web/components/provider_components.ex:1625
+#: lib/klass_hero_web/components/provider_components.ex:1680
+#: lib/klass_hero_web/components/provider_components.ex:1866
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2042,7 +2043,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:75
+#: lib/klass_hero_web/components/provider_components.ex:76
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr ""
@@ -2052,30 +2053,31 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:178
+#: lib/klass_hero_web/components/provider_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1342
+#: lib/klass_hero_web/components/provider_components.ex:1343
+#: lib/klass_hero_web/components/provider_components.ex:1640
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
-#: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:1403
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:374
+#: lib/klass_hero_web/components/provider_components.ex:375
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1374
+#: lib/klass_hero_web/components/provider_components.ex:1375
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -2145,9 +2147,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
 #: lib/klass_hero_web/components/participation_components.ex:635
-#: lib/klass_hero_web/components/provider_components.ex:764
-#: lib/klass_hero_web/components/provider_components.ex:1168
-#: lib/klass_hero_web/components/provider_components.ex:1718
+#: lib/klass_hero_web/components/provider_components.ex:765
+#: lib/klass_hero_web/components/provider_components.ex:1169
+#: lib/klass_hero_web/components/provider_components.ex:1805
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2404,7 +2406,7 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:749
+#: lib/klass_hero_web/components/provider_components.ex:750
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
 #: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
@@ -2416,8 +2418,8 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1485
 #: lib/klass_hero_web/components/provider_components.ex:1486
+#: lib/klass_hero_web/components/provider_components.ex:1487
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2580,12 +2582,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:276
+#: lib/klass_hero_web/components/provider_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:751
+#: lib/klass_hero_web/components/provider_components.ex:752
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
@@ -2605,12 +2607,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1028
+#: lib/klass_hero_web/components/provider_components.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1894
+#: lib/klass_hero_web/components/provider_components.ex:1981
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2622,7 +2624,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:752
-#: lib/klass_hero_web/components/provider_components.ex:46
+#: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
 #, elixir-autogen, elixir-format
@@ -2634,7 +2636,7 @@ msgstr ""
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:559
+#: lib/klass_hero_web/components/provider_components.ex:560
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
@@ -2644,7 +2646,7 @@ msgstr ""
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1152
+#: lib/klass_hero_web/components/provider_components.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
@@ -2666,7 +2668,7 @@ msgstr ""
 msgid "Berlin's leading network for tutors, coaches, and camp providers!"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:653
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2676,7 +2678,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:653
+#: lib/klass_hero_web/components/provider_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2712,18 +2714,18 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:829
+#: lib/klass_hero_web/components/provider_components.ex:830
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:976
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1773
+#: lib/klass_hero_web/components/provider_components.ex:1677
+#: lib/klass_hero_web/components/provider_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2738,7 +2740,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2748,17 +2750,17 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:831
+#: lib/klass_hero_web/components/provider_components.ex:832
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:432
+#: lib/klass_hero_web/components/provider_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2768,7 +2770,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1830
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2794,35 +2796,35 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1096
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:968
+#: lib/klass_hero_web/components/provider_components.ex:969
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:603
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:1040
 #: lib/klass_hero_web/live/settings/children_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2855,7 +2857,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1738
+#: lib/klass_hero_web/components/provider_components.ex:1825
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2865,39 +2867,39 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:798
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:595
+#: lib/klass_hero_web/components/provider_components.ex:596
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:910
+#: lib/klass_hero_web/components/provider_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:896
+#: lib/klass_hero_web/components/provider_components.ex:897
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1596
-#: lib/klass_hero_web/components/provider_components.ex:1852
+#: lib/klass_hero_web/components/provider_components.ex:1683
+#: lib/klass_hero_web/components/provider_components.ex:1939
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/components/provider_components.ex:1533
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:940
+#: lib/klass_hero_web/components/provider_components.ex:941
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2907,7 +2909,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1853
+#: lib/klass_hero_web/components/provider_components.ex:1940
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2939,7 +2941,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:601
-#: lib/klass_hero_web/components/provider_components.ex:1038
+#: lib/klass_hero_web/components/provider_components.ex:1039
 #: lib/klass_hero_web/live/settings/children_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2950,22 +2952,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:2019
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1934
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:682
+#: lib/klass_hero_web/components/provider_components.ex:683
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:623
+#: lib/klass_hero_web/components/provider_components.ex:624
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
@@ -2990,12 +2992,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1776
+#: lib/klass_hero_web/components/provider_components.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:692
+#: lib/klass_hero_web/components/provider_components.ex:693
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -3005,12 +3007,12 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1838
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
@@ -3045,17 +3047,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1549
+#: lib/klass_hero_web/components/provider_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:731
+#: lib/klass_hero_web/components/provider_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1144
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
@@ -3077,22 +3079,22 @@ msgstr ""
 msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:629
+#: lib/klass_hero_web/components/provider_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:922
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1031
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:849
+#: lib/klass_hero_web/components/provider_components.ex:850
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -3105,43 +3107,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:602
-#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/components/provider_components.ex:1038
 #: lib/klass_hero_web/live/settings/children_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:955
+#: lib/klass_hero_web/components/provider_components.ex:956
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1077
+#: lib/klass_hero_web/components/provider_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:860
+#: lib/klass_hero_web/components/provider_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1014
+#: lib/klass_hero_web/components/provider_components.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:949
+#: lib/klass_hero_web/components/provider_components.ex:950
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -3156,12 +3158,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1670
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -3177,17 +3179,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1763
+#: lib/klass_hero_web/components/provider_components.ex:1850
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1079
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1072
+#: lib/klass_hero_web/components/provider_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -3218,18 +3220,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1154
+#: lib/klass_hero_web/components/provider_components.ex:1155
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:291
+#: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:604
-#: lib/klass_hero_web/components/provider_components.ex:1040
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #: lib/klass_hero_web/live/settings/children_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -3240,7 +3242,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2036
+#: lib/klass_hero_web/components/provider_components.ex:2123
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3250,13 +3252,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:966
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:751
-#: lib/klass_hero_web/components/provider_components.ex:261
+#: lib/klass_hero_web/components/provider_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
@@ -3281,7 +3283,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:840
+#: lib/klass_hero_web/components/provider_components.ex:841
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -3291,7 +3293,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1004
+#: lib/klass_hero_web/components/provider_components.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
@@ -3330,13 +3332,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1938
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:991
+#: lib/klass_hero_web/components/provider_components.ex:992
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -3346,7 +3348,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:932
+#: lib/klass_hero_web/components/provider_components.ex:933
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
@@ -3356,12 +3358,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:918
+#: lib/klass_hero_web/components/provider_components.ex:919
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3398,7 +3400,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:753
-#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -3410,17 +3412,17 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:714
-#: lib/klass_hero_web/components/provider_components.ex:1119
-#: lib/klass_hero_web/components/provider_components.ex:1811
-#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:715
+#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:2142
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3430,30 +3432,30 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/components/provider_components.ex:1476
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1861
-#: lib/klass_hero_web/components/provider_components.ex:1873
-#: lib/klass_hero_web/components/provider_components.ex:1884
+#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:1971
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1181
+#: lib/klass_hero_web/components/provider_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:857
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3468,7 +3470,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3485,18 +3487,18 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1937
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:686
+#: lib/klass_hero_web/components/provider_components.ex:687
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:943
+#: lib/klass_hero_web/components/provider_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
@@ -3506,7 +3508,7 @@ msgstr ""
 msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:659
+#: lib/klass_hero_web/components/provider_components.ex:660
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -3523,12 +3525,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:905
+#: lib/klass_hero_web/components/provider_components.ex:906
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:891
+#: lib/klass_hero_web/components/provider_components.ex:892
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3594,7 +3596,7 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:822
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -3604,7 +3606,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1933
+#: lib/klass_hero_web/components/provider_components.ex:2020
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3624,32 +3626,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1695
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
+#: lib/klass_hero_web/components/provider_components.ex:2166
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2041
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1935
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3671,7 +3673,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:246
+#: lib/klass_hero_web/components/provider_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "Verified"
 msgstr ""
@@ -3686,32 +3688,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:640
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:630
+#: lib/klass_hero_web/components/provider_components.ex:631
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:624
+#: lib/klass_hero_web/components/provider_components.ex:625
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:646
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:823
+#: lib/klass_hero_web/components/provider_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:850
+#: lib/klass_hero_web/components/provider_components.ex:851
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -4425,7 +4427,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/components/provider_components.ex:1752
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -4553,7 +4555,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/components/provider_components.ex:1501
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -4580,7 +4582,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4736,7 +4738,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1747
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
@@ -5372,7 +5374,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr ""
@@ -5592,7 +5594,7 @@ msgstr ""
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:393
 #, elixir-autogen, elixir-format
 msgid "Team Members"
 msgstr ""
@@ -5793,7 +5795,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:434
+#: lib/klass_hero_web/components/provider_components.ex:435
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "You've reached your program limit. Upgrade your plan to add more programs."
@@ -5818,4 +5820,39 @@ msgstr ""
 #: lib/klass_hero_web/live/messaging_live_helper.ex:338
 #, elixir-autogen, elixir-format
 msgid "for"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1622
+#, elixir-autogen, elixir-format
+msgid "Assigned staff"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1624
+#, elixir-autogen, elixir-format
+msgid "Attendance"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1606
+#, elixir-autogen, elixir-format
+msgid "Close"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1623
+#, elixir-autogen, elixir-format
+msgid "Cover"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1621
+#, elixir-autogen, elixir-format
+msgid "Date / time"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1615
+#, elixir-autogen, elixir-format
+msgid "No sessions scheduled yet."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1604
+#, elixir-autogen, elixir-format
+msgid "Sessions — %{title}"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1515
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -981,9 +981,9 @@ msgstr ""
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
-#: lib/klass_hero_web/components/provider_components.ex:1714
-#: lib/klass_hero_web/components/provider_components.ex:1753
+#: lib/klass_hero_web/components/provider_components.ex:1720
+#: lib/klass_hero_web/components/provider_components.ex:1721
+#: lib/klass_hero_web/components/provider_components.ex:1760
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1902,13 +1902,13 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1319
-#: lib/klass_hero_web/components/provider_components.ex:1686
-#: lib/klass_hero_web/components/provider_components.ex:1869
+#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1400
+#: lib/klass_hero_web/components/provider_components.ex:1407
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -1953,7 +1953,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:540
-#: lib/klass_hero_web/components/provider_components.ex:1381
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -1966,7 +1966,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1988,9 +1988,9 @@ msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1401
-#: lib/klass_hero_web/components/provider_components.ex:1916
-#: lib/klass_hero_web/components/provider_components.ex:1936
+#: lib/klass_hero_web/components/provider_components.ex:1408
+#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1943
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
@@ -2033,9 +2033,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1313
-#: lib/klass_hero_web/components/provider_components.ex:1625
-#: lib/klass_hero_web/components/provider_components.ex:1680
-#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1632
+#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1873
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2059,14 +2059,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1343
-#: lib/klass_hero_web/components/provider_components.ex:1640
+#: lib/klass_hero_web/components/provider_components.ex:1647
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1403
+#: lib/klass_hero_web/components/provider_components.ex:1410
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1375
+#: lib/klass_hero_web/components/provider_components.ex:1382
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -2149,7 +2149,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:635
 #: lib/klass_hero_web/components/provider_components.ex:765
 #: lib/klass_hero_web/components/provider_components.ex:1169
-#: lib/klass_hero_web/components/provider_components.ex:1805
+#: lib/klass_hero_web/components/provider_components.ex:1812
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2418,8 +2418,8 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1486
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1493
+#: lib/klass_hero_web/components/provider_components.ex:1494
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2724,8 +2724,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1677
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:1684
+#: lib/klass_hero_web/components/provider_components.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2770,7 +2770,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1825
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2888,13 +2888,13 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1939
+#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1946
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1533
+#: lib/klass_hero_web/components/provider_components.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1940
+#: lib/klass_hero_web/components/provider_components.ex:1947
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2952,12 +2952,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:2026
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2028
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -3007,12 +3007,12 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1797
+#: lib/klass_hero_web/components/provider_components.ex:1804
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1838
+#: lib/klass_hero_web/components/provider_components.ex:1845
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1550
+#: lib/klass_hero_web/components/provider_components.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -3158,12 +3158,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2054
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1670
+#: lib/klass_hero_web/components/provider_components.ex:1677
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -3179,7 +3179,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -3242,7 +3242,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2123
+#: lib/klass_hero_web/components/provider_components.ex:2130
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3332,7 +3332,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1938
+#: lib/klass_hero_web/components/provider_components.ex:1945
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3414,15 +3414,15 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:1120
-#: lib/klass_hero_web/components/provider_components.ex:1898
-#: lib/klass_hero_web/components/provider_components.ex:2142
+#: lib/klass_hero_web/components/provider_components.ex:1905
+#: lib/klass_hero_web/components/provider_components.ex:2149
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1891
+#: lib/klass_hero_web/components/provider_components.ex:1898
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3437,15 +3437,15 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1476
+#: lib/klass_hero_web/components/provider_components.ex:1483
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
-#: lib/klass_hero_web/components/provider_components.ex:1960
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:1955
+#: lib/klass_hero_web/components/provider_components.ex:1967
+#: lib/klass_hero_web/components/provider_components.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
@@ -3470,7 +3470,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2120
+#: lib/klass_hero_web/components/provider_components.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1937
+#: lib/klass_hero_web/components/provider_components.ex:1944
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3606,7 +3606,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2027
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3626,32 +3626,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2166
+#: lib/klass_hero_web/components/provider_components.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2075
+#: lib/klass_hero_web/components/provider_components.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2041
+#: lib/klass_hero_web/components/provider_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2038
+#: lib/klass_hero_web/components/provider_components.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -4427,7 +4427,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1752
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1501
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -4582,7 +4582,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1747
+#: lib/klass_hero_web/components/provider_components.ex:1754
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
@@ -5822,37 +5822,42 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1622
+#: lib/klass_hero_web/components/provider_components.ex:1629
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1624
+#: lib/klass_hero_web/components/provider_components.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1606
+#: lib/klass_hero_web/components/provider_components.ex:1613
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1623
+#: lib/klass_hero_web/components/provider_components.ex:1630
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1621
+#: lib/klass_hero_web/components/provider_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1622
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1604
+#: lib/klass_hero_web/components/provider_components.ex:1611
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1374
+#, elixir-autogen, elixir-format
+msgid "View sessions"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1515
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -981,9 +981,9 @@ msgstr ""
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
-#: lib/klass_hero_web/components/provider_components.ex:1714
-#: lib/klass_hero_web/components/provider_components.ex:1753
+#: lib/klass_hero_web/components/provider_components.ex:1720
+#: lib/klass_hero_web/components/provider_components.ex:1721
+#: lib/klass_hero_web/components/provider_components.ex:1760
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1902,13 +1902,13 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1319
-#: lib/klass_hero_web/components/provider_components.ex:1686
-#: lib/klass_hero_web/components/provider_components.ex:1869
+#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1400
+#: lib/klass_hero_web/components/provider_components.ex:1407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
@@ -1953,7 +1953,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:540
-#: lib/klass_hero_web/components/provider_components.ex:1381
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -1966,7 +1966,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1988,9 +1988,9 @@ msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1401
-#: lib/klass_hero_web/components/provider_components.ex:1916
-#: lib/klass_hero_web/components/provider_components.ex:1936
+#: lib/klass_hero_web/components/provider_components.ex:1408
+#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1943
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
@@ -2033,9 +2033,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1313
-#: lib/klass_hero_web/components/provider_components.ex:1625
-#: lib/klass_hero_web/components/provider_components.ex:1680
-#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1632
+#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1873
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2059,14 +2059,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1343
-#: lib/klass_hero_web/components/provider_components.ex:1640
+#: lib/klass_hero_web/components/provider_components.ex:1647
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1403
+#: lib/klass_hero_web/components/provider_components.ex:1410
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1375
+#: lib/klass_hero_web/components/provider_components.ex:1382
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -2149,7 +2149,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:635
 #: lib/klass_hero_web/components/provider_components.ex:765
 #: lib/klass_hero_web/components/provider_components.ex:1169
-#: lib/klass_hero_web/components/provider_components.ex:1805
+#: lib/klass_hero_web/components/provider_components.ex:1812
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2418,8 +2418,8 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1486
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1493
+#: lib/klass_hero_web/components/provider_components.ex:1494
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2724,8 +2724,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1677
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:1684
+#: lib/klass_hero_web/components/provider_components.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2770,7 +2770,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1825
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2888,13 +2888,13 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1939
+#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1946
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1533
+#: lib/klass_hero_web/components/provider_components.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1940
+#: lib/klass_hero_web/components/provider_components.ex:1947
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2952,12 +2952,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:2026
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2028
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -3007,12 +3007,12 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1797
+#: lib/klass_hero_web/components/provider_components.ex:1804
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1838
+#: lib/klass_hero_web/components/provider_components.ex:1845
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1550
+#: lib/klass_hero_web/components/provider_components.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -3158,12 +3158,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2054
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1670
+#: lib/klass_hero_web/components/provider_components.ex:1677
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -3179,7 +3179,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -3242,7 +3242,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2123
+#: lib/klass_hero_web/components/provider_components.ex:2130
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3332,7 +3332,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1938
+#: lib/klass_hero_web/components/provider_components.ex:1945
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -3414,15 +3414,15 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:1120
-#: lib/klass_hero_web/components/provider_components.ex:1898
-#: lib/klass_hero_web/components/provider_components.ex:2142
+#: lib/klass_hero_web/components/provider_components.ex:1905
+#: lib/klass_hero_web/components/provider_components.ex:2149
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1891
+#: lib/klass_hero_web/components/provider_components.ex:1898
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3437,15 +3437,15 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1476
+#: lib/klass_hero_web/components/provider_components.ex:1483
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
-#: lib/klass_hero_web/components/provider_components.ex:1960
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:1955
+#: lib/klass_hero_web/components/provider_components.ex:1967
+#: lib/klass_hero_web/components/provider_components.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
@@ -3470,7 +3470,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2120
+#: lib/klass_hero_web/components/provider_components.ex:2127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1937
+#: lib/klass_hero_web/components/provider_components.ex:1944
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3606,7 +3606,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2027
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3626,32 +3626,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2166
+#: lib/klass_hero_web/components/provider_components.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2075
+#: lib/klass_hero_web/components/provider_components.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2041
+#: lib/klass_hero_web/components/provider_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2038
+#: lib/klass_hero_web/components/provider_components.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -4427,7 +4427,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1752
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1501
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -4582,7 +4582,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1747
+#: lib/klass_hero_web/components/provider_components.ex:1754
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
@@ -5822,37 +5822,42 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1622
+#: lib/klass_hero_web/components/provider_components.ex:1629
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1624
+#: lib/klass_hero_web/components/provider_components.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1606
+#: lib/klass_hero_web/components/provider_components.ex:1613
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1623
+#: lib/klass_hero_web/components/provider_components.ex:1630
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1621
+#: lib/klass_hero_web/components/provider_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1622
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1604
+#: lib/klass_hero_web/components/provider_components.ex:1611
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1374
+#, elixir-autogen, elixir-format
+msgid "View sessions"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -39,7 +39,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:138
 #: lib/klass_hero_web/components/layouts/app.html.heex:217
 #: lib/klass_hero_web/components/layouts/app.html.heex:253
-#: lib/klass_hero_web/components/provider_components.ex:356
+#: lib/klass_hero_web/components/provider_components.ex:357
 #: lib/klass_hero_web/live/dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1315
+#: lib/klass_hero_web/components/provider_components.ex:1316
 #: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -628,7 +628,7 @@ msgstr ""
 msgid "Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:644
+#: lib/klass_hero_web/components/provider_components.ex:645
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
 #: lib/klass_hero_web/live/user_live/login.ex:49
@@ -981,9 +981,9 @@ msgstr ""
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
-#: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:1666
+#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1714
+#: lib/klass_hero_web/components/provider_components.ex:1753
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1485,7 +1485,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:102
 #: lib/klass_hero_web/components/layouts/admin.html.heex:58
-#: lib/klass_hero_web/components/provider_components.ex:89
+#: lib/klass_hero_web/components/provider_components.ex:90
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "OUR MISSION"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:681
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr ""
@@ -1901,19 +1901,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1318
-#: lib/klass_hero_web/components/provider_components.ex:1599
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1319
+#: lib/klass_hero_web/components/provider_components.ex:1686
+#: lib/klass_hero_web/components/provider_components.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1399
+#: lib/klass_hero_web/components/provider_components.ex:1400
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:597
+#: lib/klass_hero_web/components/provider_components.ex:598
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1309
+#: lib/klass_hero_web/components/provider_components.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1936,7 +1936,7 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:175
+#: lib/klass_hero_web/components/provider_components.ex:176
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
@@ -1952,67 +1952,67 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/components/provider_components.ex:540
+#: lib/klass_hero_web/components/provider_components.ex:1381
 #: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:193
+#: lib/klass_hero_web/components/provider_components.ex:194
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:166
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:82
+#: lib/klass_hero_web/components/provider_components.ex:83
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:417
-#: lib/klass_hero_web/components/provider_components.ex:799
+#: lib/klass_hero_web/components/provider_components.ex:418
+#: lib/klass_hero_web/components/provider_components.ex:800
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:68
+#: lib/klass_hero_web/components/provider_components.ex:69
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:45
-#: lib/klass_hero_web/components/provider_components.ex:1400
-#: lib/klass_hero_web/components/provider_components.ex:1829
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:46
+#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1916
+#: lib/klass_hero_web/components/provider_components.ex:1936
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1369
+#: lib/klass_hero_web/components/provider_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1252
+#: lib/klass_hero_web/components/provider_components.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1306
+#: lib/klass_hero_web/components/provider_components.ex:1307
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:382
+#: lib/klass_hero_web/components/provider_components.ex:383
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Slots"
 msgstr ""
@@ -2027,14 +2027,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:1265
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1312
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1779
+#: lib/klass_hero_web/components/provider_components.ex:1313
+#: lib/klass_hero_web/components/provider_components.ex:1625
+#: lib/klass_hero_web/components/provider_components.ex:1680
+#: lib/klass_hero_web/components/provider_components.ex:1866
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2042,7 +2043,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:75
+#: lib/klass_hero_web/components/provider_components.ex:76
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr ""
@@ -2052,30 +2053,31 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:178
+#: lib/klass_hero_web/components/provider_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1342
+#: lib/klass_hero_web/components/provider_components.ex:1343
+#: lib/klass_hero_web/components/provider_components.ex:1640
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
-#: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:1403
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:374
+#: lib/klass_hero_web/components/provider_components.ex:375
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1374
+#: lib/klass_hero_web/components/provider_components.ex:1375
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -2145,9 +2147,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
 #: lib/klass_hero_web/components/participation_components.ex:635
-#: lib/klass_hero_web/components/provider_components.ex:764
-#: lib/klass_hero_web/components/provider_components.ex:1168
-#: lib/klass_hero_web/components/provider_components.ex:1718
+#: lib/klass_hero_web/components/provider_components.ex:765
+#: lib/klass_hero_web/components/provider_components.ex:1169
+#: lib/klass_hero_web/components/provider_components.ex:1805
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2404,7 +2406,7 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:749
+#: lib/klass_hero_web/components/provider_components.ex:750
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
 #: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
@@ -2416,8 +2418,8 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1485
 #: lib/klass_hero_web/components/provider_components.ex:1486
+#: lib/klass_hero_web/components/provider_components.ex:1487
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2580,12 +2582,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:276
+#: lib/klass_hero_web/components/provider_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:751
+#: lib/klass_hero_web/components/provider_components.ex:752
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
@@ -2605,12 +2607,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1028
+#: lib/klass_hero_web/components/provider_components.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1894
+#: lib/klass_hero_web/components/provider_components.ex:1981
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2622,7 +2624,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:752
-#: lib/klass_hero_web/components/provider_components.ex:46
+#: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
 #, elixir-autogen, elixir-format
@@ -2634,7 +2636,7 @@ msgstr ""
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:559
+#: lib/klass_hero_web/components/provider_components.ex:560
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
@@ -2644,7 +2646,7 @@ msgstr ""
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1152
+#: lib/klass_hero_web/components/provider_components.ex:1153
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
@@ -2666,7 +2668,7 @@ msgstr ""
 msgid "Berlin's leading network for tutors, coaches, and camp providers!"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:653
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2676,7 +2678,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:653
+#: lib/klass_hero_web/components/provider_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2712,18 +2714,18 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:829
+#: lib/klass_hero_web/components/provider_components.ex:830
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:976
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1773
+#: lib/klass_hero_web/components/provider_components.ex:1677
+#: lib/klass_hero_web/components/provider_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2738,7 +2740,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2748,17 +2750,17 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:831
+#: lib/klass_hero_web/components/provider_components.ex:832
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:432
+#: lib/klass_hero_web/components/provider_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2768,7 +2770,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1830
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2794,35 +2796,35 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1096
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:968
+#: lib/klass_hero_web/components/provider_components.ex:969
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1089
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:603
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:1040
 #: lib/klass_hero_web/live/settings/children_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2855,7 +2857,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1738
+#: lib/klass_hero_web/components/provider_components.ex:1825
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2865,39 +2867,39 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:798
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:595
+#: lib/klass_hero_web/components/provider_components.ex:596
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:910
+#: lib/klass_hero_web/components/provider_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:896
+#: lib/klass_hero_web/components/provider_components.ex:897
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1596
-#: lib/klass_hero_web/components/provider_components.ex:1852
+#: lib/klass_hero_web/components/provider_components.ex:1683
+#: lib/klass_hero_web/components/provider_components.ex:1939
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/components/provider_components.ex:1533
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:940
+#: lib/klass_hero_web/components/provider_components.ex:941
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2907,7 +2909,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1853
+#: lib/klass_hero_web/components/provider_components.ex:1940
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2939,7 +2941,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:601
-#: lib/klass_hero_web/components/provider_components.ex:1038
+#: lib/klass_hero_web/components/provider_components.ex:1039
 #: lib/klass_hero_web/live/settings/children_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2950,22 +2952,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:2019
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1934
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:682
+#: lib/klass_hero_web/components/provider_components.ex:683
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:623
+#: lib/klass_hero_web/components/provider_components.ex:624
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
@@ -2990,12 +2992,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1776
+#: lib/klass_hero_web/components/provider_components.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:692
+#: lib/klass_hero_web/components/provider_components.ex:693
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -3005,12 +3007,12 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1838
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
@@ -3045,17 +3047,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1549
+#: lib/klass_hero_web/components/provider_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:731
+#: lib/klass_hero_web/components/provider_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1144
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
@@ -3077,22 +3079,22 @@ msgstr ""
 msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:629
+#: lib/klass_hero_web/components/provider_components.ex:630
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:922
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1031
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:849
+#: lib/klass_hero_web/components/provider_components.ex:850
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -3105,43 +3107,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:602
-#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/components/provider_components.ex:1038
 #: lib/klass_hero_web/live/settings/children_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:955
+#: lib/klass_hero_web/components/provider_components.ex:956
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1077
+#: lib/klass_hero_web/components/provider_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:860
+#: lib/klass_hero_web/components/provider_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1014
+#: lib/klass_hero_web/components/provider_components.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:949
+#: lib/klass_hero_web/components/provider_components.ex:950
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -3156,12 +3158,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1670
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -3177,17 +3179,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1763
+#: lib/klass_hero_web/components/provider_components.ex:1850
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1079
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1072
+#: lib/klass_hero_web/components/provider_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -3218,18 +3220,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1154
+#: lib/klass_hero_web/components/provider_components.ex:1155
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:291
+#: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:604
-#: lib/klass_hero_web/components/provider_components.ex:1040
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #: lib/klass_hero_web/live/settings/children_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -3240,7 +3242,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2036
+#: lib/klass_hero_web/components/provider_components.ex:2123
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3250,13 +3252,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:966
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:751
-#: lib/klass_hero_web/components/provider_components.ex:261
+#: lib/klass_hero_web/components/provider_components.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
@@ -3281,7 +3283,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:840
+#: lib/klass_hero_web/components/provider_components.ex:841
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -3291,7 +3293,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1004
+#: lib/klass_hero_web/components/provider_components.ex:1005
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
@@ -3330,13 +3332,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1938
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:991
+#: lib/klass_hero_web/components/provider_components.ex:992
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
@@ -3346,7 +3348,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:932
+#: lib/klass_hero_web/components/provider_components.ex:933
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
@@ -3356,12 +3358,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:928
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:918
+#: lib/klass_hero_web/components/provider_components.ex:919
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3398,7 +3400,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:753
-#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -3410,17 +3412,17 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:714
-#: lib/klass_hero_web/components/provider_components.ex:1119
-#: lib/klass_hero_web/components/provider_components.ex:1811
-#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:715
+#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:2142
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3430,30 +3432,30 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/components/provider_components.ex:1476
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1861
-#: lib/klass_hero_web/components/provider_components.ex:1873
-#: lib/klass_hero_web/components/provider_components.ex:1884
+#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:1971
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1181
+#: lib/klass_hero_web/components/provider_components.ex:1182
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:857
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3468,7 +3470,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:2120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3485,18 +3487,18 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1937
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:686
+#: lib/klass_hero_web/components/provider_components.ex:687
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:943
+#: lib/klass_hero_web/components/provider_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
@@ -3506,7 +3508,7 @@ msgstr ""
 msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:659
+#: lib/klass_hero_web/components/provider_components.ex:660
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -3523,12 +3525,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:905
+#: lib/klass_hero_web/components/provider_components.ex:906
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:891
+#: lib/klass_hero_web/components/provider_components.ex:892
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3594,7 +3596,7 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:822
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -3604,7 +3606,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1933
+#: lib/klass_hero_web/components/provider_components.ex:2020
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3624,32 +3626,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1695
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
+#: lib/klass_hero_web/components/provider_components.ex:2166
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2041
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1935
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3671,7 +3673,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:246
+#: lib/klass_hero_web/components/provider_components.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified"
 msgstr ""
@@ -3686,32 +3688,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:640
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:630
+#: lib/klass_hero_web/components/provider_components.ex:631
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:624
+#: lib/klass_hero_web/components/provider_components.ex:625
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:646
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:823
+#: lib/klass_hero_web/components/provider_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:850
+#: lib/klass_hero_web/components/provider_components.ex:851
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -4425,7 +4427,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/components/provider_components.ex:1752
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -4553,7 +4555,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/components/provider_components.ex:1501
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -4580,7 +4582,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4736,7 +4738,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1747
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
@@ -5372,7 +5374,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:554
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -5592,7 +5594,7 @@ msgstr ""
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:393
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Team Members"
 msgstr ""
@@ -5793,7 +5795,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:434
+#: lib/klass_hero_web/components/provider_components.ex:435
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "You've reached your program limit. Upgrade your plan to add more programs."
@@ -5818,4 +5820,39 @@ msgstr ""
 #: lib/klass_hero_web/live/messaging_live_helper.ex:338
 #, elixir-autogen, elixir-format, fuzzy
 msgid "for"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1622
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Assigned staff"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1624
+#, elixir-autogen, elixir-format
+msgid "Attendance"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1606
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Close"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1623
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Cover"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1621
+#, elixir-autogen, elixir-format
+msgid "Date / time"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1615
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No sessions scheduled yet."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1604
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sessions — %{title}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,8 +11,8 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:57
-#: lib/klass_hero_web/components/layouts/app.html.heex:248
+#: lib/klass_hero_web/components/layouts/app.html.heex:44
+#: lib/klass_hero_web/components/layouts/app.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -28,19 +28,19 @@ msgstr ""
 msgid "Choose your preferred language for the interface"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:603
-#: lib/klass_hero_web/components/layouts/app.html.heex:65
-#: lib/klass_hero_web/components/layouts/app.html.heex:249
+#: lib/klass_hero_web/components/composite_components.ex:608
+#: lib/klass_hero_web/components/layouts/app.html.heex:52
+#: lib/klass_hero_web/components/layouts/app.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:128
-#: lib/klass_hero_web/components/layouts/app.html.heex:168
-#: lib/klass_hero_web/components/layouts/app.html.heex:255
-#: lib/klass_hero_web/components/layouts/app.html.heex:285
-#: lib/klass_hero_web/components/provider_components.ex:355
-#: lib/klass_hero_web/live/dashboard_live.ex:52
+#: lib/klass_hero_web/components/layouts/app.html.heex:113
+#: lib/klass_hero_web/components/layouts/app.html.heex:138
+#: lib/klass_hero_web/components/layouts/app.html.heex:217
+#: lib/klass_hero_web/components/layouts/app.html.heex:253
+#: lib/klass_hero_web/components/provider_components.ex:356
+#: lib/klass_hero_web/live/dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -60,8 +60,8 @@ msgstr ""
 msgid "Failed to update language preference."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:41
-#: lib/klass_hero_web/components/layouts/app.html.heex:246
+#: lib/klass_hero_web/components/layouts/app.html.heex:28
+#: lib/klass_hero_web/components/layouts/app.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -76,22 +76,22 @@ msgstr ""
 msgid "Language preference updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:205
-#: lib/klass_hero_web/components/layouts/app.html.heex:303
+#: lib/klass_hero_web/components/layouts/app.html.heex:167
+#: lib/klass_hero_web/components/layouts/app.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Login"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:601
-#: lib/klass_hero_web/components/composite_components.ex:609
-#: lib/klass_hero_web/components/layouts/app.html.heex:49
-#: lib/klass_hero_web/components/layouts/app.html.heex:247
+#: lib/klass_hero_web/components/composite_components.ex:602
+#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/layouts/app.html.heex:36
+#: lib/klass_hero_web/components/layouts/app.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:152
-#: lib/klass_hero_web/components/layouts/app.html.heex:277
+#: lib/klass_hero_web/components/layouts/app.html.heex:122
+#: lib/klass_hero_web/components/layouts/app.html.heex:245
 #: lib/klass_hero_web/live/settings_live.ex:17
 #: lib/klass_hero_web/live/settings_live.ex:56
 #, elixir-autogen, elixir-format
@@ -99,15 +99,15 @@ msgid "Settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:20
-#: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/layouts/app.html.heex:297
+#: lib/klass_hero_web/components/layouts/app.html.heex:159
+#: lib/klass_hero_web/components/layouts/app.html.heex:265
 #: lib/klass_hero_web/live/settings_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Sign Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:211
-#: lib/klass_hero_web/components/layouts/app.html.heex:311
+#: lib/klass_hero_web/components/layouts/app.html.heex:173
+#: lib/klass_hero_web/components/layouts/app.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Sign Up"
 msgstr ""
@@ -127,109 +127,104 @@ msgstr ""
 msgid "Your Data"
 msgstr ""
 
-#: lib/klass_hero_web/components/core_components.ex:68
-#: lib/klass_hero_web/components/provider_components.ex:1501
+#: lib/klass_hero_web/components/core_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:445
+#: lib/klass_hero_web/live/booking_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:365
+#: lib/klass_hero_web/live/program_detail_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:352
+#: lib/klass_hero_web/live/booking_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:458
+#: lib/klass_hero_web/live/booking_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:393
+#: lib/klass_hero_web/live/booking_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:197
+#: lib/klass_hero_web/live/program_detail_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:531
+#: lib/klass_hero_web/live/booking_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:475
+#: lib/klass_hero_web/live/booking_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:235
+#: lib/klass_hero_web/live/home_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:245
-#, elixir-autogen, elixir-format
-msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:508
+#: lib/klass_hero_web/live/booking_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:533
+#: lib/klass_hero_web/live/booking_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:243
+#: lib/klass_hero_web/live/home_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:550
+#: lib/klass_hero_web/live/booking_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:499
+#: lib/klass_hero_web/live/booking_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:532
+#: lib/klass_hero_web/live/booking_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:384
+#: lib/klass_hero_web/live/booking_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:233
+#: lib/klass_hero_web/live/home_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:521
+#: lib/klass_hero_web/live/program_detail_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1308
-#: lib/klass_hero_web/live/booking_live.ex:347
+#: lib/klass_hero_web/components/provider_components.ex:1315
+#: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr ""
@@ -239,7 +234,7 @@ msgstr ""
 msgid "Enrollment - %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:220
+#: lib/klass_hero_web/live/booking_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr ""
@@ -249,7 +244,7 @@ msgstr ""
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:225
+#: lib/klass_hero_web/live/home_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
@@ -270,17 +265,12 @@ msgstr ""
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:347
-#, elixir-autogen, elixir-format
-msgid "Free cancellation up to 48 hours before start date"
-msgstr ""
-
 #: lib/klass_hero_web/live/programs_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:529
+#: lib/klass_hero_web/live/booking_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
@@ -295,7 +285,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:405
+#: lib/klass_hero_web/live/program_detail_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -307,22 +297,22 @@ msgstr[1] ""
 msgid "No programs found"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:483
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:500
+#: lib/klass_hero_web/live/booking_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:494
+#: lib/klass_hero_web/live/booking_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:518
+#: lib/klass_hero_web/live/booking_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
@@ -332,7 +322,7 @@ msgstr ""
 msgid "Payment information is invalid. Please check your details."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:177
+#: lib/klass_hero_web/live/booking_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr ""
@@ -344,17 +334,18 @@ msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:59
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:47
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:53
+#: lib/klass_hero_web/live/program_detail_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:149
-#: lib/klass_hero_web/live/home_live.ex:223
+#: lib/klass_hero_web/live/about_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Safety First"
 msgstr ""
@@ -370,12 +361,12 @@ msgstr ""
 msgid "Search programs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:429
+#: lib/klass_hero_web/live/booking_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:439
+#: lib/klass_hero_web/live/booking_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr ""
@@ -390,17 +381,17 @@ msgstr ""
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:468
+#: lib/klass_hero_web/live/booking_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:377
+#: lib/klass_hero_web/live/booking_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:524
+#: lib/klass_hero_web/live/booking_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
@@ -411,7 +402,7 @@ msgid "Try adjusting your search or filter criteria."
 msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:84
-#: lib/klass_hero_web/live/program_detail_live.ex:60
+#: lib/klass_hero_web/live/program_detail_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Unable to load program. Please try again later."
 msgstr ""
@@ -426,7 +417,7 @@ msgstr ""
 msgid "Why Klass Hero?"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:209
+#: lib/klass_hero_web/live/program_detail_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -436,7 +427,7 @@ msgstr ""
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:602
+#: lib/klass_hero_web/components/composite_components.ex:605
 #: lib/klass_hero_web/live/about_live.ex:10
 #, elixir-autogen, elixir-format, fuzzy
 msgid "About Us"
@@ -453,6 +444,7 @@ msgid "Account Termination"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:81
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -467,7 +459,7 @@ msgstr ""
 msgid "Already registered?"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:160
+#: lib/klass_hero_web/live/user_live/registration.ex:159
 #, elixir-autogen, elixir-format
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr ""
@@ -507,14 +499,14 @@ msgstr ""
 msgid "Check out our FAQ section for answers to common questions."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:66
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:66
+#: lib/klass_hero_web/live/provider/participation_live.ex:67
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:133
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
+#: lib/klass_hero_web/live/provider/participation_live.ex:130
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -529,7 +521,7 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:195
+#: lib/klass_hero_web/live/about_live.ex:193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Community"
 msgstr ""
@@ -561,11 +553,11 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:788
+#: lib/klass_hero_web/components/composite_components.ex:808
 #: lib/klass_hero_web/live/contact_live.ex:15
 #: lib/klass_hero_web/live/contact_live.ex:112
 #: lib/klass_hero_web/live/privacy_policy_live.ex:217
-#: lib/klass_hero_web/live/trust_safety_live.ex:227
+#: lib/klass_hero_web/live/trust_safety_live.ex:225
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Us"
 msgstr ""
@@ -631,16 +623,16 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:17
+#: lib/klass_hero_web/live/user_live/login.ex:18
 #, elixir-autogen, elixir-format
 msgid "Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:637
+#: lib/klass_hero_web/components/provider_components.ex:644
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
-#: lib/klass_hero_web/live/user_live/login.ex:48
-#: lib/klass_hero_web/live/user_live/login.ex:80
+#: lib/klass_hero_web/live/user_live/login.ex:49
+#: lib/klass_hero_web/live/user_live/login.ex:81
 #: lib/klass_hero_web/live/user_live/registration.ex:39
 #: lib/klass_hero_web/live/user_live/settings.ex:155
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:60
@@ -673,20 +665,20 @@ msgstr ""
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:81
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:81
+#: lib/klass_hero_web/live/provider/participation_live.ex:82
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:150
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/live/provider/participation_live.ex:147
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:114
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
+#: lib/klass_hero_web/live/provider/sessions_live.ex:134
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -696,16 +688,16 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:355
-#: lib/klass_hero_web/live/provider/participation_live.ex:356
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:306
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:307
+#: lib/klass_hero_web/live/provider/participation_live.ex:328
+#: lib/klass_hero_web/live/provider/participation_live.ex:329
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:283
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Failed to load session data"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:91
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:111
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -735,7 +727,7 @@ msgstr ""
 msgid "I want to..."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:141
+#: lib/klass_hero_web/live/user_live/login.ex:142
 #, elixir-autogen, elixir-format
 msgid "If your email is in our system, you will receive instructions for logging in shortly."
 msgstr ""
@@ -760,9 +752,9 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:69
-#: lib/klass_hero_web/live/provider/sessions_live.ex:319
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
+#: lib/klass_hero_web/live/provider/sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:336
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -777,7 +769,7 @@ msgstr ""
 msgid "Keep me logged in on this device"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:719
+#: lib/klass_hero_web/components/composite_components.ex:739
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr ""
@@ -793,12 +785,12 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:92
+#: lib/klass_hero_web/live/user_live/login.ex:93
 #, elixir-autogen, elixir-format
 msgid "Log in and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:95
+#: lib/klass_hero_web/live/user_live/login.ex:96
 #, elixir-autogen, elixir-format
 msgid "Log in only this time"
 msgstr ""
@@ -820,13 +812,14 @@ msgstr ""
 msgid "Looking for Quick Answers?"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:91
+#: lib/klass_hero_web/live/user_live/confirmation.ex:90
 #, elixir-autogen, elixir-format
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:162
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -841,15 +834,15 @@ msgstr ""
 msgid "Monday - Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:159
+#: lib/klass_hero_web/live/dashboard_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "My Children"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:20
+#: lib/klass_hero_web/live/provider/sessions_live.ex:35
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:5
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:23
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:24
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -876,23 +869,23 @@ msgstr ""
 msgid "Office Hours"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:104
+#: lib/klass_hero_web/live/user_live/login.ex:105
 #, elixir-autogen, elixir-format
 msgid "Or use magic link"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:63
+#: lib/klass_hero_web/live/user_live/login.ex:64
 #, elixir-autogen, elixir-format
 msgid "Or use password"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:154
-#: lib/klass_hero_web/presenters/provider_presenter.ex:110
+#: lib/klass_hero_web/presenters/provider_presenter.ex:129
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:88
+#: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/settings.ex:170
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:68
 #, elixir-autogen, elixir-format
@@ -905,11 +898,12 @@ msgid "Payment Terms"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:73
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:656
+#: lib/klass_hero_web/components/composite_components.ex:676
 #: lib/klass_hero_web/live/privacy_policy_live.ex:10
 #: lib/klass_hero_web/live/privacy_policy_live.ex:235
 #, elixir-autogen, elixir-format
@@ -936,16 +930,16 @@ msgstr ""
 msgid "Questions About These Terms?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:271
-#: lib/klass_hero_web/live/provider/participation_live.ex:56
-#: lib/klass_hero_web/live/provider/participation_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:56
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
+#: lib/klass_hero_web/live/admin/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/participation_live.ex:57
+#: lib/klass_hero_web/live/provider/participation_live.ex:119
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:57
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:21
+#: lib/klass_hero_web/live/user_live/login.ex:22
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr ""
@@ -965,7 +959,8 @@ msgstr ""
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:771
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
+#: lib/klass_hero_web/live/settings/children_live.ex:765
 #: lib/klass_hero_web/live/user_live/settings.ex:202
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Saving..."
@@ -981,15 +976,18 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:54
+#: lib/klass_hero_web/live/user_live/login.ex:55
 #, elixir-autogen, elixir-format
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1620
-#: lib/klass_hero_web/components/provider_components.ex:1621
-#: lib/klass_hero_web/components/provider_components.ex:1661
+#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1627
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #: lib/klass_hero_web/live/contact_live.ex:184
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr ""
@@ -999,28 +997,29 @@ msgstr ""
 msgid "Send us a Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:100
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
+#: lib/klass_hero_web/live/provider/sessions_live.ex:120
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:69
 #: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:344
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:295
+#: lib/klass_hero_web/live/provider/participation_live.ex:317
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:77
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
+#: lib/klass_hero_web/live/provider/sessions_live.ex:97
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:146
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -1030,7 +1029,7 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:727
+#: lib/klass_hero_web/components/composite_components.ex:747
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr ""
@@ -1040,7 +1039,7 @@ msgstr ""
 msgid "Technical Issue"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:658
+#: lib/klass_hero_web/components/composite_components.ex:678
 #: lib/klass_hero_web/live/terms_of_service_live.ex:10
 #: lib/klass_hero_web/live/terms_of_service_live.ex:268
 #, elixir-autogen, elixir-format
@@ -1057,7 +1056,7 @@ msgstr ""
 msgid "Tip: If you prefer passwords, you can enable them in the user settings."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:31
+#: lib/klass_hero_web/live/user_live/login.ex:32
 #, elixir-autogen, elixir-format
 msgid "To see sent emails, visit"
 msgstr ""
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "User Conduct & Responsibilities"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:162
+#: lib/klass_hero_web/live/dashboard_live.ex:196
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View All"
 msgstr ""
@@ -1117,43 +1116,43 @@ msgstr ""
 msgid "Welcome %{email}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:12
+#: lib/klass_hero_web/live/user_live/login.ex:13
 #, elixir-autogen, elixir-format
 msgid "Welcome Back"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:29
+#: lib/klass_hero_web/live/user_live/login.ex:30
 #, elixir-autogen, elixir-format
 msgid "You are running the local mail adapter."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:369
+#: lib/klass_hero_web/user_auth.ex:368
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:282
+#: lib/klass_hero_web/user_auth.ex:281
 #, elixir-autogen, elixir-format
 msgid "You must have a parent profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:291
+#: lib/klass_hero_web/user_auth.ex:290
 #, elixir-autogen, elixir-format
 msgid "You must have a provider profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:252
-#: lib/klass_hero_web/user_auth.ex:418
+#: lib/klass_hero_web/user_auth.ex:251
+#: lib/klass_hero_web/user_auth.ex:417
 #, elixir-autogen, elixir-format
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:269
+#: lib/klass_hero_web/user_auth.ex:268
 #, elixir-autogen, elixir-format
 msgid "You must re-authenticate to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:15
+#: lib/klass_hero_web/live/user_live/login.ex:16
 #, elixir-autogen, elixir-format
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
@@ -1173,12 +1172,12 @@ msgstr ""
 msgid "Your privacy matters to us"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:21
+#: lib/klass_hero_web/live/user_live/login.ex:22
 #, elixir-autogen, elixir-format
 msgid "for an account now."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:31
+#: lib/klass_hero_web/live/user_live/login.ex:32
 #, elixir-autogen, elixir-format
 msgid "the mailbox page"
 msgstr ""
@@ -1188,12 +1187,12 @@ msgstr ""
 msgid "to your account now."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:611
+#: lib/klass_hero_web/components/composite_components.ex:622
 #, elixir-autogen, elixir-format
 msgid "Afterschool"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:653
+#: lib/klass_hero_web/components/composite_components.ex:673
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr ""
@@ -1203,24 +1202,19 @@ msgstr ""
 msgid "Building the future of youth education by connecting communities."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:613
+#: lib/klass_hero_web/components/composite_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "Class Trips"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/composite_components.ex:639
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connect"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:614
+#: lib/klass_hero_web/components/composite_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "Enrichment"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:604
-#, elixir-autogen, elixir-format
-msgid "FAQ"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:599
@@ -1228,7 +1222,7 @@ msgstr ""
 msgid "Quick Links"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:612
+#: lib/klass_hero_web/components/composite_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "Summer Camps"
 msgstr ""
@@ -1279,7 +1273,7 @@ msgid "Cards, bank accounts, billing info"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:373
+#: lib/klass_hero_web/live/settings/children_live.ex:367
 #: lib/klass_hero_web/live/settings_live.ex:88
 #: lib/klass_hero_web/live/user_live/settings.ex:48
 #: lib/klass_hero_web/live/user_live/settings.ex:347
@@ -1494,7 +1488,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:89
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:115
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions"
 msgstr ""
@@ -1544,21 +1538,21 @@ msgstr ""
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:188
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:221
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:178
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:211
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:15
+#: lib/klass_hero_web/live/provider/participation_live.ex:16
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:284
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:22
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:16
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:17
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Participation History"
@@ -1581,7 +1575,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:152
+#: lib/klass_hero_web/live/about_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "All instructors are background-checked and verified"
 msgstr ""
@@ -1592,12 +1586,12 @@ msgstr ""
 msgid "Arts"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:198
+#: lib/klass_hero_web/live/about_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Building connections between families and local instructors"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:115
+#: lib/klass_hero_web/live/about_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Built for Berlin Families"
 msgstr ""
@@ -1607,12 +1601,12 @@ msgstr ""
 msgid "Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:278
+#: lib/klass_hero_web/live/home_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Create a Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:288
+#: lib/klass_hero_web/live/home_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Deliver Quality"
 msgstr ""
@@ -1628,12 +1622,12 @@ msgstr ""
 msgid "Education"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:215
+#: lib/klass_hero_web/live/about_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Every instructor goes through rigorous screening to ensure the highest quality"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:513
+#: lib/klass_hero_web/live/home_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Everything you need to know about Klass Hero"
 msgstr ""
@@ -1643,37 +1637,37 @@ msgstr ""
 msgid "For Families"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:259
+#: lib/klass_hero_web/live/home_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "For Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:510
+#: lib/klass_hero_web/live/home_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Frequently Asked Questions"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:123
+#: lib/klass_hero_web/live/about_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:294
+#: lib/klass_hero_web/live/about_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "GET STARTED TODAY"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:298
+#: lib/klass_hero_web/live/home_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:265
+#: lib/klass_hero_web/live/home_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "How to Grow Your Youth Program: Let's Build Together."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:268
+#: lib/klass_hero_web/live/home_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Join our community of passionate educators. Tools and support to help you succeed."
 msgstr ""
@@ -1694,17 +1688,17 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:100
+#: lib/klass_hero_web/live/about_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "OUR MISSION"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:674
+#: lib/klass_hero_web/components/provider_components.ex:681
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:288
+#: lib/klass_hero_web/live/about_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "Ready to join the movement?"
 msgstr ""
@@ -1714,12 +1708,12 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:300
+#: lib/klass_hero_web/live/home_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Secure payments, insights into your business, and opportunities to expand your impact."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:280
+#: lib/klass_hero_web/live/home_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
@@ -1730,27 +1724,27 @@ msgstr ""
 msgid "Sports"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:316
+#: lib/klass_hero_web/live/home_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Start Teaching Today →"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:175
+#: lib/klass_hero_web/live/about_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Supporting local programs and eco-conscious practices"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:172
+#: lib/klass_hero_web/live/about_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:290
+#: lib/klass_hero_web/live/home_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Teach your passion with our tools for scheduling, communication, and progress tracking."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:103
+#: lib/klass_hero_web/live/about_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "To modernize how families discover and engage with children's programs in Berlin"
 msgstr ""
@@ -1760,7 +1754,7 @@ msgstr ""
 msgid "Trending in Berlin:"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:118
+#: lib/klass_hero_web/live/about_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr ""
@@ -1770,21 +1764,21 @@ msgstr ""
 msgid "Workshops"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:181
-#: lib/klass_hero_web/live/settings/children_live.ex:402
-#: lib/klass_hero_web/live/settings/children_live.ex:424
-#: lib/klass_hero_web/live/settings/children_live.ex:646
-#: lib/klass_hero_web/live/settings/children_live.ex:780
+#: lib/klass_hero_web/live/dashboard_live.ex:215
+#: lib/klass_hero_web/live/settings/children_live.ex:396
+#: lib/klass_hero_web/live/settings/children_live.ex:418
+#: lib/klass_hero_web/live/settings/children_live.ex:640
+#: lib/klass_hero_web/live/settings/children_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:71
+#: lib/klass_hero_web/live/dashboard_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Almost there! One more to go!"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:70
+#: lib/klass_hero_web/live/dashboard_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Congratulations! Goal achieved!"
 msgstr ""
@@ -1829,12 +1823,12 @@ msgstr ""
 msgid "Weekly Activity Goal"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:72
+#: lib/klass_hero_web/live/dashboard_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "You're just getting started!"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:73
+#: lib/klass_hero_web/live/dashboard_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "You're doing great! Keep it up!"
 msgstr ""
@@ -1907,37 +1901,37 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1311
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1777
+#: lib/klass_hero_web/components/provider_components.ex:1318
+#: lib/klass_hero_web/components/provider_components.ex:1599
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1392
+#: lib/klass_hero_web/components/provider_components.ex:1399
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:590
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1341
+#: lib/klass_hero_web/components/provider_components.ex:597
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:74
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1554
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:81
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1623
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1302
+#: lib/klass_hero_web/components/provider_components.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:324
-#: lib/klass_hero_web/live/program_detail_live.ex:545
+#: lib/klass_hero_web/live/program_detail_live.ex:363
+#: lib/klass_hero_web/live/program_detail_live.ex:579
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Book Now"
 msgstr ""
@@ -1947,32 +1941,32 @@ msgstr ""
 msgid "Business Profile"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:96
-#: lib/klass_hero_web/presenters/provider_presenter.ex:106
+#: lib/klass_hero_web/presenters/provider_presenter.ex:115
+#: lib/klass_hero_web/presenters/provider_presenter.ex:125
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1324
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:532
-#: lib/klass_hero_web/components/provider_components.ex:1373
-#: lib/klass_hero_web/live/settings/children_live.ex:473
+#: lib/klass_hero_web/components/provider_components.ex:539
+#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/live/settings/children_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:193
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:158
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1129
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:166
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1394
+#: lib/klass_hero_web/components/provider_components.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1982,8 +1976,8 @@ msgstr ""
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:792
+#: lib/klass_hero_web/components/provider_components.ex:417
+#: lib/klass_hero_web/components/provider_components.ex:799
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
@@ -1994,53 +1988,53 @@ msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:45
-#: lib/klass_hero_web/components/provider_components.ex:1393
-#: lib/klass_hero_web/components/provider_components.ex:1824
-#: lib/klass_hero_web/components/provider_components.ex:1844
-#: lib/klass_hero_web/live/admin/sessions_live.ex:322
+#: lib/klass_hero_web/components/provider_components.ex:1400
+#: lib/klass_hero_web/components/provider_components.ex:1829
+#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1362
+#: lib/klass_hero_web/components/provider_components.ex:1369
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1299
+#: lib/klass_hero_web/components/provider_components.ex:1306
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:381
+#: lib/klass_hero_web/components/provider_components.ex:382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Slots"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:83
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:337
+#: lib/klass_hero_web/live/program_detail_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1257
+#: lib/klass_hero_web/components/provider_components.ex:1264
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1305
-#: lib/klass_hero_web/components/provider_components.ex:1587
-#: lib/klass_hero_web/components/provider_components.ex:1774
+#: lib/klass_hero_web/components/provider_components.ex:1312
+#: lib/klass_hero_web/components/provider_components.ex:1593
+#: lib/klass_hero_web/components/provider_components.ex:1779
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2053,7 +2047,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1321
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2063,231 +2057,229 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:50
+#: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:1395
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#: lib/klass_hero_web/components/provider_components.ex:1402
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:373
+#: lib/klass_hero_web/components/provider_components.ex:374
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1367
+#: lib/klass_hero_web/components/provider_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:455
+#: lib/klass_hero_web/live/settings/children_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:542
+#: lib/klass_hero_web/components/messaging_components.ex:664
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:206
+#: lib/klass_hero_web/live/dashboard_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "%{remaining} remaining"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:410
+#: lib/klass_hero_web/live/settings/children_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:525
-#: lib/klass_hero_web/live/settings/children_live.ex:721
+#: lib/klass_hero_web/live/settings/children_live.ex:519
+#: lib/klass_hero_web/live/settings/children_live.ex:715
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:748
+#: lib/klass_hero_web/live/settings/children_live.ex:742
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:227
+#: lib/klass_hero_web/live/settings/children_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:729
+#: lib/klass_hero_web/live/settings/children_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:388
+#: lib/klass_hero_web/live/settings/children_live.ex:382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:190
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
+#: lib/klass_hero_web/live/provider/participation_live.ex:182
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:136
+#: lib/klass_hero_web/components/messaging_components.ex:147
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:78
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
 #: lib/klass_hero_web/components/participation_components.ex:635
-#: lib/klass_hero_web/components/provider_components.ex:757
-#: lib/klass_hero_web/components/provider_components.ex:1161
-#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:764
+#: lib/klass_hero_web/components/provider_components.ex:1168
+#: lib/klass_hero_web/components/provider_components.ex:1718
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:197
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:606
-#: lib/klass_hero_web/live/settings/children_live.ex:766
+#: lib/klass_hero_web/live/settings/children_live.ex:600
+#: lib/klass_hero_web/live/settings/children_live.ex:760
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:311
+#: lib/klass_hero_web/live/settings/children_live.ex:307
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child added successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:314
+#: lib/klass_hero_web/live/settings/children_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Child added, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:89
-#: lib/klass_hero_web/live/settings/children_live.ex:189
+#: lib/klass_hero_web/live/settings/children_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Child not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:182
+#: lib/klass_hero_web/live/settings/children_live.ex:179
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child removed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:316
+#: lib/klass_hero_web/live/settings/children_live.ex:311
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:319
+#: lib/klass_hero_web/live/settings/children_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:304
+#: lib/klass_hero_web/live/messaging_live_helper.ex:354
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:137
+#: lib/klass_hero_web/live/messaging_live_helper.ex:164
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:198
+#: lib/klass_hero_web/live/settings/children_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Could not remove child. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:503
+#: lib/klass_hero_web/live/settings/children_live.ex:497
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:685
+#: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:487
+#: lib/klass_hero_web/live/settings/children_live.ex:481
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:648
+#: lib/klass_hero_web/live/settings/children_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:514
-#: lib/klass_hero_web/live/settings/children_live.ex:714
+#: lib/klass_hero_web/live/settings/children_live.ex:508
+#: lib/klass_hero_web/live/settings/children_live.ex:708
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:65
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:237
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to load pending notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:116
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:271
+#: lib/klass_hero_web/live/provider/participation_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:100
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:171
-#, elixir-autogen, elixir-format
-msgid "Failed to send message"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/participation_live.ex:208
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:206
+#: lib/klass_hero_web/live/provider/participation_live.ex:199
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:671
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:677
+#: lib/klass_hero_web/live/settings/children_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:722
+#: lib/klass_hero_web/live/settings/children_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:374
+#: lib/klass_hero_web/live/settings/children_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr ""
@@ -2298,83 +2290,86 @@ msgid "Manage your children's profiles"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:64
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:268
-#: lib/klass_hero_web/components/messaging_components.ex:331
-#: lib/klass_hero_web/components/messaging_components.ex:354
-#: lib/klass_hero_web/live/messaging_live_helper.ex:265
+#: lib/klass_hero_web/components/layouts/app.html.heex:236
+#: lib/klass_hero_web/components/messaging_components.ex:434
+#: lib/klass_hero_web/components/messaging_components.ex:457
+#: lib/klass_hero_web/live/messaging_live_helper.ex:301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:195
+#: lib/klass_hero_web/live/dashboard_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Monthly Booking Usage"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:409
+#: lib/klass_hero_web/live/settings/children_live.ex:403
 #: lib/klass_hero_web/presenters/child_presenter.ex:96
 #, elixir-autogen, elixir-format
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:399
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:263
-#: lib/klass_hero_web/components/messaging_components.ex:552
+#: lib/klass_hero_web/components/messaging_components.ex:368
+#: lib/klass_hero_web/components/messaging_components.ex:674
+#: lib/klass_hero_web/components/messaging_components.ex:685
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:92
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:56
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:196
-#: lib/klass_hero_web/live/provider/participation_live.ex:263
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:194
+#: lib/klass_hero_web/live/provider/participation_live.ex:188
+#: lib/klass_hero_web/live/provider/participation_live.ex:250
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:105
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:257
+#: lib/klass_hero_web/live/provider/participation_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:541
+#: lib/klass_hero_web/components/messaging_components.ex:663
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:715
+#: lib/klass_hero_web/live/settings/children_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:221
+#: lib/klass_hero_web/live/settings/children_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Please check the form for errors."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:194
+#: lib/klass_hero_web/live/booking_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr ""
@@ -2399,19 +2394,19 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:300
+#: lib/klass_hero_web/live/messaging_live_helper.ex:350
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:745
+#: lib/klass_hero_web/live/settings/children_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:742
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
-#: lib/klass_hero_web/live/settings/children_live.ex:782
+#: lib/klass_hero_web/components/provider_components.ex:749
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
+#: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
@@ -2421,70 +2416,78 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1479
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1485
+#: lib/klass_hero_web/components/provider_components.ex:1486
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:222
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:266
+#: lib/klass_hero_web/components/messaging_components.ex:371
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:226
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:536
-#: lib/klass_hero_web/live/settings/children_live.ex:728
+#: lib/klass_hero_web/live/settings/children_live.ex:530
+#: lib/klass_hero_web/live/settings/children_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:219
+#: lib/klass_hero_web/components/messaging_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:375
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:326
+#: lib/klass_hero_web/live/provider/participation_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:421
-#: lib/klass_hero_web/live/dashboard_live.ex:216
+#: lib/klass_hero_web/live/booking_live.ex:418
+#: lib/klass_hero_web/live/dashboard_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Upgrade"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:165
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:200
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:143
+#: lib/klass_hero_web/live/messaging_live_helper.ex:170
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:144
+#: lib/klass_hero_web/live/settings/children_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to delete this child."
 msgstr ""
@@ -2494,54 +2497,57 @@ msgstr ""
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:408
+#: lib/klass_hero_web/live/booking_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "You have %{remaining} of %{total} bookings remaining this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:200
+#: lib/klass_hero_web/live/dashboard_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "You have used %{used} of %{cap} bookings this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:184
+#: lib/klass_hero_web/live/booking_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "You've reached your monthly booking limit. Upgrade to Active tier for unlimited bookings."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:402
+#: lib/klass_hero_web/live/booking_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Your Booking Plan"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:304
+#: lib/klass_hero_web/components/messaging_components.ex:408
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:307
+#: lib/klass_hero_web/components/messaging_components.ex:410
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:25
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:86
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your subscription tier doesn't support broadcasts"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:152
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:414
-#: lib/klass_hero_web/live/dashboard_live.ex:209
+#: lib/klass_hero_web/live/booking_live.ex:411
+#: lib/klass_hero_web/live/dashboard_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "tier"
 msgstr ""
@@ -2553,23 +2559,23 @@ msgid_plural "%{count} documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:586
-#: lib/klass_hero_web/components/program_components.ex:594
+#: lib/klass_hero_web/components/program_components.ex:575
+#: lib/klass_hero_web/components/program_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/klass_hero_web/components/program_components.ex:571
 #: lib/klass_hero_web/components/program_components.ex:582
-#: lib/klass_hero_web/components/program_components.ex:593
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:607
+#: lib/klass_hero_web/components/program_components.ex:596
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr ""
@@ -2579,32 +2585,32 @@ msgstr ""
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:744
+#: lib/klass_hero_web/components/provider_components.ex:751
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1363
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:566
+#: lib/klass_hero_web/components/program_components.ex:555
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:570
+#: lib/klass_hero_web/components/program_components.ex:559
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1889
+#: lib/klass_hero_web/components/provider_components.ex:1894
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2615,9 +2621,9 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:752
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/live/admin/sessions_live.ex:319
+#: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Approved"
@@ -2628,22 +2634,23 @@ msgstr ""
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:552
+#: lib/klass_hero_web/components/provider_components.ex:559
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:484
+#: lib/klass_hero_web/live/home_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1145
+#: lib/klass_hero_web/components/provider_components.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1125
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1199
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
 #: lib/klass_hero_web/live/provider/subscription_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
@@ -2659,27 +2666,27 @@ msgstr ""
 msgid "Berlin's leading network for tutors, coaches, and camp providers!"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:652
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:251
+#: lib/klass_hero_web/live/dashboard_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:646
+#: lib/klass_hero_web/components/provider_components.ex:653
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:252
+#: lib/klass_hero_web/live/about_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Built by Parents and Educators for More Learning Opportunities"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:481
+#: lib/klass_hero_web/live/home_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
@@ -2689,33 +2696,34 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1147
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1134
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1155
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:822
+#: lib/klass_hero_web/components/provider_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:968
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1584
-#: lib/klass_hero_web/components/provider_components.ex:1768
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1773
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2730,27 +2738,27 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1133
+#: lib/klass_hero_web/components/provider_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1209
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1283
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:721
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:824
+#: lib/klass_hero_web/components/provider_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:429
+#: lib/klass_hero_web/components/provider_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2760,12 +2768,12 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1825
+#: lib/klass_hero_web/components/provider_components.ex:1830
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:413
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -2775,45 +2783,46 @@ msgstr ""
 msgid "Could not load verification documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:690
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:646
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:654
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:668
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:961
+#: lib/klass_hero_web/components/provider_components.ex:968
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1081
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:614
-#: lib/klass_hero_web/components/provider_components.ex:1032
-#: lib/klass_hero_web/live/settings/children_live.ex:698
+#: lib/klass_hero_web/components/program_components.ex:603
+#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/live/settings/children_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1996
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2841,12 +2850,12 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:435
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1733
+#: lib/klass_hero_web/components/provider_components.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2856,39 +2865,39 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:790
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:588
+#: lib/klass_hero_web/components/provider_components.ex:595
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:903
+#: lib/klass_hero_web/components/provider_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:896
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1596
+#: lib/klass_hero_web/components/provider_components.ex:1852
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1526
+#: lib/klass_hero_web/components/provider_components.ex:1532
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:933
+#: lib/klass_hero_web/components/provider_components.ex:940
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2898,8 +2907,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1848
-#: lib/klass_hero_web/live/admin/emails_live.ex:221
+#: lib/klass_hero_web/components/provider_components.ex:1853
+#: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -2914,24 +2923,24 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:628
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:444
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:232
+#: lib/klass_hero_web/live/dashboard_live.ex:266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Family Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:612
-#: lib/klass_hero_web/components/provider_components.ex:1031
-#: lib/klass_hero_web/live/settings/children_live.ex:697
+#: lib/klass_hero_web/components/program_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:1038
+#: lib/klass_hero_web/live/settings/children_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
@@ -2941,196 +2950,198 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1929
+#: lib/klass_hero_web/components/provider_components.ex:1932
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1931
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:675
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:616
+#: lib/klass_hero_web/components/provider_components.ex:623
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:693
+#: lib/klass_hero_web/live/settings/children_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:621
+#: lib/klass_hero_web/components/program_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:630
+#: lib/klass_hero_web/components/program_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:626
+#: lib/klass_hero_web/components/program_components.ex:614
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1771
+#: lib/klass_hero_web/components/provider_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:685
+#: lib/klass_hero_web/components/provider_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:108
+#: lib/klass_hero_web/presenters/provider_presenter.ex:127
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1705
+#: lib/klass_hero_web/components/provider_components.ex:1710
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1746
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:699
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} families."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:263
+#: lib/klass_hero_web/live/about_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "In 2025, Shane connected with his friend Max Pergl, a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom, offering more to the community, but without the time to manage bookings, payments, and compliance on their own."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:107
+#: lib/klass_hero_web/presenters/provider_presenter.ex:126
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:643
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:640
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:617
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1543
+#: lib/klass_hero_web/components/provider_components.ex:1549
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:724
+#: lib/klass_hero_web/components/provider_components.ex:731
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1212
+#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:268
+#: lib/klass_hero_web/live/about_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:707
+#: lib/klass_hero_web/live/settings/children_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:273
+#: lib/klass_hero_web/live/about_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:622
+#: lib/klass_hero_web/components/provider_components.ex:629
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:914
+#: lib/klass_hero_web/components/provider_components.ex:921
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1024
+#: lib/klass_hero_web/components/provider_components.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:842
+#: lib/klass_hero_web/components/provider_components.ex:849
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:390
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:613
-#: lib/klass_hero_web/components/provider_components.ex:1030
-#: lib/klass_hero_web/live/settings/children_live.ex:696
+#: lib/klass_hero_web/components/program_components.ex:602
+#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/live/settings/children_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1013
+#: lib/klass_hero_web/components/provider_components.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:948
+#: lib/klass_hero_web/components/provider_components.ex:955
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:853
+#: lib/klass_hero_web/components/provider_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1007
+#: lib/klass_hero_web/components/provider_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:942
+#: lib/klass_hero_web/components/provider_components.ex:949
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/components/provider_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -3145,38 +3156,38 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:1960
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1577
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:168
+#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:686
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:706
+#: lib/klass_hero_web/live/settings/children_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1763
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1072
+#: lib/klass_hero_web/components/provider_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/components/provider_components.ex:1072
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -3186,7 +3197,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:240
+#: lib/klass_hero_web/live/dashboard_live.ex:274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs booked yet"
 msgstr ""
@@ -3196,7 +3207,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1362
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1411
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -3207,7 +3218,7 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1147
+#: lib/klass_hero_web/components/provider_components.ex:1154
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
@@ -3217,44 +3228,45 @@ msgstr ""
 msgid "Not Verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:615
-#: lib/klass_hero_web/components/provider_components.ex:1033
-#: lib/klass_hero_web/live/settings/children_live.ex:695
+#: lib/klass_hero_web/components/program_components.ex:604
+#: lib/klass_hero_web/components/provider_components.ex:1040
+#: lib/klass_hero_web/live/settings/children_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:479
+#: lib/klass_hero_web/live/home_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:537
+#: lib/klass_hero_web/components/program_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:958
+#: lib/klass_hero_web/components/provider_components.ex:965
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/participation_components.ex:751
 #: lib/klass_hero_web/components/provider_components.ex:261
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:380
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:858
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:955
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1035
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:884
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:945
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:980
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1052
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -3269,87 +3281,87 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:833
+#: lib/klass_hero_web/components/provider_components.ex:840
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:376
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:405
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:997
+#: lib/klass_hero_web/components/provider_components.ex:1004
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1870
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1937
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1877
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1944
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:506
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:542
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:545
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:895
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:529
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:565
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:568
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:883
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:909
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:385
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:499
+#: lib/klass_hero_web/live/home_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:728
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/participation_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:984
+#: lib/klass_hero_web/components/provider_components.ex:991
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:157
+#: lib/klass_hero_web/live/program_detail_live.ex:190
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:925
+#: lib/klass_hero_web/components/provider_components.ex:932
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:920
+#: lib/klass_hero_web/components/provider_components.ex:927
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:911
+#: lib/klass_hero_web/components/provider_components.ex:918
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3359,7 +3371,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:129
+#: lib/klass_hero_web/live/program_detail_live.ex:162
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration is closed"
 msgstr ""
@@ -3369,12 +3381,12 @@ msgstr ""
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:78
+#: lib/klass_hero_web/live/program_detail_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:125
+#: lib/klass_hero_web/live/program_detail_live.ex:158
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration opens %{date}"
 msgstr ""
@@ -3385,7 +3397,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:753
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
@@ -3398,16 +3410,17 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:707
-#: lib/klass_hero_web/components/provider_components.ex:1112
-#: lib/klass_hero_web/components/provider_components.ex:1806
-#: lib/klass_hero_web/components/provider_components.ex:2052
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1188
+#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:1119
+#: lib/klass_hero_web/components/provider_components.ex:1811
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1804
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3417,105 +3430,105 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:631
+#: lib/klass_hero_web/components/provider_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1469
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:154
+#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1856
-#: lib/klass_hero_web/components/provider_components.ex:1868
-#: lib/klass_hero_web/components/provider_components.ex:1879
+#: lib/klass_hero_web/components/provider_components.ex:1861
+#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1174
+#: lib/klass_hero_web/components/provider_components.ex:1181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:849
+#: lib/klass_hero_web/components/provider_components.ex:856
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:192
+#: lib/klass_hero_web/live/program_detail_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:705
+#: lib/klass_hero_web/live/settings/children_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2030
+#: lib/klass_hero_web/components/provider_components.ex:2033
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:136
-#: lib/klass_hero_web/live/booking_live.ex:204
+#: lib/klass_hero_web/live/booking_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:848
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:910
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:874
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
-#: lib/klass_hero_web/live/admin/emails_live.ex:220
+#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:679
+#: lib/klass_hero_web/components/provider_components.ex:686
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:936
+#: lib/klass_hero_web/components/provider_components.ex:943
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:258
+#: lib/klass_hero_web/live/about_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:659
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1041
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:235
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:299
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:315
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:268
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:898
+#: lib/klass_hero_web/components/provider_components.ex:905
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:884
+#: lib/klass_hero_web/components/provider_components.ex:891
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3526,72 +3539,72 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:386
+#: lib/klass_hero_web/live/booking_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:109
+#: lib/klass_hero_web/presenters/provider_presenter.ex:128
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:977
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:978
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:296
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1007
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1008
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1148
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:249
+#: lib/klass_hero_web/live/about_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:620
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:902
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:927
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:815
+#: lib/klass_hero_web/components/provider_components.ex:822
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:278
+#: lib/klass_hero_web/live/about_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1930
+#: lib/klass_hero_web/components/provider_components.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3601,42 +3614,42 @@ msgstr ""
 msgid "Unable to load document preview."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:574
+#: lib/klass_hero_web/components/program_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:634
+#: lib/klass_hero_web/components/program_components.ex:622
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
+#: lib/klass_hero_web/components/provider_components.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1985
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:1954
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3649,8 +3662,8 @@ msgstr ""
 msgid "Verification document not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:177
-#: lib/klass_hero_web/components/layouts/app.html.heex:288
+#: lib/klass_hero_web/components/layouts/app.html.heex:147
+#: lib/klass_hero_web/components/layouts/app.html.heex:256
 #: lib/klass_hero_web/live/admin/verifications_live.ex:40
 #: lib/klass_hero_web/live/admin/verifications_live.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:189
@@ -3663,42 +3676,42 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:128
+#: lib/klass_hero_web/live/about_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:316
+#: lib/klass_hero_web/user_auth.ex:315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:632
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:623
+#: lib/klass_hero_web/components/provider_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:617
+#: lib/klass_hero_web/components/provider_components.ex:624
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:645
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:843
+#: lib/klass_hero_web/components/provider_components.ex:850
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3733,8 +3746,8 @@ msgid_plural "%{count} team seats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/about_live.ex:73
-#: lib/klass_hero_web/live/trust_safety_live.ex:55
+#: lib/klass_hero_web/live/about_live.ex:71
+#: lib/klass_hero_web/live/trust_safety_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
@@ -3750,7 +3763,7 @@ msgstr ""
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:236
+#: lib/klass_hero_web/live/trust_safety_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "And at Klass Hero, both come standard."
 msgstr ""
@@ -3761,7 +3774,7 @@ msgstr ""
 msgid "Applicants complete a video screening to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:104
+#: lib/klass_hero_web/live/trust_safety_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. Our platform is built to connect families, schools, and organizations with qualified, vetted, and safety-verified educators and activity providers."
 msgstr ""
@@ -3781,8 +3794,8 @@ msgstr ""
 msgid "Business Plus"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:71
-#: lib/klass_hero_web/live/trust_safety_live.ex:53
+#: lib/klass_hero_web/live/about_live.ex:69
+#: lib/klass_hero_web/live/trust_safety_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
@@ -3797,8 +3810,8 @@ msgstr ""
 msgid "Choose your plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:83
-#: lib/klass_hero_web/live/trust_safety_live.ex:61
+#: lib/klass_hero_web/live/about_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3808,7 +3821,7 @@ msgstr ""
 msgid "Could not change subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:75
+#: lib/klass_hero_web/live/trust_safety_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Create long-term trust across our community"
 msgstr ""
@@ -3819,7 +3832,7 @@ msgstr ""
 msgid "Current Plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1297
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Current Plan: %{plan}"
 msgstr ""
@@ -3835,18 +3848,18 @@ msgstr ""
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:82
+#: lib/klass_hero_web/live/trust_safety_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:159
+#: lib/klass_hero_web/live/trust_safety_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Every educator and enrichment professional on Klass Hero completes a 6-step verification process before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:85
-#: lib/klass_hero_web/live/trust_safety_live.ex:63
+#: lib/klass_hero_web/live/about_live.ex:83
+#: lib/klass_hero_web/live/trust_safety_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
@@ -3878,7 +3891,7 @@ msgstr ""
 msgid "Free"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:138
+#: lib/klass_hero_web/live/trust_safety_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
@@ -3893,12 +3906,12 @@ msgstr ""
 msgid "Get started for free"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:216
+#: lib/klass_hero_web/live/trust_safety_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Have Questions?"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:156
+#: lib/klass_hero_web/live/trust_safety_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
@@ -3909,7 +3922,7 @@ msgstr ""
 msgid "Identity & Age Verification"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:219
+#: lib/klass_hero_web/live/trust_safety_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "If you'd like to learn more about our Trust & Safety standards or provider verification process, we're happy to help."
 msgstr ""
@@ -3920,27 +3933,27 @@ msgstr ""
 msgid "Invalid subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1307
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
 #, elixir-autogen, elixir-format
 msgid "Manage Plan →"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:186
+#: lib/klass_hero_web/live/trust_safety_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality & Accountability"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:116
+#: lib/klass_hero_web/live/trust_safety_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Our Commitment to Child Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:509
+#: lib/klass_hero_web/live/booking_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
@@ -3950,12 +3963,12 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:520
+#: lib/klass_hero_web/live/booking_live.ex:517
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1711
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3965,7 +3978,7 @@ msgstr ""
 msgid "Promotional content"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:72
+#: lib/klass_hero_web/live/trust_safety_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Protect children and families"
 msgstr ""
@@ -3976,17 +3989,17 @@ msgstr ""
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:205
+#: lib/klass_hero_web/live/trust_safety_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Providers who fail to uphold our expectations may be suspended or removed from the platform."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:83
+#: lib/klass_hero_web/live/trust_safety_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:228
+#: lib/klass_hero_web/live/booking_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
@@ -4006,7 +4019,7 @@ msgstr ""
 msgid "Subscription Plans"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:73
+#: lib/klass_hero_web/live/trust_safety_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Support schools and institutions with reliable providers"
 msgstr ""
@@ -4021,35 +4034,36 @@ msgstr ""
 msgid "Switched to %{plan}"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:101
+#: lib/klass_hero_web/live/trust_safety_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "TRUST & SAFETY"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:84
+#: lib/klass_hero_web/live/trust_safety_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Taking action when standards are not met"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:212
+#: lib/klass_hero_web/live/booking_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:661
-#: lib/klass_hero_web/components/layouts/app.html.heex:73
-#: lib/klass_hero_web/components/layouts/app.html.heex:250
+#: lib/klass_hero_web/components/composite_components.ex:612
+#: lib/klass_hero_web/components/composite_components.ex:681
+#: lib/klass_hero_web/components/layouts/app.html.heex:60
+#: lib/klass_hero_web/components/layouts/app.html.heex:212
 #: lib/klass_hero_web/live/trust_safety_live.ex:12
 #, elixir-autogen, elixir-format
 msgid "Trust & Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:189
+#: lib/klass_hero_web/live/trust_safety_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Trust doesn't stop at onboarding. Klass Hero continuously works to maintain a safe and high-quality ecosystem by:"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:233
+#: lib/klass_hero_web/live/trust_safety_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Trust is earned. Safety is non-negotiable."
 msgstr ""
@@ -4059,17 +4073,17 @@ msgstr ""
 msgid "Unlimited programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1300
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to unlock more features"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:74
+#: lib/klass_hero_web/live/trust_safety_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:135
+#: lib/klass_hero_web/live/trust_safety_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
@@ -4085,7 +4099,7 @@ msgstr ""
 msgid "Video Screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:119
+#: lib/klass_hero_web/live/trust_safety_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "We believe that children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
 msgstr ""
@@ -4106,87 +4120,87 @@ msgstr ""
 msgid "month"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:523
+#: lib/klass_hero_web/live/home_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:521
+#: lib/klass_hero_web/live/home_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:212
+#: lib/klass_hero_web/live/about_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Our 6-Step Vetting Process"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:140
+#: lib/klass_hero_web/live/settings/children_live.ex:139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Could not check enrollments. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:619
+#: lib/klass_hero_web/live/settings/children_live.ex:613
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:573
+#: lib/klass_hero_web/live/settings/children_live.ex:567
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:591
+#: lib/klass_hero_web/live/settings/children_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:578
+#: lib/klass_hero_web/live/settings/children_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:155
+#: lib/klass_hero_web/live/settings/children_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "This deletion request has expired. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:660
+#: lib/klass_hero_web/live/home_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "1st cancellation (90 days): Warning only"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:661
+#: lib/klass_hero_web/live/home_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "2nd cancellation: €50 penalty"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:639
+#: lib/klass_hero_web/live/home_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "3-7 days before: Usually 75% refund (you keep 25%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:662
+#: lib/klass_hero_web/live/home_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "3rd cancellation: €100 penalty + 14-day suspension"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:663
+#: lib/klass_hero_web/live/home_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "4+ cancellations: Account termination"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:638
+#: lib/klass_hero_web/live/home_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "7+ days before: Usually full refund (you keep nothing)"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:269
+#: lib/klass_hero_web/live/admin/sessions_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:734
+#: lib/klass_hero_web/components/participation_components.ex:735
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -4202,22 +4216,22 @@ msgstr ""
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:596
+#: lib/klass_hero_web/live/home_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:568
+#: lib/klass_hero_web/live/home_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:284
+#: lib/klass_hero_web/live/admin/sessions_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:592
+#: lib/klass_hero_web/live/home_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
@@ -4227,7 +4241,7 @@ msgstr ""
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:614
+#: lib/klass_hero_web/live/home_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -4247,47 +4261,48 @@ msgstr ""
 msgid "Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:564
+#: lib/klass_hero_web/live/home_live.ex:573
 #, elixir-autogen, elixir-format
 msgid "Business Account: You keep €901 (€60 commission + €39 monthly fee)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:554
+#: lib/klass_hero_web/live/home_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Business Account: €39/month + 6% per booking (for providers/teams earning €600+/month)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:537
+#: lib/klass_hero_web/live/home_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:756
+#: lib/klass_hero_web/live/home_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:710
+#: lib/klass_hero_web/live/home_live.ex:719
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Can I change my booking date?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:730
+#: lib/klass_hero_web/live/home_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Can I get a refund if the provider cancels?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:531
+#: lib/klass_hero_web/live/home_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:592
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:614
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr ""
@@ -4312,15 +4327,15 @@ msgstr ""
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:732
-#: lib/klass_hero_web/live/admin/sessions_live.ex:301
+#: lib/klass_hero_web/components/participation_components.ex:733
+#: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:733
-#: lib/klass_hero_web/live/admin/sessions_live.ex:302
+#: lib/klass_hero_web/components/participation_components.ex:734
+#: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:53
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:53
@@ -4333,37 +4348,37 @@ msgstr ""
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:629
+#: lib/klass_hero_web/live/home_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Clear policies protect everyone."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:758
+#: lib/klass_hero_web/live/home_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/components/participation_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:649
+#: lib/klass_hero_web/live/home_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Contact all booked parents immediately and offer alternative dates. Include us in CC/BCC (support@mail.klasshero.com)."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:712
+#: lib/klass_hero_web/live/home_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:632
+#: lib/klass_hero_web/live/home_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Contact them immediately - often you can find an alternative date. Include us in CC/BCC (support@mail.klasshero.com) so we're informed."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:738
+#: lib/klass_hero_web/live/home_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Contact us immediately at support@mail.klasshero.com or call +49 (0) 152 2426 0416. You'll receive 100% refund + family credit, and the provider faces serious penalties."
 msgstr ""
@@ -4373,47 +4388,50 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:589
+#: lib/klass_hero_web/live/dashboard_live.ex:177
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:591
+#: lib/klass_hero_web/live/home_live.ex:600
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:748
+#: lib/klass_hero_web/live/home_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:668
+#: lib/klass_hero_web/live/home_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Death in family"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:700
+#: lib/klass_hero_web/live/home_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:621
+#: lib/klass_hero_web/live/home_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:722
+#: lib/klass_hero_web/live/home_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:559
+#: lib/klass_hero_web/live/home_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Example: If you earn €1,000 in bookings"
 msgstr ""
@@ -4423,73 +4441,73 @@ msgstr ""
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:619
+#: lib/klass_hero_web/live/home_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:586
+#: lib/klass_hero_web/live/home_live.ex:595
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:670
+#: lib/klass_hero_web/live/home_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Government closure"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:597
+#: lib/klass_hero_web/live/home_live.ex:606
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:576
+#: lib/klass_hero_web/live/home_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:630
+#: lib/klass_hero_web/live/home_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "If Parent Cancels:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:647
+#: lib/klass_hero_web/live/home_live.ex:656
 #, elixir-autogen, elixir-format
 msgid "If You Must Cancel:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:674
+#: lib/klass_hero_web/live/home_live.ex:683
 #, elixir-autogen, elixir-format
 msgid "If you fail to show up without prior notice:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:676
+#: lib/klass_hero_web/live/home_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Immediate account suspension"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:730
-#: lib/klass_hero_web/live/admin/sessions_live.ex:300
+#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/live/admin/sessions_live.ex:296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:600
+#: lib/klass_hero_web/live/home_live.ex:609
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:690
+#: lib/klass_hero_web/live/home_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:682
+#: lib/klass_hero_web/live/home_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "Keep your reliability high - parents can see your cancellation rate on your profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:594
+#: lib/klass_hero_web/live/home_live.ex:603
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
@@ -4505,17 +4523,17 @@ msgstr ""
 msgid "Klass Hero Admin"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:640
+#: lib/klass_hero_web/live/home_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Less than 3 days: Usually 25-50% refund (you keep 50-75%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:667
+#: lib/klass_hero_web/live/home_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Medical emergency"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:671
+#: lib/klass_hero_web/live/home_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Minimum enrollment not met (camps only - notify 14 days before)"
 msgstr ""
@@ -4525,27 +4543,28 @@ msgstr ""
 msgid "No change"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:270
+#: lib/klass_hero_web/live/admin/sessions_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:612
+#: lib/klass_hero_web/live/home_live.ex:621
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1494
+#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:665
+#: lib/klass_hero_web/live/home_live.ex:674
 #, elixir-autogen, elixir-format
 msgid "No penalties for legitimate reasons:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:613
+#: lib/klass_hero_web/live/home_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
@@ -4556,77 +4575,78 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:605
+#: lib/klass_hero_web/live/home_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1659
+#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:581
+#: lib/klass_hero_web/live/home_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:678
+#: lib/klass_hero_web/live/home_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Parent gets 100% refund + family credit"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:585
+#: lib/klass_hero_web/live/home_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:611
+#: lib/klass_hero_web/live/home_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:589
+#: lib/klass_hero_web/live/home_live.ex:598
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:679
+#: lib/klass_hero_web/live/home_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Permanent ban if no valid emergency"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:606
+#: lib/klass_hero_web/live/home_live.ex:615
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:541
+#: lib/klass_hero_web/live/home_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:539
+#: lib/klass_hero_web/live/home_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:549
+#: lib/klass_hero_web/live/home_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "Professional: More tools and opportunities for €9/month + 12% per booking (only when you get bookings)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:562
+#: lib/klass_hero_web/live/home_live.ex:571
 #, elixir-autogen, elixir-format
 msgid "Professional: You keep €871 (€120 commission + €9 monthly fee)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:658
+#: lib/klass_hero_web/live/home_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Provider Cancellation Penalties:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:673
+#: lib/klass_hero_web/live/home_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Provider No-Show:"
 msgstr ""
@@ -4636,7 +4656,7 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:618
+#: lib/klass_hero_web/live/home_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
@@ -4646,22 +4666,22 @@ msgstr ""
 msgid "Reason for correction"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:274
+#: lib/klass_hero_web/live/admin/sessions_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:636
+#: lib/klass_hero_web/live/home_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Refunds are automatic based on our cancellation policy:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:536
+#: lib/klass_hero_web/live/home_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:593
+#: lib/klass_hero_web/live/home_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
@@ -4671,22 +4691,22 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:729
+#: lib/klass_hero_web/components/participation_components.ex:730
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:620
+#: lib/klass_hero_web/live/home_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:669
+#: lib/klass_hero_web/live/home_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Severe weather"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:578
+#: lib/klass_hero_web/live/home_live.ex:587
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -4696,127 +4716,129 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:544
+#: lib/klass_hero_web/live/home_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 20% commission per booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:561
+#: lib/klass_hero_web/live/home_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Starter: You keep €800 (€200 commission)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:643
+#: lib/klass_hero_web/live/home_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Stripe processes all refunds - funds returned to parent's original payment method within 5-10 business days. Any amounts you keep remain in your balance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:616
+#: lib/klass_hero_web/live/home_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1655
+#: lib/klass_hero_web/components/provider_components.ex:1660
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:585
+#: lib/klass_hero_web/live/dashboard_live.ex:164
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:608
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:604
+#: lib/klass_hero_web/live/home_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:534
+#: lib/klass_hero_web/live/home_live.ex:543
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:627
+#: lib/klass_hero_web/live/home_live.ex:636
 #, elixir-autogen, elixir-format
 msgid "What happens if a parent cancels or I need to cancel?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:720
+#: lib/klass_hero_web/live/home_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:736
+#: lib/klass_hero_web/live/home_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "What if the provider doesn't show up?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:579
+#: lib/klass_hero_web/live/home_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:654
+#: lib/klass_hero_web/live/home_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "When you cancel, parents get 100% refund automatically. The amount is deducted from your next payout."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:746
+#: lib/klass_hero_web/live/home_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:608
+#: lib/klass_hero_web/live/home_live.ex:617
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:538
+#: lib/klass_hero_web/live/home_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:692
+#: lib/klass_hero_web/live/home_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:533
+#: lib/klass_hero_web/live/home_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:731
+#: lib/klass_hero_web/live/home_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Yes, always 100% refund if provider cancels. No exceptions."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:702
+#: lib/klass_hero_web/live/home_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:587
+#: lib/klass_hero_web/live/home_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:610
+#: lib/klass_hero_web/live/home_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:583
+#: lib/klass_hero_web/live/home_live.ex:592
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:677
+#: lib/klass_hero_web/live/home_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "€200 penalty (deducted from balance or invoiced)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:77
+#: lib/klass_hero_web/components/participation_components.ex:78
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr ""
@@ -4831,12 +4853,12 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:339
+#: lib/klass_hero_web/live/provider/sessions_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:150
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:152
 #, elixir-autogen, elixir-format
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
@@ -4847,8 +4869,8 @@ msgstr ""
 msgid "Add Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:159
-#: lib/klass_hero_web/components/layouts/app.html.heex:281
+#: lib/klass_hero_web/components/layouts/app.html.heex:129
+#: lib/klass_hero_web/components/layouts/app.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -4868,7 +4890,7 @@ msgstr ""
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:232
+#: lib/klass_hero_web/components/participation_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
@@ -4878,13 +4900,13 @@ msgstr ""
 msgid "Archive"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:216
+#: lib/klass_hero_web/live/admin/emails_live.ex:215
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:88
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr ""
@@ -4905,7 +4927,7 @@ msgstr ""
 msgid "Behavioral Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:506
+#: lib/klass_hero_web/components/messaging_components.ex:628
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4922,7 +4944,7 @@ msgstr ""
 msgid "Check Out"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:280
+#: lib/klass_hero_web/live/admin/sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr ""
@@ -4942,7 +4964,7 @@ msgstr ""
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:216
+#: lib/klass_hero_web/components/participation_components.ex:217
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
@@ -4963,13 +4985,13 @@ msgid "Clear selection"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:76
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:200
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:202
 #, elixir-autogen, elixir-format
 msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:295
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -5009,7 +5031,7 @@ msgstr ""
 msgid "Content is being fetched..."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:204
+#: lib/klass_hero_web/live/messaging_live_helper.ex:240
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Could not start private conversation"
 msgstr ""
@@ -5026,8 +5048,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:313
-#: lib/klass_hero_web/live/provider/sessions_live.ex:314
+#: lib/klass_hero_web/live/provider/sessions_live.ex:330
+#: lib/klass_hero_web/live/provider/sessions_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -5070,12 +5092,12 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:338
+#: lib/klass_hero_web/live/provider/sessions_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -5085,7 +5107,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:273
+#: lib/klass_hero_web/live/provider/sessions_live.ex:290
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -5100,7 +5122,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:332
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -5141,8 +5163,8 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:282
-#: lib/klass_hero_web/live/provider/sessions_live.ex:334
+#: lib/klass_hero_web/live/admin/sessions_live.ex:278
+#: lib/klass_hero_web/live/provider/sessions_live.ex:351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -5168,7 +5190,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:312
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:342
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -5178,8 +5200,8 @@ msgstr ""
 msgid "Joined"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:28
-#: lib/klass_hero_web/components/layouts/app.html.heex:240
+#: lib/klass_hero_web/components/layouts/app.html.heex:15
+#: lib/klass_hero_web/components/layouts/app.html.heex:202
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Klass Hero Logo"
 msgstr ""
@@ -5189,7 +5211,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:70
+#: lib/klass_hero_web/components/participation_components.ex:71
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location TBD"
 msgstr ""
@@ -5210,7 +5232,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:309
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -5230,7 +5252,7 @@ msgstr ""
 msgid "No participation records yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:92
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs assigned yet."
 msgstr ""
@@ -5246,7 +5268,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:324
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -5266,7 +5288,7 @@ msgstr ""
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:178
+#: lib/klass_hero_web/components/participation_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
@@ -5287,7 +5309,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:341
+#: lib/klass_hero_web/live/provider/sessions_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -5304,7 +5326,7 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:133
+#: lib/klass_hero_web/live/provider/sessions_live.ex:153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program is required"
 msgstr ""
@@ -5319,7 +5341,7 @@ msgstr ""
 msgid "Provider observation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:215
+#: lib/klass_hero_web/live/admin/emails_live.ex:214
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
@@ -5335,12 +5357,12 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/components/messaging_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:211
+#: lib/klass_hero_web/live/messaging_live_helper.ex:247
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
@@ -5350,7 +5372,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:546
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -5385,44 +5407,44 @@ msgstr ""
 msgid "Send Reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:219
+#: lib/klass_hero_web/live/admin/emails_live.ex:218
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:57
+#: lib/klass_hero_web/components/participation_components.ex:58
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:231
+#: lib/klass_hero_web/components/participation_components.ex:232
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:187
+#: lib/klass_hero_web/components/participation_components.ex:188
 #: lib/klass_hero_web/components/participation_components.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:253
+#: lib/klass_hero_web/live/provider/sessions_live.ex:270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:962
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:273
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -5432,7 +5454,7 @@ msgstr ""
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:247
+#: lib/klass_hero_web/components/participation_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
@@ -5442,12 +5464,12 @@ msgstr ""
 msgid "Support: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:39
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:322
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5472,8 +5494,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:323
-#: lib/klass_hero_web/live/provider/sessions_live.ex:324
+#: lib/klass_hero_web/live/provider/sessions_live.ex:340
+#: lib/klass_hero_web/live/provider/sessions_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -5488,15 +5510,15 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:140
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:58
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
+#: lib/klass_hero_web/live/provider/sessions_live.ex:160
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:214
+#: lib/klass_hero_web/live/admin/emails_live.ex:213
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"
@@ -5507,14 +5529,14 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:428
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:683
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:456
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:306
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -5524,7 +5546,7 @@ msgstr ""
 msgid "View your children's participation records"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:82
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome, %{name}"
 msgstr ""
@@ -5540,12 +5562,12 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:327
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:300
+#: lib/klass_hero_web/user_auth.ex:299
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You must be a staff member to access this page."
 msgstr ""
@@ -5565,12 +5587,12 @@ msgstr ""
 msgid "Your children's participation will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:130
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:391
+#: lib/klass_hero_web/components/provider_components.ex:392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Team Members"
 msgstr ""
@@ -5580,12 +5602,220 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:239
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
+#, elixir-autogen, elixir-format
+msgid "+1234567890"
+msgstr ""
+
+#: lib/klass_hero_web/components/composite_components.ex:852
+#, elixir-autogen, elixir-format
+msgid "About the Provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:250
+#, elixir-autogen, elixir-format
+msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:214
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Business Name"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:737
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Cancelled"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Categories"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1179
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Complete Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Complete Your Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "Complete Your Provider Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1162
+#, elixir-autogen, elixir-format
+msgid "Complete your provider profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "Drag and drop or click to upload"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:504
+#, elixir-autogen, elixir-format
+msgid "Failed to upload files. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:689
+#, elixir-autogen, elixir-format, fuzzy
+msgid "File is too large (max %{mb} MB)"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:502
+#, elixir-autogen, elixir-format, fuzzy
+msgid "File is too large (max %{mb} MB)."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:692
+#, elixir-autogen, elixir-format, fuzzy
+msgid "File type not accepted (images only)"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#, elixir-autogen, elixir-format
+msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
+#, elixir-autogen, elixir-format
+msgid "Manage your business"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:499
+#, elixir-autogen, elixir-format
+msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:677
+#: lib/klass_hero_web/components/messaging_components.ex:681
+#, elixir-autogen, elixir-format
+msgid "Photo"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:494
+#, elixir-autogen, elixir-format
+msgid "Please enter a message or attach a photo."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Profile completed! Klass Hero will review your profile shortly."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:36
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider not found"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:276
+#, elixir-autogen, elixir-format
+msgid "Remove attachment"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1328
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sessions Completed"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:505
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:47
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:88
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Tell parents about your organization and what makes you unique..."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:696
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many files (max %{max})"
+msgstr ""
+
+#: lib/klass_hero_web/live/messaging_live_helper.ex:497
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many files (max %{max})."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#, elixir-autogen, elixir-format
+msgid "Upgrade plan to message parents"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Upgrade plan to send broadcasts"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:700
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Upload error"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:699
+#, elixir-autogen, elixir-format
+msgid "Upload failed"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1093
+#, elixir-autogen, elixir-format
+msgid "View your assignments"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
+#, elixir-autogen, elixir-format
+msgid "Website"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:434
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:866
+#, elixir-autogen, elixir-format
+msgid "You've reached your program limit. Upgrade your plan to add more programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:248
+#, elixir-autogen, elixir-format
+msgid "Your business address"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Your business or organization name"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Your profile is already complete."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:89
+#: lib/klass_hero_web/live/messaging_live_helper.ex:338
+#, elixir-autogen, elixir-format, fuzzy
+msgid "for"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1996
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1910
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1911
+#: lib/klass_hero_web/components/provider_components.ex:1998
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1922
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1912
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:2000
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1914
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1921
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1915
+#: lib/klass_hero_web/components/provider_components.ex:2002
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1905
+#: lib/klass_hero_web/components/provider_components.ex:1910
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1906
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:1922
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1907
+#: lib/klass_hero_web/components/provider_components.ex:1912
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1908
+#: lib/klass_hero_web/components/provider_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1921
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1920
+#: lib/klass_hero_web/components/provider_components.ex:1923
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1910
+#: lib/klass_hero_web/components/provider_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1916
+#: lib/klass_hero_web/components/provider_components.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:1996
+#: lib/klass_hero_web/components/provider_components.ex:2003
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1997
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2005
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2000
+#: lib/klass_hero_web/components/provider_components.ex:2007
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2001
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2008
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2006
+#: lib/klass_hero_web/components/provider_components.ex:2013
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1996
+#: lib/klass_hero_web/components/provider_components.ex:2003
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1997
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2005
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2000
+#: lib/klass_hero_web/components/provider_components.ex:2007
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2001
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2008
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2006
+#: lib/klass_hero_web/components/provider_components.ex:2013
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1905
+#: lib/klass_hero_web/components/provider_components.ex:1910
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1906
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:1922
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1907
+#: lib/klass_hero_web/components/provider_components.ex:1912
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1908
+#: lib/klass_hero_web/components/provider_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1921
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1920
+#: lib/klass_hero_web/components/provider_components.ex:1923
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1910
+#: lib/klass_hero_web/components/provider_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1916
+#: lib/klass_hero_web/components/provider_components.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1996
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1910
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1911
+#: lib/klass_hero_web/components/provider_components.ex:1998
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1922
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1912
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:2000
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1914
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1921
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1915
+#: lib/klass_hero_web/components/provider_components.ex:2002
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:2006
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/repo/migrations/20260418101550_create_provider_session_details.exs
+++ b/priv/repo/migrations/20260418101550_create_provider_session_details.exs
@@ -1,0 +1,30 @@
+defmodule KlassHero.Repo.Migrations.CreateProviderSessionDetails do
+  use Ecto.Migration
+
+  def change do
+    create table(:provider_session_details, primary_key: false) do
+      add :session_id, :binary_id, primary_key: true
+      add :program_id, :binary_id, null: false
+      add :program_title, :string, null: false
+      add :provider_id, :binary_id, null: false
+
+      add :session_date, :date, null: false
+      add :start_time, :time, null: false
+      add :end_time, :time, null: false
+      add :status, :string, null: false
+
+      add :current_assigned_staff_id, :binary_id
+      add :current_assigned_staff_name, :string
+      add :cover_staff_id, :binary_id
+      add :cover_staff_name, :string
+
+      add :checked_in_count, :integer, null: false, default: 0
+      add :total_count, :integer, null: false, default: 0
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:provider_session_details, [:provider_id, :program_id, :session_date])
+    create index(:provider_session_details, [:provider_id, :session_date])
+  end
+end

--- a/test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -137,6 +137,42 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteI
     end
   end
 
+  describe "handle/1 — :session_cancelled" do
+    test "promotes to session_cancelled integration event" do
+      session_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      domain_event =
+        DomainEvent.new(:session_cancelled, session_id, :participation, %{
+          session_id: session_id,
+          program_id: program_id,
+          cancelled_at: DateTime.utc_now()
+        })
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+
+      event = assert_integration_event_published(:session_cancelled)
+      assert event.entity_id == session_id
+      assert event.source_context == :participation
+    end
+
+    test "swallows publish failures with :ok" do
+      session_id = Ecto.UUID.generate()
+
+      domain_event =
+        DomainEvent.new(:session_cancelled, session_id, :participation, %{
+          session_id: session_id,
+          program_id: Ecto.UUID.generate(),
+          cancelled_at: DateTime.utc_now()
+        })
+
+      TestIntegrationEventPublisher.configure_publish_error(:pubsub_down)
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+      assert_no_integration_events_published()
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Check-in/out events (aggregate_type: :participation)
   # ---------------------------------------------------------------------------

--- a/test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -154,6 +154,7 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteI
       event = assert_integration_event_published(:session_cancelled)
       assert event.entity_id == session_id
       assert event.source_context == :participation
+      assert event.payload.program_id == program_id
     end
 
     test "swallows publish failures with :ok" do

--- a/test/klass_hero/participation/domain/events/participation_integration_events_test.exs
+++ b/test/klass_hero/participation/domain/events/participation_integration_events_test.exs
@@ -628,4 +628,29 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEventsTe
                    end
     end
   end
+
+  describe "session_cancelled/3" do
+    test "creates a session_cancelled integration event" do
+      event = ParticipationIntegrationEvents.session_cancelled("session-1", %{program_id: "program-1"})
+
+      assert event.event_type == :session_cancelled
+      assert event.source_context == :participation
+      assert event.entity_type == :session
+      assert event.entity_id == "session-1"
+      assert event.payload.session_id == "session-1"
+      assert event.payload.program_id == "program-1"
+    end
+
+    test "raises when session_id is nil" do
+      assert_raise ArgumentError, fn ->
+        ParticipationIntegrationEvents.session_cancelled(nil, %{program_id: "p"})
+      end
+    end
+
+    test "raises when program_id is missing" do
+      assert_raise ArgumentError, fn ->
+        ParticipationIntegrationEvents.session_cancelled("session-1", %{})
+      end
+    end
+  end
 end

--- a/test/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/mappers/provider_session_detail_mapper_test.exs
@@ -1,0 +1,35 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapperTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderSessionDetailMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  test "to_read_model/1 maps schema struct to DTO with all fields" do
+    schema = %ProviderSessionDetailSchema{
+      session_id: "s-1",
+      program_id: "p-1",
+      program_title: "Judo",
+      provider_id: "pr-1",
+      session_date: ~D[2026-05-01],
+      start_time: ~T[15:00:00],
+      end_time: ~T[16:00:00],
+      status: :scheduled,
+      current_assigned_staff_id: "staff-1",
+      current_assigned_staff_name: "Alice",
+      cover_staff_id: nil,
+      cover_staff_name: nil,
+      checked_in_count: 3,
+      total_count: 5
+    }
+
+    assert %SessionDetail{
+             session_id: "s-1",
+             program_title: "Judo",
+             status: :scheduled,
+             current_assigned_staff_name: "Alice",
+             checked_in_count: 3,
+             total_count: 5
+           } = ProviderSessionDetailMapper.to_read_model(schema)
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/repositories/session_details_repository_test.exs
@@ -1,0 +1,71 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepositoryTest do
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionDetailsRepository
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+  alias KlassHero.Repo
+
+  defp insert_row(attrs) do
+    %ProviderSessionDetailSchema{}
+    |> Ecto.Changeset.change(attrs)
+    |> Repo.insert!()
+  end
+
+  describe "list_by_program/2" do
+    test "returns rows ordered by session_date then start_time" do
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "Judo",
+        provider_id: provider_id,
+        session_date: ~D[2026-05-02],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: :scheduled
+      })
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "Judo",
+        provider_id: provider_id,
+        session_date: ~D[2026-05-01],
+        start_time: ~T[15:00:00],
+        end_time: ~T[16:00:00],
+        status: :scheduled
+      })
+
+      [first, second] = SessionDetailsRepository.list_by_program(provider_id, program_id)
+
+      assert %SessionDetail{session_date: ~D[2026-05-01]} = first
+      assert %SessionDetail{session_date: ~D[2026-05-02]} = second
+    end
+
+    test "returns [] for unknown program" do
+      assert [] == SessionDetailsRepository.list_by_program(Ecto.UUID.generate(), Ecto.UUID.generate())
+    end
+
+    test "does not leak across providers" do
+      program_id = Ecto.UUID.generate()
+      mine = Ecto.UUID.generate()
+      theirs = Ecto.UUID.generate()
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "J",
+        provider_id: theirs,
+        session_date: ~D[2026-05-01],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: :scheduled
+      })
+
+      assert [] == SessionDetailsRepository.list_by_program(mine, program_id)
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
@@ -1,0 +1,91 @@
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsBootstrapTest do
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProgramStaffAssignmentSchema
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+  alias KlassHero.Repo
+
+  @tag :bootstrap
+  test "bootstrap projects every existing session from write tables" do
+    # Trigger: seed the write tables directly (no integration events emitted).
+    # Why: exercises bootstrap's ability to self-heal the read table from the
+    #      authoritative write tables — this is what rebuild/0 is for after
+    #      seeds (which bypass the event bus).
+    # Outcome: rebuild/0 projects every existing session row; the assertion
+    #          verifies field resolution (program title, provider_id, status).
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Judo")
+
+    session_schema =
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-05-01],
+        start_time: ~T[15:00:00],
+        end_time: ~T[16:00:00],
+        status: "scheduled"
+      )
+
+    start_supervised!({ProviderSessionDetails, name: :bootstrap_test})
+    :ok = ProviderSessionDetails.rebuild(:bootstrap_test)
+
+    row = Repo.get(ProviderSessionDetailSchema, session_schema.id)
+
+    assert row != nil
+    assert row.program_title == "Judo"
+    assert row.provider_id == provider.id
+    assert row.status == :scheduled
+    assert row.session_date == ~D[2026-05-01]
+    assert row.start_time == ~T[15:00:00]
+    assert row.end_time == ~T[16:00:00]
+    assert row.checked_in_count == 0
+    assert row.total_count == 0
+  end
+
+  @tag :bootstrap
+  test "bootstrap resolves current_assigned_staff_id/name from active assignment" do
+    # Trigger: program has an active (unassigned_at IS NULL) staff assignment
+    # Why: bootstrap must join program_staff_assignments + staff_members and
+    #      concatenate first/last name the same way the event handlers do.
+    # Outcome: row carries the staff id and "First Last" display name.
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Karate")
+
+    staff =
+      insert(:staff_member_schema,
+        provider_id: provider.id,
+        first_name: "Ada",
+        last_name: "Lovelace"
+      )
+
+    {:ok, _assignment} =
+      %ProgramStaffAssignmentSchema{}
+      |> ProgramStaffAssignmentSchema.create_changeset(%{
+        provider_id: provider.id,
+        staff_member_id: staff.id,
+        program_id: program.id,
+        assigned_at: DateTime.utc_now()
+      })
+      |> Repo.insert()
+
+    session_schema =
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-06-01],
+        start_time: ~T[10:00:00],
+        end_time: ~T[11:00:00],
+        status: "scheduled"
+      )
+
+    start_supervised!({ProviderSessionDetails, name: :bootstrap_test_staff})
+    :ok = ProviderSessionDetails.rebuild(:bootstrap_test_staff)
+
+    row = Repo.get(ProviderSessionDetailSchema, session_schema.id)
+
+    assert row != nil
+    assert row.current_assigned_staff_id == staff.id
+    assert row.current_assigned_staff_name == "Ada Lovelace"
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsBootstrapTest do
   use KlassHero.DataCase, async: false
 
+  import Ecto.Query
   import KlassHero.Factory
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProgramStaffAssignmentSchema
@@ -87,5 +88,76 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsB
     assert row != nil
     assert row.current_assigned_staff_id == staff.id
     assert row.current_assigned_staff_name == "Ada Lovelace"
+  end
+
+  @tag :bootstrap
+  test "bootstrap produces one row per session even when a program has multiple active staff" do
+    # Trigger: a program has two active staff assignments (different staff_member_ids).
+    #          The partial unique index program_staff_assignments_active_unique is
+    #          (program_id, staff_member_id) WHERE unassigned_at IS NULL, so this
+    #          is a legitimate state — not a data error.
+    # Why: without the LATERAL LIMIT 1 subquery, the LEFT JOIN on
+    #      program_staff_assignments would return N rows per session (one per
+    #      active staff), and Repo.insert_all would trip Postgres's
+    #      "ON CONFLICT DO UPDATE command cannot affect row a second time" error.
+    # Outcome: bootstrap succeeds; exactly one row per session; the earliest-assigned
+    #          staff wins (matching resolve_program_context/1's tie-breaker).
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Yoga")
+
+    first_staff =
+      insert(:staff_member_schema, provider_id: provider.id, first_name: "Grace", last_name: "Hopper")
+
+    second_staff =
+      insert(:staff_member_schema, provider_id: provider.id, first_name: "Margaret", last_name: "Hamilton")
+
+    first_assigned_at = ~U[2026-04-01 09:00:00Z]
+    second_assigned_at = ~U[2026-04-02 09:00:00Z]
+
+    {:ok, _} =
+      %ProgramStaffAssignmentSchema{}
+      |> ProgramStaffAssignmentSchema.create_changeset(%{
+        provider_id: provider.id,
+        staff_member_id: first_staff.id,
+        program_id: program.id,
+        assigned_at: first_assigned_at
+      })
+      |> Repo.insert()
+
+    {:ok, _} =
+      %ProgramStaffAssignmentSchema{}
+      |> ProgramStaffAssignmentSchema.create_changeset(%{
+        provider_id: provider.id,
+        staff_member_id: second_staff.id,
+        program_id: program.id,
+        assigned_at: second_assigned_at
+      })
+      |> Repo.insert()
+
+    session_schema =
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-05-10],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: "scheduled"
+      )
+
+    start_supervised!({ProviderSessionDetails, name: :bootstrap_test_multi_staff})
+    :ok = ProviderSessionDetails.rebuild(:bootstrap_test_multi_staff)
+
+    # Only one row for the session (no duplicate-conflict crash)
+    rows =
+      Repo.all(
+        from d in ProviderSessionDetailSchema,
+          where: d.session_id == ^session_schema.id
+      )
+
+    assert length(rows) == 1
+    [row] = rows
+
+    # Earliest-assigned staff wins (ORDER BY assigned_at ASC LIMIT 1)
+    assert row.current_assigned_staff_id == first_staff.id
+    assert row.current_assigned_staff_name == "Grace Hopper"
   end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -2,6 +2,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
   use KlassHero.DataCase, async: false
 
   import Ecto.Query
+  import ExUnit.CaptureLog
   import KlassHero.Factory
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProgramStaffAssignmentSchema
@@ -233,6 +234,19 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       _ = :sys.get_state(@test_server_name)
 
       assert %{status: :cancelled} = reload(session_id)
+    end
+
+    test "logs a warning when the session row is missing" do
+      unknown_id = Ecto.UUID.generate()
+
+      log =
+        capture_log(fn ->
+          broadcast(:session_started, unknown_id, %{session_id: unknown_id, program_id: "prog"})
+          _ = :sys.get_state(@test_server_name)
+        end)
+
+      assert log =~ "status transition skipped"
+      assert log =~ unknown_id
     end
   end
 

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -199,4 +199,78 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert row.cover_staff_name == "Cover Person"
     end
   end
+
+  describe "status transitions" do
+    setup :insert_seed_session
+
+    test "session_started sets status=:in_progress", %{session_id: session_id} do
+      broadcast(:session_started, session_id, %{session_id: session_id, program_id: "prog"})
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      assert %{status: :in_progress} = reload(session_id)
+    end
+
+    test "session_completed sets status=:completed", %{session_id: session_id} do
+      broadcast(:session_completed, session_id, %{
+        session_id: session_id,
+        program_id: "prog",
+        provider_id: "prv",
+        program_title: "Judo"
+      })
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      assert %{status: :completed} = reload(session_id)
+    end
+
+    test "session_cancelled sets status=:cancelled", %{session_id: session_id} do
+      broadcast(:session_cancelled, session_id, %{session_id: session_id, program_id: "prog"})
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      assert %{status: :cancelled} = reload(session_id)
+    end
+  end
+
+  defp broadcast(event_type, entity_id, payload) do
+    event = IntegrationEvent.new(event_type, :participation, :session, entity_id, payload)
+
+    Phoenix.PubSub.broadcast(
+      KlassHero.PubSub,
+      "integration:participation:#{event_type}",
+      {:integration_event, event}
+    )
+  end
+
+  defp reload(session_id) do
+    Repo.get(ProviderSessionDetailSchema, session_id)
+  end
+
+  defp insert_seed_session(_ctx) do
+    session_id = Ecto.UUID.generate()
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.insert_all(ProviderSessionDetailSchema, [
+      %{
+        session_id: session_id,
+        program_id: Ecto.UUID.generate(),
+        program_title: "X",
+        provider_id: Ecto.UUID.generate(),
+        session_date: ~D[2026-05-01],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: :scheduled,
+        checked_in_count: 0,
+        total_count: 0,
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
+
+    %{session_id: session_id}
+  end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -1,0 +1,14 @@
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsTest do
+  use KlassHero.DataCase, async: false
+
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+
+  setup do
+    start_supervised!({ProviderSessionDetails, name: :test_provider_session_details})
+    :ok
+  end
+
+  test "starts and responds to a ping call" do
+    assert Process.whereis(:test_provider_session_details) |> is_pid()
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -285,6 +285,92 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
     end
   end
 
+  describe "attendance counters" do
+    setup :insert_seed_session
+
+    test "child_checked_in increments checked_in_count", %{session_id: session_id} do
+      broadcast(:child_checked_in, "rec-1", %{
+        record_id: "rec-1",
+        session_id: session_id,
+        child_id: "c-1"
+      })
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      assert %{checked_in_count: 1} = reload(session_id)
+    end
+
+    test "two check-ins increment to 2", %{session_id: session_id} do
+      broadcast(:child_checked_in, "rec-1", %{
+        record_id: "rec-1",
+        session_id: session_id,
+        child_id: "c-1"
+      })
+
+      broadcast(:child_checked_in, "rec-2", %{
+        record_id: "rec-2",
+        session_id: session_id,
+        child_id: "c-2"
+      })
+
+      # Synchronize: ensure GenServer has processed both broadcasts
+      _ = :sys.get_state(@test_server_name)
+
+      assert %{checked_in_count: 2} = reload(session_id)
+    end
+
+    test "child_checked_out does not decrement", %{session_id: session_id} do
+      broadcast(:child_checked_in, "rec-1", %{
+        record_id: "rec-1",
+        session_id: session_id,
+        child_id: "c-1"
+      })
+
+      _ = :sys.get_state(@test_server_name)
+      assert %{checked_in_count: 1} = reload(session_id)
+
+      broadcast(:child_checked_out, "rec-1", %{
+        record_id: "rec-1",
+        session_id: session_id,
+        child_id: "c-1"
+      })
+
+      _ = :sys.get_state(@test_server_name)
+      assert %{checked_in_count: 1} = reload(session_id)
+    end
+
+    test "child_marked_absent does not change count", %{session_id: session_id} do
+      broadcast(:child_marked_absent, "rec-1", %{
+        record_id: "rec-1",
+        session_id: session_id,
+        child_id: "c-1"
+      })
+
+      _ = :sys.get_state(@test_server_name)
+
+      assert %{checked_in_count: 0} = reload(session_id)
+    end
+
+    test "logs a warning when child_checked_in arrives for an unknown session" do
+      unknown_id = Ecto.UUID.generate()
+
+      log =
+        capture_log(fn ->
+          broadcast(:child_checked_in, "rec-ghost", %{
+            record_id: "rec-ghost",
+            session_id: unknown_id,
+            child_id: "c-1"
+          })
+
+          _ = :sys.get_state(@test_server_name)
+        end)
+
+      assert log =~ "child_checked_in skipped"
+      assert log =~ unknown_id
+    end
+  end
+
   defp broadcast(event_type, entity_id, payload) do
     event = IntegrationEvent.new(event_type, :participation, :session, entity_id, payload)
 

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -250,6 +250,41 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
     end
   end
 
+  describe "roster_seeded" do
+    setup :insert_seed_session
+
+    test "sets total_count from seeded_count", %{session_id: session_id} do
+      broadcast(:roster_seeded, session_id, %{
+        session_id: session_id,
+        program_id: "prog",
+        seeded_count: 7
+      })
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      assert %{total_count: 7} = reload(session_id)
+    end
+
+    test "logs a warning when the session row is missing" do
+      unknown_id = Ecto.UUID.generate()
+
+      log =
+        capture_log(fn ->
+          broadcast(:roster_seeded, unknown_id, %{
+            session_id: unknown_id,
+            program_id: "prog",
+            seeded_count: 3
+          })
+
+          _ = :sys.get_state(@test_server_name)
+        end)
+
+      assert log =~ "roster_seeded skipped"
+      assert log =~ unknown_id
+    end
+  end
+
   defp broadcast(event_type, entity_id, payload) do
     event = IntegrationEvent.new(event_type, :participation, :session, entity_id, payload)
 

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -371,6 +371,119 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
     end
   end
 
+  describe "staff assignment" do
+    test "staff_assigned_to_program updates scheduled sessions for the program and skips non-scheduled ones" do
+      # Trigger: AssignStaffToProgram publishes an integration event and the
+      #          projection must bulk-update all scheduled rows for that program.
+      # Why: cover staff on the bulk update path — only :scheduled rows flip to
+      #      the new staff; already-started/completed rows retain their state.
+      # Outcome: scheduled row carries new staff_id + "First Last" name;
+      #          completed row's staff fields stay untouched.
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      staff =
+        insert(:staff_member_schema,
+          provider_id: provider.id,
+          first_name: "Alice",
+          last_name: "Smith"
+        )
+
+      scheduled_session_id = Ecto.UUID.generate()
+      completed_session_id = Ecto.UUID.generate()
+
+      insert_program_session(
+        session_id: scheduled_session_id,
+        program_id: program.id,
+        provider_id: provider.id,
+        status: :scheduled
+      )
+
+      insert_program_session(
+        session_id: completed_session_id,
+        program_id: program.id,
+        provider_id: provider.id,
+        status: :completed
+      )
+
+      broadcast_provider(:staff_assigned_to_program, staff.id, %{
+        staff_member_id: staff.id,
+        program_id: program.id,
+        provider_id: provider.id,
+        staff_user_id: Ecto.UUID.generate()
+      })
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      scheduled = reload(scheduled_session_id)
+      completed = reload(completed_session_id)
+
+      assert scheduled.current_assigned_staff_id == staff.id
+      assert scheduled.current_assigned_staff_name == "Alice Smith"
+      assert completed.current_assigned_staff_id == nil
+      assert completed.current_assigned_staff_name == nil
+    end
+
+    test "staff_unassigned_from_program clears staff fields on scheduled rows for the program" do
+      # Trigger: UnassignStaffFromProgram publishes an integration event and the
+      #          projection must bulk-clear staff fields on all :scheduled rows
+      #          for that program (non-scheduled rows remain untouched).
+      # Why: once a session starts/ends, its historical staff attribution
+      #      persists; only upcoming (:scheduled) sessions lose the assignment.
+      # Outcome: scheduled row's staff_id/name are nil; completed row keeps its
+      #          pre-existing staff attribution.
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      staff =
+        insert(:staff_member_schema,
+          provider_id: provider.id,
+          first_name: "Bob",
+          last_name: "Jones"
+        )
+
+      scheduled_session_id = Ecto.UUID.generate()
+      completed_session_id = Ecto.UUID.generate()
+
+      insert_program_session(
+        session_id: scheduled_session_id,
+        program_id: program.id,
+        provider_id: provider.id,
+        status: :scheduled,
+        current_assigned_staff_id: staff.id,
+        current_assigned_staff_name: "Bob Jones"
+      )
+
+      insert_program_session(
+        session_id: completed_session_id,
+        program_id: program.id,
+        provider_id: provider.id,
+        status: :completed,
+        current_assigned_staff_id: staff.id,
+        current_assigned_staff_name: "Bob Jones"
+      )
+
+      broadcast_provider(:staff_unassigned_from_program, staff.id, %{
+        staff_member_id: staff.id,
+        program_id: program.id,
+        provider_id: provider.id,
+        staff_user_id: Ecto.UUID.generate()
+      })
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      scheduled = reload(scheduled_session_id)
+      completed = reload(completed_session_id)
+
+      assert scheduled.current_assigned_staff_id == nil
+      assert scheduled.current_assigned_staff_name == nil
+      assert completed.current_assigned_staff_id == staff.id
+      assert completed.current_assigned_staff_name == "Bob Jones"
+    end
+  end
+
   defp broadcast(event_type, entity_id, payload) do
     event = IntegrationEvent.new(event_type, :participation, :session, entity_id, payload)
 
@@ -379,6 +492,37 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       "integration:participation:#{event_type}",
       {:integration_event, event}
     )
+  end
+
+  defp broadcast_provider(event_type, entity_id, payload) do
+    event = IntegrationEvent.new(event_type, :provider, :staff, entity_id, payload)
+
+    Phoenix.PubSub.broadcast(
+      KlassHero.PubSub,
+      "integration:provider:#{event_type}",
+      {:integration_event, event}
+    )
+  end
+
+  defp insert_program_session(attrs) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    base = %{
+      session_id: Ecto.UUID.generate(),
+      program_id: Ecto.UUID.generate(),
+      program_title: "P",
+      provider_id: Ecto.UUID.generate(),
+      session_date: ~D[2026-05-01],
+      start_time: ~T[09:00:00],
+      end_time: ~T[10:00:00],
+      status: :scheduled,
+      checked_in_count: 0,
+      total_count: 0,
+      inserted_at: now,
+      updated_at: now
+    }
+
+    Repo.insert_all(ProviderSessionDetailSchema, [Map.merge(base, Map.new(attrs))])
   end
 
   defp reload(session_id) do

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -1,14 +1,73 @@
 defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsTest do
   use KlassHero.DataCase, async: false
 
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  @test_server_name :test_provider_session_details
 
   setup do
-    start_supervised!({ProviderSessionDetails, name: :test_provider_session_details})
+    start_supervised!({ProviderSessionDetails, name: @test_server_name})
+    # Synchronize: ensure bootstrap has completed before running the test body
+    _ = :sys.get_state(@test_server_name)
     :ok
   end
 
   test "starts and responds to a ping call" do
-    assert Process.whereis(:test_provider_session_details) |> is_pid()
+    assert Process.whereis(@test_server_name) |> is_pid()
+  end
+
+  describe "session_created" do
+    test "inserts a row with defaults, resolving program_title and provider_id" do
+      # Trigger: programs FK on provider_id requires a real provider row
+      # Why: the handler reads programs to resolve program_title/provider_id
+      # Outcome: factory creates a provider + user that satisfies FK constraints
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Judo")
+      session_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :session_created,
+          :participation,
+          :session,
+          session_id,
+          %{
+            session_id: session_id,
+            program_id: program.id,
+            session_date: ~D[2026-05-01],
+            start_time: ~T[15:00:00],
+            end_time: ~T[16:00:00]
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:participation:session_created",
+        {:integration_event, event}
+      )
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      row = Repo.get(ProviderSessionDetailSchema, session_id)
+
+      assert row != nil
+      assert row.program_id == program.id
+      assert row.program_title == "Judo"
+      assert row.provider_id == provider.id
+      assert row.session_date == ~D[2026-05-01]
+      assert row.start_time == ~T[15:00:00]
+      assert row.end_time == ~T[16:00:00]
+      assert row.status == :scheduled
+      assert row.checked_in_count == 0
+      assert row.total_count == 0
+      assert row.current_assigned_staff_id == nil
+      assert row.current_assigned_staff_name == nil
+    end
   end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsTest do
   use KlassHero.DataCase, async: false
 
+  import Ecto.Query
   import KlassHero.Factory
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProgramStaffAssignmentSchema
@@ -126,6 +127,76 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert row != nil
       assert row.current_assigned_staff_id == staff.id
       assert row.current_assigned_staff_name == "Ada Lovelace"
+    end
+
+    test "duplicate delivery preserves evolved state written by other handlers" do
+      # Trigger: session_created is replayed (at-least-once delivery) after other
+      #          handlers (session_started/completed, roster_seeded, child_checked_in,
+      #          and a future cover-staff handler) have mutated the row
+      # Why: spec requires session_created to be a no-op on duplicate delivery —
+      #      it must NOT stomp evolved state owned by other handlers
+      # Outcome: after a second broadcast, status/checked_in_count/total_count and
+      #          cover_staff_* fields retain the evolved values
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Aikido")
+      session_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :session_created,
+          :participation,
+          :session,
+          session_id,
+          %{
+            session_id: session_id,
+            program_id: program.id,
+            session_date: ~D[2026-05-03],
+            start_time: ~T[09:00:00],
+            end_time: ~T[10:00:00]
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:participation:session_created",
+        {:integration_event, event}
+      )
+
+      # Synchronize: ensure GenServer has processed the first broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      # Simulate evolved state written by other handlers between deliveries
+      cover_staff_id = Ecto.UUID.generate()
+
+      Repo.update_all(
+        from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id),
+        set: [
+          status: :in_progress,
+          checked_in_count: 5,
+          total_count: 10,
+          cover_staff_id: cover_staff_id,
+          cover_staff_name: "Cover Person"
+        ]
+      )
+
+      # Replay the same event (at-least-once delivery)
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:participation:session_created",
+        {:integration_event, event}
+      )
+
+      # Synchronize: ensure GenServer has processed the replay
+      _ = :sys.get_state(@test_server_name)
+
+      row = Repo.get(ProviderSessionDetailSchema, session_id)
+
+      assert row != nil
+      assert row.status == :in_progress
+      assert row.checked_in_count == 5
+      assert row.total_count == 10
+      assert row.cover_staff_id == cover_staff_id
+      assert row.cover_staff_name == "Cover Person"
     end
   end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -3,6 +3,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
 
   import KlassHero.Factory
 
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProgramStaffAssignmentSchema
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
   alias KlassHero.Repo
@@ -68,6 +69,63 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert row.total_count == 0
       assert row.current_assigned_staff_id == nil
       assert row.current_assigned_staff_name == nil
+    end
+
+    test "resolves current_assigned_staff_id/name from active program_staff_assignments row" do
+      # Trigger: handler reads program_staff_assignments joined with staff_members
+      # Why: exercise the happy-path active-staff resolution (WHERE unassigned_at IS NULL)
+      # Outcome: row carries the seeded staff id + concatenated "First Last" name
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Karate")
+
+      staff =
+        insert(:staff_member_schema,
+          provider_id: provider.id,
+          first_name: "Ada",
+          last_name: "Lovelace"
+        )
+
+      {:ok, _assignment} =
+        %ProgramStaffAssignmentSchema{}
+        |> ProgramStaffAssignmentSchema.create_changeset(%{
+          provider_id: provider.id,
+          staff_member_id: staff.id,
+          program_id: program.id,
+          assigned_at: DateTime.utc_now()
+        })
+        |> Repo.insert()
+
+      session_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :session_created,
+          :participation,
+          :session,
+          session_id,
+          %{
+            session_id: session_id,
+            program_id: program.id,
+            session_date: ~D[2026-05-02],
+            start_time: ~T[10:00:00],
+            end_time: ~T[11:00:00]
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:participation:session_created",
+        {:integration_event, event}
+      )
+
+      # Synchronize: ensure GenServer has processed the broadcast
+      _ = :sys.get_state(@test_server_name)
+
+      row = Repo.get(ProviderSessionDetailSchema, session_id)
+
+      assert row != nil
+      assert row.current_assigned_staff_id == staff.id
+      assert row.current_assigned_staff_name == "Ada Lovelace"
     end
   end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -199,6 +199,49 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert row.cover_staff_id == cover_staff_id
       assert row.cover_staff_name == "Cover Person"
     end
+
+    test "skips the insert and warns when the program does not exist" do
+      # Trigger: a session_created event arrives whose program_id is not in the
+      #          programs write table (e.g., event reordering, replay before
+      #          the program row has been created, or a deleted program)
+      # Why: program_title and provider_id are NOT NULL in provider_session_details,
+      #      so projecting with nil values would crash the GenServer; bootstrap
+      #      will reconcile later if/when the program appears
+      # Outcome: no row inserted; warning logged with session + program context
+      unknown_program_id = Ecto.UUID.generate()
+      session_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :session_created,
+          :participation,
+          :session,
+          session_id,
+          %{
+            session_id: session_id,
+            program_id: unknown_program_id,
+            session_date: ~D[2026-05-01],
+            start_time: ~T[09:00:00],
+            end_time: ~T[10:00:00]
+          }
+        )
+
+      log =
+        capture_log(fn ->
+          Phoenix.PubSub.broadcast(
+            KlassHero.PubSub,
+            "integration:participation:session_created",
+            {:integration_event, event}
+          )
+
+          _ = :sys.get_state(@test_server_name)
+        end)
+
+      assert Repo.get(ProviderSessionDetailSchema, session_id) == nil
+      assert log =~ "session_created skipped: program not found"
+      assert log =~ session_id
+      assert log =~ unknown_program_id
+    end
   end
 
   describe "status transitions" do

--- a/test/klass_hero/provider/application/queries/list_program_sessions_test.exs
+++ b/test/klass_hero/provider/application/queries/list_program_sessions_test.exs
@@ -12,7 +12,7 @@ defmodule KlassHero.Provider.Application.Queries.ListProgramSessionsTest do
   alias KlassHero.Provider.Domain.ReadModels.SessionDetail
   alias KlassHero.Repo
 
-  describe "run/2" do
+  describe "execute/2" do
     test "returns sessions for the provider's program ordered by date and start time" do
       provider_id = Ecto.UUID.generate()
       program_id = Ecto.UUID.generate()
@@ -39,14 +39,14 @@ defmodule KlassHero.Provider.Application.Queries.ListProgramSessionsTest do
         status: :scheduled
       })
 
-      [first, second] = ListProgramSessions.run(provider_id, program_id)
+      [first, second] = ListProgramSessions.execute(provider_id, program_id)
 
       assert %SessionDetail{session_date: ~D[2026-05-01]} = first
       assert %SessionDetail{session_date: ~D[2026-05-02]} = second
     end
 
     test "returns [] when the program has no sessions" do
-      assert [] == ListProgramSessions.run(Ecto.UUID.generate(), Ecto.UUID.generate())
+      assert [] == ListProgramSessions.execute(Ecto.UUID.generate(), Ecto.UUID.generate())
     end
 
     test "does not leak sessions across providers" do
@@ -65,7 +65,7 @@ defmodule KlassHero.Provider.Application.Queries.ListProgramSessionsTest do
         status: :scheduled
       })
 
-      assert [] == ListProgramSessions.run(mine, program_id)
+      assert [] == ListProgramSessions.execute(mine, program_id)
     end
   end
 

--- a/test/klass_hero/provider/application/queries/list_program_sessions_test.exs
+++ b/test/klass_hero/provider/application/queries/list_program_sessions_test.exs
@@ -1,0 +1,77 @@
+defmodule KlassHero.Provider.Application.Queries.ListProgramSessionsTest do
+  @moduledoc """
+  Integration tests for the ListProgramSessions use case.
+
+  Tests the complete data flow: Use Case -> Read Repository -> Database -> SessionDetail read model.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Application.Queries.ListProgramSessions
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+  alias KlassHero.Repo
+
+  describe "run/2" do
+    test "returns sessions for the provider's program ordered by date and start time" do
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "Judo",
+        provider_id: provider_id,
+        session_date: ~D[2026-05-02],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: :scheduled
+      })
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "Judo",
+        provider_id: provider_id,
+        session_date: ~D[2026-05-01],
+        start_time: ~T[15:00:00],
+        end_time: ~T[16:00:00],
+        status: :scheduled
+      })
+
+      [first, second] = ListProgramSessions.run(provider_id, program_id)
+
+      assert %SessionDetail{session_date: ~D[2026-05-01]} = first
+      assert %SessionDetail{session_date: ~D[2026-05-02]} = second
+    end
+
+    test "returns [] when the program has no sessions" do
+      assert [] == ListProgramSessions.run(Ecto.UUID.generate(), Ecto.UUID.generate())
+    end
+
+    test "does not leak sessions across providers" do
+      program_id = Ecto.UUID.generate()
+      mine = Ecto.UUID.generate()
+      theirs = Ecto.UUID.generate()
+
+      insert_row(%{
+        session_id: Ecto.UUID.generate(),
+        program_id: program_id,
+        program_title: "Judo",
+        provider_id: theirs,
+        session_date: ~D[2026-05-01],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: :scheduled
+      })
+
+      assert [] == ListProgramSessions.run(mine, program_id)
+    end
+  end
+
+  defp insert_row(attrs) do
+    %ProviderSessionDetailSchema{}
+    |> Ecto.Changeset.change(attrs)
+    |> Repo.insert!()
+  end
+end

--- a/test/klass_hero_web/components/participation_components_test.exs
+++ b/test/klass_hero_web/components/participation_components_test.exs
@@ -1,0 +1,21 @@
+defmodule KlassHeroWeb.ParticipationComponentsTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHeroWeb.ParticipationComponents
+
+  describe "participation_status/1" do
+    test "renders :cancelled with red badge and x-circle icon" do
+      html =
+        render_component(&ParticipationComponents.participation_status/1,
+          status: :cancelled,
+          size: :sm
+        )
+
+      assert html =~ "bg-red-100"
+      assert html =~ "hero-x-circle"
+      assert html =~ "Cancelled"
+    end
+  end
+end

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -1,0 +1,59 @@
+defmodule KlassHeroWeb.ProviderComponentsTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionDetail
+
+  describe "sessions_modal/1" do
+    test "renders the provided sessions in order" do
+      modal = %{
+        program_id: "prog-1",
+        program_title: "Judo",
+        sessions: [
+          %SessionDetail{
+            session_id: "s-1",
+            program_id: "prog-1",
+            provider_id: "prv-1",
+            session_date: ~D[2026-05-01],
+            start_time: ~T[15:00:00],
+            end_time: ~T[16:00:00],
+            status: :scheduled,
+            program_title: "Judo",
+            current_assigned_staff_name: "Alice",
+            checked_in_count: 0,
+            total_count: 0
+          },
+          %SessionDetail{
+            session_id: "s-2",
+            program_id: "prog-1",
+            provider_id: "prv-1",
+            session_date: ~D[2026-05-08],
+            start_time: ~T[15:00:00],
+            end_time: ~T[16:00:00],
+            status: :cancelled,
+            program_title: "Judo",
+            current_assigned_staff_name: nil,
+            checked_in_count: 0,
+            total_count: 0
+          }
+        ]
+      }
+
+      html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
+
+      assert html =~ "Judo"
+      assert html =~ "Alice"
+      assert html =~ "Unassigned"
+      # Cancelled row hides attendance (same-line match; dotall flag removed because the
+      # plan's `/is` regex spans across rows and fires even for a correct implementation)
+      refute html =~ ~r/0\s*\/\s*0.*cancelled/i
+    end
+
+    test "shows empty state when sessions is []" do
+      modal = %{program_id: "p", program_title: "T", sessions: []}
+      html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
+      assert html =~ "No sessions scheduled yet"
+    end
+  end
+end

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -5,6 +5,31 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
 
   alias KlassHero.Provider.Domain.ReadModels.SessionDetail
 
+  describe "programs_table/1" do
+    test "renders a Sessions button per row" do
+      program = %{
+        id: "prog-1",
+        name: "Judo",
+        category: "Sports",
+        price: "120",
+        assigned_staff: nil,
+        status: :active,
+        enrolled: 5,
+        capacity: 10
+      }
+
+      html =
+        render_component(&KlassHeroWeb.ProviderComponents.programs_table/1,
+          programs: [{"programs-prog-1", program}],
+          staff_options: [%{value: "all", label: "All Staff"}]
+        )
+
+      assert html =~ "phx-click=\"view_sessions\""
+      assert html =~ "phx-value-program-id=\"prog-1\""
+      assert html =~ ~s|aria-label="View sessions"|
+    end
+  end
+
   describe "sessions_modal/1" do
     test "renders the provided sessions in order" do
       modal = %{

--- a/test/klass_hero_web/live/provider/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_live_test.exs
@@ -3,9 +3,12 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.BulkEnrollmentInviteRepository
   alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramListingSchema
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
   alias KlassHero.ProviderFixtures
+  alias KlassHero.Repo
 
   setup :register_and_log_in_provider
 
@@ -43,6 +46,43 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
       updated_at: program.updated_at || now
     })
     |> KlassHero.Repo.insert!()
+
+    program
+  end
+
+  # Trigger: sessions modal reads from provider_session_details (event-driven projection)
+  # Why: projections are disabled in the test env (start_projections: false); we start
+  #      a per-test named projection, grant it sandbox access, then rebuild from the
+  #      write tables — the same path the supervisor uses in non-test envs.
+  # Outcome: read table converges to the write-table state so ListProgramSessions
+  #          returns the inserted session.
+  defp seed_program_with_session!(provider, attrs) do
+    attrs_map = Map.new(attrs)
+    title = Map.get(attrs_map, :title, "Test Program")
+
+    program = insert_program_with_listing(provider_id: provider.id, title: title)
+
+    KlassHero.Factory.insert(:program_session_schema,
+      program_id: program.id,
+      session_date: ~D[2026-05-01],
+      start_time: ~T[15:00:00],
+      end_time: ~T[16:00:00],
+      status: "scheduled"
+    )
+
+    name = :"provider_session_details_#{System.unique_integer([:positive])}"
+    pid = start_supervised!({ProviderSessionDetails, name: name})
+    # Trigger: the GenServer's handle_continue/handle_call callbacks run in its
+    #          own process, which the Ecto sandbox doesn't own by default (async
+    #          test connection is owned by the test pid).
+    # Why: grant the projection access to the same checked-out connection so its
+    #      bootstrap query can see the write rows we just inserted. The initial
+    #      handle_continue(:bootstrap) may race ahead of this allow and fail —
+    #      the projection self-heals via :retry_bootstrap after 1s, but we also
+    #      force a synchronous rebuild below to avoid that wait.
+    # Outcome: the projection can read from and write to the test's sandboxed DB.
+    :ok = Sandbox.allow(Repo, self(), pid)
+    :ok = ProviderSessionDetails.rebuild(name)
 
     program
   end
@@ -533,6 +573,27 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
 
       view |> element("button[phx-click=close_roster]") |> render_click()
       refute has_element?(view, "#roster-modal")
+    end
+  end
+
+  describe "sessions modal" do
+    test "clicking Sessions opens the modal with the program's sessions", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = seed_program_with_session!(provider, title: "Judo")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view
+      |> element(~s|button[phx-click="view_sessions"][phx-value-program-id="#{program.id}"]|)
+      |> render_click()
+
+      assert has_element?(view, "#sessions-modal")
+      assert render(view) =~ "Judo"
+
+      view |> element("#sessions-modal button[phx-click='close_sessions']") |> render_click()
+      refute has_element?(view, "#sessions-modal")
     end
   end
 


### PR DESCRIPTION
## Summary
- New `ProviderSessionDetails` projection in the Provider context, subscribed to Participation + Provider integration events (session_created, session_cancelled, session_started/completed, staff_member_assigned/unassigned, roster_seeded, child_checked_in/out).
- Sessions button + modal on provider dashboard showing date/time, assigned staff, cover (reserved), attendance counts, and status per session for the selected program.
- Extended `participation_status` schema with `:cancelled` variant; added `session_cancelled` integration event (promoted from domain event so the Provider projection can react to it).

Closes #373.

## Review Focus
- **Projection event handlers** — idempotency and ordering behavior documented in `docs/contexts/provider/specs/per-session-projection.md`. Two bugs caught during review and fixed: `fix: preserve evolved state on session_created replay` (0f47adc1) and `fix: warn when status transition targets unknown session` (1f9b5220).
- **Bootstrap cross-context read** — `BootstrapProviderSessionDetails` reads Participation write tables directly via SQL during a one-time bootstrap. This is acknowledged in the spec; if boundary-checker flags it, the fallback is to add per-context bootstrap helpers (deferred as out-of-scope for this PR).
- **Staff reassignment scheduled-only rule** — staff_member_assigned / unassigned updates only apply to sessions in `:scheduled` status (enforced by the projection and covered by tests).

## Test Plan
- [x] `mix precommit` green locally
- [x] Projection unit tests (session_created replay, active-staff resolution, status transitions, attendance counters, staff assignment)
- [x] Bootstrap tests (reads from write tables, seeds read model)
- [x] Repository + use-case tests (`ListProgramSessions` query)
- [x] Component tests (sessions_modal rendering)
- [x] LiveView tests (Sessions button + modal wiring on provider dashboard)
- [x] `/review-architecture` passed (Task 20) with only two known-mitigated findings below
- [ ] Manual smoke on dev: create a session, cancel a session, check-in a child → modal reflects each change

## Known Pre-Existing Concerns (not introduced by this PR)
- **Cross-context bootstrap SQL** — acknowledged in the spec under "Trade-offs". If we add more projections that bootstrap cross-context, we should build a shared bootstrap-read port.
- **Concurrency flake in `critical_event_handler_registry_test.exs`** — pre-existing intermittent failure, unrelated to this PR.

## Follow-ups
- Migrate `list_admin_sessions/1` to the same projection (separate ticket).
- Implement cover-provider domain support (sub-issue of #373) — the modal reserves a slot for this.