### PR TITLE
feat: optional checkout + edit-after-check-in on attendance roster

### DIFF
--- a/lib/klass_hero/participation/application/commands/correct_attendance.ex
+++ b/lib/klass_hero/participation/application/commands/correct_attendance.ex
@@ -1,10 +1,16 @@
 defmodule KlassHero.Participation.Application.Commands.CorrectAttendance do
   @moduledoc """
-  Use case for admin corrections to attendance records.
+  Use case for correcting an attendance record.
 
-  Allows admins to change status and/or check-in/check-out times on a
-  participation record. Requires a reason that is appended (not replaced)
-  to the appropriate notes field.
+  Two callers are supported via `:actor_role`:
+
+  - `:admin` (default) — requires a `:reason`, which is appended to the
+    appropriate notes field with an `[Admin correction]` prefix. Preserves
+    the legacy admin behaviour.
+
+  - `:provider` / `:staff` — `:reason` is optional. Notes the caller supplied
+    via `:check_in_notes` / `:check_out_notes` replace the existing notes
+    on the record (the edit *is* the audit trail; `updated_at` records when).
   """
 
   alias KlassHero.Participation.Domain.Models.ParticipationRecord
@@ -18,73 +24,93 @@ defmodule KlassHero.Participation.Application.Commands.CorrectAttendance do
                               [:participation, :for_storing_participation_records]
                             )
 
+  @type actor_role :: :admin | :provider | :staff
+
   @type params :: %{
           required(:record_id) => String.t(),
-          required(:reason) => String.t(),
+          optional(:actor_role) => actor_role(),
+          optional(:reason) => String.t(),
           optional(:status) => ParticipationRecord.status(),
           optional(:check_in_at) => DateTime.t(),
-          optional(:check_out_at) => DateTime.t()
+          optional(:check_out_at) => DateTime.t(),
+          optional(:check_in_notes) => String.t(),
+          optional(:check_out_notes) => String.t()
         }
 
   @type result :: {:ok, ParticipationRecord.t()} | {:error, atom()}
 
   @spec execute(params()) :: result()
-  def execute(%{record_id: record_id, reason: reason} = params) do
-    with :ok <- validate_reason(reason),
-         correction_attrs = build_correction_attrs(params),
+  def execute(%{record_id: record_id} = params) do
+    actor_role = Map.get(params, :actor_role, :admin)
+
+    with :ok <- validate_reason(actor_role, params),
          {:ok, record} <- @participation_reader.get_by_id(record_id),
+         correction_attrs = build_correction_attrs(actor_role, record, params),
          {:ok, corrected} <- ParticipationRecord.admin_correct(record, correction_attrs) do
-      corrected_with_notes = append_correction_reason(corrected, record, params)
-      @participation_repository.update(corrected_with_notes)
+      @participation_repository.update(corrected)
     end
   end
 
-  def execute(%{record_id: _record_id}), do: {:error, :reason_required}
-
-  defp validate_reason(reason) when is_binary(reason) do
+  defp validate_reason(:admin, %{reason: reason}) when is_binary(reason) do
     if String.trim(reason) == "", do: {:error, :reason_required}, else: :ok
   end
 
-  defp validate_reason(_), do: {:error, :reason_required}
+  defp validate_reason(:admin, _params), do: {:error, :reason_required}
+  defp validate_reason(_role, _params), do: :ok
 
-  defp build_correction_attrs(params) do
+  defp build_correction_attrs(:admin, record, params) do
+    params
+    |> base_correction_attrs()
+    |> apply_admin_reason_notes(record, params)
+  end
+
+  defp build_correction_attrs(role, _record, params) when role in [:provider, :staff] do
+    notes =
+      params
+      |> Map.take([:check_in_notes, :check_out_notes])
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+
+    Map.merge(base_correction_attrs(params), notes)
+  end
+
+  defp base_correction_attrs(params) do
     params
     |> Map.take([:status, :check_in_at, :check_out_at])
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
     |> Map.new()
   end
 
-  # Trigger: check_in_at was changed
-  # Why: correction reason belongs alongside the data that was corrected
-  # Outcome: reason appended to check_in_notes
-  defp append_correction_reason(corrected, original, %{reason: reason} = params) do
-    note = "[Admin correction] #{String.trim(reason)}"
+  # Admin-only: append the supplied reason to the field whose change motivated it.
+  # Time correction → check-in/out notes alongside the corrected time.
+  # Status correction → check-in notes (status changes always start there).
+  defp apply_admin_reason_notes(attrs, record, %{reason: reason}) when is_binary(reason) do
+    trimmed = String.trim(reason)
 
     cond do
-      Map.has_key?(params, :check_in_at) and params.check_in_at != original.check_in_at ->
-        append_to_field(corrected, :check_in_notes, note)
+      Map.has_key?(attrs, :check_in_at) and attrs.check_in_at != record.check_in_at ->
+        Map.put(attrs, :check_in_notes, append_admin_note(record.check_in_notes, trimmed))
 
-      Map.has_key?(params, :check_out_at) and params.check_out_at != original.check_out_at ->
-        append_to_field(corrected, :check_out_notes, note)
+      Map.has_key?(attrs, :check_out_at) and attrs.check_out_at != record.check_out_at ->
+        Map.put(attrs, :check_out_notes, append_admin_note(record.check_out_notes, trimmed))
 
-      Map.has_key?(params, :status) and params.status != original.status ->
-        append_to_field(corrected, :check_in_notes, note)
+      Map.has_key?(attrs, :status) and attrs.status != record.status ->
+        Map.put(attrs, :check_in_notes, append_admin_note(record.check_in_notes, trimmed))
 
       true ->
-        corrected
+        attrs
     end
   end
 
-  defp append_to_field(record, field, note) do
-    existing = Map.get(record, field)
+  defp apply_admin_reason_notes(attrs, _record, _params), do: attrs
 
-    new_value =
-      case existing do
-        nil -> note
-        "" -> note
-        existing -> "#{existing} | #{note}"
-      end
+  defp append_admin_note(existing, reason) do
+    note = "[Admin correction] #{reason}"
 
-    Map.put(record, field, new_value)
+    case existing do
+      nil -> note
+      "" -> note
+      existing -> "#{existing} | #{note}"
+    end
   end
 end

--- a/lib/klass_hero/participation/domain/models/participation_record.ex
+++ b/lib/klass_hero/participation/domain/models/participation_record.ex
@@ -228,7 +228,13 @@ defmodule KlassHero.Participation.Domain.Models.ParticipationRecord do
       (Map.has_key?(attrs, :check_in_at) and attrs.check_in_at != record.check_in_at) or
         (Map.has_key?(attrs, :check_out_at) and attrs.check_out_at != record.check_out_at)
 
-    if has_status_change or has_time_change, do: :ok, else: {:error, :no_changes}
+    has_notes_change =
+      (Map.has_key?(attrs, :check_in_notes) and attrs.check_in_notes != record.check_in_notes) or
+        (Map.has_key?(attrs, :check_out_notes) and attrs.check_out_notes != record.check_out_notes)
+
+    if has_status_change or has_time_change or has_notes_change,
+      do: :ok,
+      else: {:error, :no_changes}
   end
 
   defp validate_status(%{status: status}) when status not in @valid_statuses, do: {:error, :invalid_status}
@@ -256,6 +262,8 @@ defmodule KlassHero.Participation.Domain.Models.ParticipationRecord do
     |> maybe_update(:check_in_at, attrs)
     |> maybe_update(:check_out_at, attrs)
     |> clear_downstream_fields(attrs)
+    |> maybe_update(:check_in_notes, attrs)
+    |> maybe_update(:check_out_notes, attrs)
   end
 
   defp maybe_update(record, field, attrs) do

--- a/lib/klass_hero_web/components/participation_components.ex
+++ b/lib/klass_hero_web/components/participation_components.ex
@@ -554,6 +554,86 @@ defmodule KlassHeroWeb.ParticipationComponents do
   end
 
   @doc """
+  Inline edit form for a participation record (provider/staff).
+
+  Lets the caller patch the record's primary notes field and, when the child
+  hasn't departed yet, optionally record a departure time. Submits the
+  `submit_edit` event with the form values; the LiveView wires that to
+  `Participation.correct_attendance/1` with the appropriate `actor_role`.
+
+  ## Examples
+
+      <.edit_record_form
+        form={@edit_forms[record.id]}
+        record={record}
+      />
+  """
+  attr :form, Form, required: true, doc: "Form struct from to_form/2"
+  attr :record, :map, required: true, doc: "Participation record being edited"
+
+  def edit_record_form(assigns) do
+    ~H"""
+    <div class="mt-4 border-t border-hero-grey-200 pt-4" id={"edit-form-#{@record.id}"}>
+      <.form
+        for={@form}
+        id={"edit-record-form-#{@record.id}"}
+        phx-change="update_edit_form"
+        phx-submit="submit_edit"
+        phx-value-id={@record.id}
+      >
+        <div class="space-y-3">
+          <.input
+            field={@form[:notes]}
+            type="textarea"
+            label={edit_notes_label(@record)}
+            placeholder={gettext("Update the note for this child (e.g. clarify what happened)")}
+            rows="3"
+          />
+
+          <%= if is_nil(@record.check_out_at) do %>
+            <.input
+              field={@form[:check_out_at]}
+              type="datetime-local"
+              label={gettext("Record departure time (optional)")}
+            />
+            <p class="text-xs text-hero-grey-500 -mt-2">
+              {gettext("Leave blank to keep this child marked as present.")}
+            </p>
+          <% end %>
+
+          <div class="flex gap-2 flex-wrap">
+            <button
+              type="submit"
+              class={[
+                "flex-1 px-4 py-2 bg-hero-blue-600 text-white font-medium hover:bg-hero-blue-700",
+                "focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                Theme.rounded(:md),
+                Theme.transition(:normal)
+              ]}
+            >
+              {gettext("Save changes")}
+            </button>
+            <button
+              type="button"
+              phx-click="cancel_edit"
+              phx-value-id={@record.id}
+              class={[
+                "px-4 py-2 bg-white text-hero-black-100 font-medium border border-hero-grey-300",
+                "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                Theme.rounded(:md),
+                Theme.transition(:normal)
+              ]}
+            >
+              {gettext("Cancel")}
+            </button>
+          </div>
+        </div>
+      </.form>
+    </div>
+    """
+  end
+
+  @doc """
   Renders a list of approved behavioral notes for a child.
 
   ## Examples
@@ -730,8 +810,8 @@ defmodule KlassHeroWeb.ParticipationComponents do
   defp status_label(:scheduled), do: gettext("Scheduled")
   defp status_label(:in_progress), do: gettext("In Progress")
   defp status_label(:completed), do: gettext("Completed")
-  defp status_label(:checked_in), do: gettext("Checked In")
-  defp status_label(:checked_out), do: gettext("Checked Out")
+  defp status_label(:checked_in), do: gettext("Present")
+  defp status_label(:checked_out), do: gettext("Departed")
   defp status_label(:absent), do: gettext("Absent")
   defp status_label(:expected), do: gettext("Expected")
   defp status_label(:cancelled), do: gettext("Cancelled")
@@ -751,4 +831,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
   defp note_status_label(:pending_approval), do: gettext("Pending Review")
   defp note_status_label(:approved), do: gettext("Approved")
   defp note_status_label(:rejected), do: gettext("Rejected")
+
+  defp edit_notes_label(%{check_out_at: %DateTime{}}), do: gettext("Departure notes")
+  defp edit_notes_label(_record), do: gettext("Notes")
 end

--- a/lib/klass_hero_web/helpers/participation_edit_helpers.ex
+++ b/lib/klass_hero_web/helpers/participation_edit_helpers.ex
@@ -21,6 +21,10 @@ defmodule KlassHeroWeb.Helpers.ParticipationEditHelpers do
   @spec default_edit_notes(ParticipationRecord.t() | map()) :: String.t()
   def default_edit_notes(%{check_out_at: %DateTime{}, check_out_notes: notes}) when is_binary(notes), do: notes
 
+  # Departed but no check-out note yet — start the textarea empty so we don't
+  # silently copy `check_in_notes` into `check_out_notes` on save.
+  def default_edit_notes(%{check_out_at: %DateTime{}}), do: ""
+
   def default_edit_notes(%{check_in_notes: notes}) when is_binary(notes), do: notes
   def default_edit_notes(_), do: ""
 

--- a/lib/klass_hero_web/helpers/participation_edit_helpers.ex
+++ b/lib/klass_hero_web/helpers/participation_edit_helpers.ex
@@ -1,0 +1,70 @@
+defmodule KlassHeroWeb.Helpers.ParticipationEditHelpers do
+  @moduledoc """
+  Shared helpers for the inline "edit participation record" form used by the
+  provider and staff roster LiveViews.
+
+  Translates form values (notes + optional `datetime-local` departure time)
+  into a `KlassHero.Participation.correct_attendance/1` command tagged with
+  the appropriate `:actor_role`.
+  """
+
+  alias KlassHero.Participation.Domain.Models.ParticipationRecord
+
+  @type role :: :provider | :staff
+
+  @doc """
+  Pre-fill text for the edit form's notes textarea.
+
+  Falls back to whichever notes field the edit will write to:
+  `check_out_notes` once the child has departed, otherwise `check_in_notes`.
+  """
+  @spec default_edit_notes(ParticipationRecord.t() | map()) :: String.t()
+  def default_edit_notes(%{check_out_at: %DateTime{}, check_out_notes: notes}) when is_binary(notes), do: notes
+
+  def default_edit_notes(%{check_in_notes: notes}) when is_binary(notes), do: notes
+  def default_edit_notes(_), do: ""
+
+  @doc """
+  Build a `correct_attendance` command from raw edit-form params.
+
+  - If a departure time is supplied AND the child has not yet departed,
+    a retroactive check-out is recorded (status flip + check_out_at + notes).
+  - If the child has already departed, notes go into `check_out_notes`.
+  - Otherwise notes go into `check_in_notes`.
+  """
+  @spec build_edit_correction(ParticipationRecord.t() | map(), map(), role()) ::
+          {:ok, map()} | {:error, :invalid_datetime}
+  def build_edit_correction(record, params, role) when role in [:provider, :staff] do
+    notes = params |> Map.get("notes", "") |> to_string()
+    check_out_at_input = params |> Map.get("check_out_at", "") |> to_string() |> String.trim()
+    base = %{record_id: record.id, actor_role: role}
+
+    cond do
+      check_out_at_input != "" and is_nil(record.check_out_at) ->
+        with {:ok, dt} <- parse_datetime_local(check_out_at_input) do
+          {:ok,
+           base
+           |> Map.put(:status, :checked_out)
+           |> Map.put(:check_out_at, dt)
+           |> Map.put(:check_out_notes, notes)}
+        end
+
+      not is_nil(record.check_out_at) ->
+        {:ok, Map.put(base, :check_out_notes, notes)}
+
+      true ->
+        {:ok, Map.put(base, :check_in_notes, notes)}
+    end
+  end
+
+  # datetime-local inputs submit "YYYY-MM-DDTHH:MM" (no seconds, no zone)
+  @spec parse_datetime_local(String.t()) :: {:ok, DateTime.t()} | {:error, :invalid_datetime}
+  defp parse_datetime_local(input) do
+    normalized = if byte_size(input) == 16, do: input <> ":00", else: input
+
+    case NaiveDateTime.from_iso8601(normalized) do
+      {:ok, ndt} -> {:ok, DateTime.from_naive!(ndt, "Etc/UTC")}
+      _ -> {:error, :invalid_datetime}
+    end
+  end
+end

--- a/lib/klass_hero_web/live/provider/participation_live.ex
+++ b/lib/klass_hero_web/live/provider/participation_live.ex
@@ -3,6 +3,7 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
 
   alias KlassHero.Participation
   alias KlassHero.Shared.Domain.Events.DomainEvent
+  alias KlassHeroWeb.Helpers.ParticipationEditHelpers
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -28,6 +29,8 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
       |> assign(:note_forms, %{})
       |> assign(:revision_form_expanded, nil)
       |> assign(:revision_forms, %{})
+      |> assign(:edit_form_expanded, nil)
+      |> assign(:edit_forms, %{})
       |> assign(:provider_notes, %{})
       |> assign(:record_note_map, %{})
 
@@ -256,6 +259,74 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
         )
 
         {:noreply, put_flash(socket, :error, gettext("Failed to resubmit note"))}
+    end
+  end
+
+  @impl true
+  def handle_event("expand_edit_form", %{"id" => record_id}, socket) do
+    case find_participation_record(socket, record_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, gettext("Record not found"))}
+
+      record ->
+        form =
+          to_form(
+            %{"notes" => ParticipationEditHelpers.default_edit_notes(record), "check_out_at" => ""},
+            as: "edit"
+          )
+
+        {:noreply,
+         socket
+         |> assign(:edit_form_expanded, record_id)
+         |> assign(:edit_forms, Map.put(socket.assigns.edit_forms, record_id, form))}
+    end
+  end
+
+  @impl true
+  def handle_event("cancel_edit", %{"id" => record_id}, socket) do
+    {:noreply,
+     socket
+     |> assign(:edit_form_expanded, nil)
+     |> assign(:edit_forms, Map.delete(socket.assigns.edit_forms, record_id))}
+  end
+
+  @impl true
+  def handle_event("update_edit_form", %{"id" => record_id, "edit" => params}, socket) do
+    form = to_form(params, as: "edit")
+
+    {:noreply, assign(socket, :edit_forms, Map.put(socket.assigns.edit_forms, record_id, form))}
+  end
+
+  @impl true
+  def handle_event("submit_edit", %{"id" => record_id, "edit" => params}, socket) do
+    record = find_participation_record(socket, record_id)
+
+    with {:record, record} when not is_nil(record) <- {:record, record},
+         {:ok, correction} <- ParticipationEditHelpers.build_edit_correction(record, params, :provider),
+         {:ok, _} <- Participation.correct_attendance(correction) do
+      {:noreply,
+       socket
+       |> put_flash(:info, gettext("Record updated"))
+       |> assign(:edit_form_expanded, nil)
+       |> assign(:edit_forms, Map.delete(socket.assigns.edit_forms, record_id))
+       |> load_session_data()}
+    else
+      {:record, nil} ->
+        {:noreply, put_flash(socket, :error, gettext("Record not found"))}
+
+      {:error, :invalid_datetime} ->
+        {:noreply, put_flash(socket, :error, gettext("Departure time is not a valid date and time"))}
+
+      {:error, :no_changes} ->
+        {:noreply, put_flash(socket, :info, gettext("Nothing to update"))}
+
+      {:error, reason} ->
+        Logger.error("[ParticipationLive.submit_edit] Failed",
+          record_id: record_id,
+          reason: inspect(reason)
+        )
+
+        {:noreply, put_flash(socket, :error, gettext("Failed to update record"))}
     end
   end
 

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -33,26 +33,50 @@
       >
         <:actions :let={record}>
           <%= cond do %>
-            <%!-- Checked In: Show "Check Out" button (hide when form expanded) --%>
-            <% record.status == :checked_in && @checkout_form_expanded != to_string(record.id) -> %>
+            <% record.status == :checked_in && @edit_form_expanded != to_string(record.id) && @checkout_form_expanded != to_string(record.id) -> %>
               <button
-                phx-click="expand_checkout_form"
+                id={"edit-btn-#{record.id}"}
+                phx-click="expand_edit_form"
                 phx-value-id={record.id}
                 class={[
-                  "px-3 py-1.5 text-sm bg-blue-600 text-white font-medium hover:bg-blue-700",
-                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:md),
                   Theme.transition(:normal)
                 ]}
               >
-                {gettext("Check Out")}
+                <.icon name="hero-pencil-square-mini" class="w-4 h-4" />
+                {gettext("Edit")}
               </button>
-              <%!-- Checked Out: Show status text --%>
-            <% record.status == :checked_out -> %>
-              <span class="px-3 py-1.5 text-sm text-gray-500">
-                {gettext("Checked Out")}
-              </span>
-              <%!-- Expected: Show Check In button --%>
+              <button
+                phx-click="expand_checkout_form"
+                phx-value-id={record.id}
+                class={[
+                  "px-3 py-1.5 text-sm bg-white text-hero-grey-700 font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                {gettext("Record departure")}
+              </button>
+            <% record.status == :checked_out && @edit_form_expanded != to_string(record.id) -> %>
+              <button
+                id={"edit-btn-#{record.id}"}
+                phx-click="expand_edit_form"
+                phx-value-id={record.id}
+                class={[
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                <.icon name="hero-pencil-square-mini" class="w-4 h-4" />
+                {gettext("Edit")}
+              </button>
+              <%!-- A form for this record is expanded — suppress row actions while editing. --%>
+            <% record.status in [:checked_in, :checked_out] -> %>
             <% true -> %>
               <button
                 phx-click="check_in"
@@ -126,6 +150,14 @@
         </:actions>
 
         <:expanded_content :let={record}>
+          <%!-- Inline edit form (notes + optional departure time) --%>
+          <%= if @edit_form_expanded == to_string(record.id) do %>
+            <.edit_record_form
+              form={Map.get(@edit_forms, to_string(record.id))}
+              record={record}
+            />
+          <% end %>
+
           <%!-- Inline note form (full-width below record row) --%>
           <%= if @note_form_expanded == to_string(record.id) do %>
             <.behavioral_note_form

--- a/lib/klass_hero_web/live/staff/staff_participation_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.ex
@@ -5,6 +5,7 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Shared.Domain.Events.DomainEvent
+  alias KlassHeroWeb.Helpers.ParticipationEditHelpers
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -30,6 +31,8 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
       |> assign(:checkout_forms, %{})
       |> assign(:note_form_expanded, nil)
       |> assign(:note_forms, %{})
+      |> assign(:edit_form_expanded, nil)
+      |> assign(:edit_forms, %{})
       |> assign(:record_note_map, %{})
 
     if connected?(socket) do
@@ -195,6 +198,74 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
         )
 
         {:noreply, put_flash(socket, :error, gettext("Failed to submit note"))}
+    end
+  end
+
+  @impl true
+  def handle_event("expand_edit_form", %{"id" => record_id}, socket) do
+    case find_participation_record(socket, record_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, gettext("Record not found"))}
+
+      record ->
+        form =
+          to_form(
+            %{"notes" => ParticipationEditHelpers.default_edit_notes(record), "check_out_at" => ""},
+            as: "edit"
+          )
+
+        {:noreply,
+         socket
+         |> assign(:edit_form_expanded, record_id)
+         |> assign(:edit_forms, Map.put(socket.assigns.edit_forms, record_id, form))}
+    end
+  end
+
+  @impl true
+  def handle_event("cancel_edit", %{"id" => record_id}, socket) do
+    {:noreply,
+     socket
+     |> assign(:edit_form_expanded, nil)
+     |> assign(:edit_forms, Map.delete(socket.assigns.edit_forms, record_id))}
+  end
+
+  @impl true
+  def handle_event("update_edit_form", %{"id" => record_id, "edit" => params}, socket) do
+    form = to_form(params, as: "edit")
+
+    {:noreply, assign(socket, :edit_forms, Map.put(socket.assigns.edit_forms, record_id, form))}
+  end
+
+  @impl true
+  def handle_event("submit_edit", %{"id" => record_id, "edit" => params}, socket) do
+    record = find_participation_record(socket, record_id)
+
+    with {:record, record} when not is_nil(record) <- {:record, record},
+         {:ok, correction} <- ParticipationEditHelpers.build_edit_correction(record, params, :staff),
+         {:ok, _} <- Participation.correct_attendance(correction) do
+      {:noreply,
+       socket
+       |> put_flash(:info, gettext("Record updated"))
+       |> assign(:edit_form_expanded, nil)
+       |> assign(:edit_forms, Map.delete(socket.assigns.edit_forms, record_id))
+       |> load_session_data()}
+    else
+      {:record, nil} ->
+        {:noreply, put_flash(socket, :error, gettext("Record not found"))}
+
+      {:error, :invalid_datetime} ->
+        {:noreply, put_flash(socket, :error, gettext("Departure time is not a valid date and time"))}
+
+      {:error, :no_changes} ->
+        {:noreply, put_flash(socket, :info, gettext("Nothing to update"))}
+
+      {:error, reason} ->
+        Logger.error("[StaffParticipationLive.submit_edit] Failed",
+          record_id: record_id,
+          reason: inspect(reason)
+        )
+
+        {:noreply, put_flash(socket, :error, gettext("Failed to update record"))}
     end
   end
 

--- a/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
@@ -33,26 +33,50 @@
       >
         <:actions :let={record}>
           <%= cond do %>
-            <%!-- Checked In: Show "Check Out" button (hide when form expanded) --%>
-            <% record.status == :checked_in && @checkout_form_expanded != to_string(record.id) -> %>
+            <% record.status == :checked_in && @edit_form_expanded != to_string(record.id) && @checkout_form_expanded != to_string(record.id) -> %>
               <button
-                phx-click="expand_checkout_form"
+                id={"edit-btn-#{record.id}"}
+                phx-click="expand_edit_form"
                 phx-value-id={record.id}
                 class={[
-                  "px-3 py-1.5 text-sm bg-blue-600 text-white font-medium hover:bg-blue-700",
-                  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:md),
                   Theme.transition(:normal)
                 ]}
               >
-                {gettext("Check Out")}
+                <.icon name="hero-pencil-square-mini" class="w-4 h-4" />
+                {gettext("Edit")}
               </button>
-              <%!-- Checked Out: Show status text --%>
-            <% record.status == :checked_out -> %>
-              <span class="px-3 py-1.5 text-sm text-gray-500">
-                {gettext("Checked Out")}
-              </span>
-              <%!-- Expected: Show Check In button --%>
+              <button
+                phx-click="expand_checkout_form"
+                phx-value-id={record.id}
+                class={[
+                  "px-3 py-1.5 text-sm bg-white text-hero-grey-700 font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                {gettext("Record departure")}
+              </button>
+            <% record.status == :checked_out && @edit_form_expanded != to_string(record.id) -> %>
+              <button
+                id={"edit-btn-#{record.id}"}
+                phx-click="expand_edit_form"
+                phx-value-id={record.id}
+                class={[
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                <.icon name="hero-pencil-square-mini" class="w-4 h-4" />
+                {gettext("Edit")}
+              </button>
+              <%!-- A form for this record is expanded — suppress row actions while editing. --%>
+            <% record.status in [:checked_in, :checked_out] -> %>
             <% true -> %>
               <button
                 phx-click="check_in"
@@ -100,6 +124,14 @@
         </:actions>
 
         <:expanded_content :let={record}>
+          <%!-- Inline edit form (notes + optional departure time) --%>
+          <%= if @edit_form_expanded == to_string(record.id) do %>
+            <.edit_record_form
+              form={Map.get(@edit_forms, to_string(record.id))}
+              record={record}
+            />
+          <% end %>
+
           <%!-- Inline note form (full-width below record row) --%>
           <%= if @note_form_expanded == to_string(record.id) do %>
             <.behavioral_note_form

--- a/test/klass_hero/participation/application/commands/correct_attendance_test.exs
+++ b/test/klass_hero/participation/application/commands/correct_attendance_test.exs
@@ -160,5 +160,58 @@ defmodule KlassHero.Participation.Application.Commands.CorrectAttendanceTest do
       assert corrected.check_in_notes == "[Admin correction] Wrong time recorded"
       refute corrected.check_in_notes =~ " | "
     end
+
+    for role <- [:provider, :staff] do
+      test "actor_role #{role}: patches check_in_notes without requiring a reason", %{
+        record: record
+      } do
+        assert {:ok, corrected} =
+                 Participation.correct_attendance(%{
+                   record_id: record.id,
+                   actor_role: unquote(role),
+                   check_in_notes: "Updated by #{unquote(role)}"
+                 })
+
+        assert corrected.check_in_notes == "Updated by #{unquote(role)}"
+        refute corrected.check_in_notes =~ "[Admin correction]"
+      end
+
+      test "actor_role #{role}: records a retroactive check-out time and notes", %{
+        record: record
+      } do
+        assert {:ok, corrected} =
+                 Participation.correct_attendance(%{
+                   record_id: record.id,
+                   actor_role: unquote(role),
+                   status: :checked_out,
+                   check_out_at: ~U[2026-03-13 10:30:00Z],
+                   check_out_notes: "Picked up by mom"
+                 })
+
+        assert corrected.status == :checked_out
+        assert corrected.check_out_at == ~U[2026-03-13 10:30:00Z]
+        assert corrected.check_out_notes == "Picked up by mom"
+        refute (corrected.check_out_notes || "") =~ "[Admin correction]"
+      end
+
+      test "actor_role #{role}: rejects edits with no actual changes", %{record: record} do
+        assert {:error, :no_changes} =
+                 Participation.correct_attendance(%{
+                   record_id: record.id,
+                   actor_role: unquote(role)
+                 })
+      end
+
+      test "actor_role #{role}: treats notes-equal-to-existing as no_changes", %{
+        record: record
+      } do
+        assert {:error, :no_changes} =
+                 Participation.correct_attendance(%{
+                   record_id: record.id,
+                   actor_role: unquote(role),
+                   check_in_notes: record.check_in_notes
+                 })
+      end
+    end
   end
 end

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -676,6 +676,32 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
       assert html =~ "Departed"
     end
 
+    # Regression for PR #709 review (Copilot): when a record is :checked_out but
+    # check_out_notes is nil (record_check_out accepts optional notes), the edit
+    # form must NOT pre-fill the textarea with check_in_notes — that value
+    # would silently get copied into check_out_notes on save.
+    test "edit form starts empty when record is checked-out without check-out notes",
+         %{conn: conn, session: session, record: record, user: user} do
+      record
+      |> Ecto.Changeset.change(check_in_notes: "Brought hat and gloves")
+      |> KlassHero.Repo.update!()
+
+      checked_in = check_in!(record, user)
+
+      {:ok, _} =
+        KlassHero.Participation.record_check_out(%{
+          record_id: checked_in.id,
+          checked_out_by: user.id
+          # no :notes — leaves check_out_notes as nil
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+      view |> element("#edit-btn-#{record.id}") |> render_click()
+
+      html = render(view)
+      refute html =~ "Brought hat and gloves"
+    end
+
     test "cancel_edit collapses the form without changes", %{
       conn: conn,
       session: session,

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -549,4 +549,150 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
       refute has_element?(view, "#checkout-form-#{record.id}")
     end
   end
+
+  describe "edit-after-check-in flow" do
+    setup [:create_session_with_child]
+
+    defp check_in!(record, user) do
+      {:ok, updated} =
+        KlassHero.Participation.record_check_in(%{
+          record_id: record.id,
+          checked_in_by: user.id
+        })
+
+      updated
+    end
+
+    test "shows Edit and 'Record departure' buttons for a checked-in child", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      _checked_in = check_in!(record, user)
+      {:ok, view, html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      assert has_element?(view, "#edit-btn-#{record.id}")
+
+      assert has_element?(
+               view,
+               "button[phx-click='expand_checkout_form'][phx-value-id='#{record.id}']",
+               "Record departure"
+             )
+
+      # Status pill flipped to "Present" rather than the prior "Checked In" wording.
+      assert html =~ "Present"
+      refute html =~ "Checked In"
+    end
+
+    test "expand_edit_form opens the inline edit form pre-filled with check-in notes", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      _checked_in = check_in!(record, user)
+
+      # Seed an existing check-in note so we can confirm pre-fill behaviour.
+      record
+      |> Ecto.Changeset.change(check_in_notes: "Forgot raincoat")
+      |> KlassHero.Repo.update!()
+
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view
+      |> element("#edit-btn-#{record.id}")
+      |> render_click()
+
+      assert has_element?(view, "#edit-record-form-#{record.id}")
+      html = render(view)
+      assert html =~ "Forgot raincoat"
+    end
+
+    test "submitting notes-only update calls correct_attendance and updates the row", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      _checked_in = check_in!(record, user)
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#edit-btn-#{record.id}") |> render_click()
+
+      view
+      |> form("#edit-record-form-#{record.id}", edit: %{notes: "Was a bit shy today"})
+      |> render_submit()
+
+      assert KlassHero.Repo.get!(ParticipationRecordSchema, record.id).check_in_notes ==
+               "Was a bit shy today"
+
+      # Form collapsed after successful submit.
+      refute has_element?(view, "#edit-record-form-#{record.id}")
+    end
+
+    test "submitting departure time records check-out via correct_attendance", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      _checked_in = check_in!(record, user)
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#edit-btn-#{record.id}") |> render_click()
+
+      view
+      |> form("#edit-record-form-#{record.id}",
+        edit: %{notes: "Picked up by dad", check_out_at: "2026-04-20T15:30"}
+      )
+      |> render_submit()
+
+      reloaded = KlassHero.Repo.get!(ParticipationRecordSchema, record.id)
+      assert reloaded.status == :checked_out
+      assert reloaded.check_out_at == ~U[2026-04-20 15:30:00Z]
+      assert reloaded.check_out_notes == "Picked up by dad"
+    end
+
+    test "Edit button is available for already-checked-out rows", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      checked_in = check_in!(record, user)
+
+      {:ok, _checked_out} =
+        KlassHero.Participation.record_check_out(%{
+          record_id: checked_in.id,
+          checked_out_by: user.id,
+          notes: "left at 3pm"
+        })
+
+      {:ok, view, html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      assert has_element?(view, "#edit-btn-#{record.id}")
+      # Pill reads "Departed" once the child has gone.
+      assert html =~ "Departed"
+    end
+
+    test "cancel_edit collapses the form without changes", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      _checked_in = check_in!(record, user)
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#edit-btn-#{record.id}") |> render_click()
+      assert has_element?(view, "#edit-record-form-#{record.id}")
+
+      view
+      |> element("button[phx-click='cancel_edit'][phx-value-id='#{record.id}']")
+      |> render_click()
+
+      refute has_element?(view, "#edit-record-form-#{record.id}")
+    end
+  end
 end

--- a/test/klass_hero_web/live/staff/staff_participation_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_participation_live_test.exs
@@ -4,6 +4,8 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Participation.Adapters.Driven.Persistence.Schemas.ParticipationRecordSchema
+
   describe "authentication and authorization" do
     test "redirects unauthenticated users to login", %{conn: conn} do
       session_id = Ecto.UUID.generate()
@@ -137,7 +139,7 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
 
-      # Expand checkout form
+      # Expand "Record departure" form
       view
       |> element("button[phx-click='expand_checkout_form'][phx-value-id='#{record.id}']")
       |> render_click()
@@ -151,6 +153,91 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
 
       assert_flash(view, :info, "Child checked out successfully")
       refute has_element?(view, "#checkout-form-#{record.id}")
+    end
+
+    test "shows Edit and 'Record departure' buttons for a checked-in child; pill reads Present",
+         %{conn: conn, session: session, record: record, user: user} do
+      {:ok, _} =
+        KlassHero.Participation.record_check_in(%{
+          record_id: record.id,
+          checked_in_by: user.id
+        })
+
+      {:ok, view, html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      assert has_element?(view, "#edit-btn-#{record.id}")
+
+      assert has_element?(
+               view,
+               "button[phx-click='expand_checkout_form'][phx-value-id='#{record.id}']",
+               "Record departure"
+             )
+
+      assert html =~ "Present"
+      refute html =~ "Checked In"
+    end
+
+    test "submitting notes-only edit updates the check-in note", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      {:ok, _} =
+        KlassHero.Participation.record_check_in(%{
+          record_id: record.id,
+          checked_in_by: user.id
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      view |> element("#edit-btn-#{record.id}") |> render_click()
+
+      view
+      |> form("#edit-record-form-#{record.id}", edit: %{notes: "Brought a snack"})
+      |> render_submit()
+
+      reloaded =
+        KlassHero.Repo.get!(
+          ParticipationRecordSchema,
+          record.id
+        )
+
+      assert reloaded.check_in_notes == "Brought a snack"
+      refute has_element?(view, "#edit-record-form-#{record.id}")
+    end
+
+    test "submitting departure time records check-out via correct_attendance", %{
+      conn: conn,
+      session: session,
+      record: record,
+      user: user
+    } do
+      {:ok, _} =
+        KlassHero.Participation.record_check_in(%{
+          record_id: record.id,
+          checked_in_by: user.id
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      view |> element("#edit-btn-#{record.id}") |> render_click()
+
+      view
+      |> form("#edit-record-form-#{record.id}",
+        edit: %{notes: "Mum collected", check_out_at: "2026-04-20T16:15"}
+      )
+      |> render_submit()
+
+      reloaded =
+        KlassHero.Repo.get!(
+          ParticipationRecordSchema,
+          record.id
+        )
+
+      assert reloaded.status == :checked_out
+      assert reloaded.check_out_at == ~U[2026-04-20 16:15:00Z]
+      assert reloaded.check_out_notes == "Mum collected"
     end
   end
 end


### PR DESCRIPTION
Closes #693.

## Summary

- **Roster UX**: status pill renders as **"Present"** / **"Departed"** instead of the prescriptive "Checked In" / "Checked Out". The "Check Out" primary blue CTA is demoted to a ghost-styled **"Record departure"** button — it's now clearly optional.
- **New "Edit" action** on `:checked_in` and `:checked_out` rows opens an inline form (mirrors the existing checkout-form expand pattern) that lets providers and staff fix notes or record a retroactive departure time without leaving the roster.
- **Use case extension**: `Participation.correct_attendance/1` gains an optional `:actor_role` (default `:admin`, preserving the legacy contract). For `:provider` / `:staff` callers, `:reason` is optional and `:check_in_notes` / `:check_out_notes` patch the record directly without an `[Admin correction]` prefix. `ParticipationRecord.admin_correct/2` treats notes as a first-class patchable field in change-detection and post-clear application order.
- **Helpers extracted** to `lib/klass_hero_web/helpers/participation_edit_helpers.ex` so provider and staff LiveViews share a single implementation of edit-form translation logic.

## Review focus

- `lib/klass_hero/participation/application/commands/correct_attendance.ex` — the role-based branching in `validate_reason/2` and `build_correction_attrs/3`. Admin path goes through `apply_admin_reason_notes/3` (unchanged behaviour); provider/staff path is a straight pass-through of supplied notes.
- `lib/klass_hero/participation/domain/models/participation_record.ex` — `validate_has_changes/2` now counts notes changes; `apply_corrections/2` applies notes *after* `clear_downstream_fields/2` so reverting status to `:registered` doesn't wipe a freshly-supplied note.
- `lib/klass_hero_web/live/{provider,staff}/participation_live.ex` — both LiveViews delegate to the shared `ParticipationEditHelpers`. The 4 new `handle_event` clauses (`expand_edit_form`, `cancel_edit`, `update_edit_form`, `submit_edit`) mirror the existing checkout/note form lifecycle.

## Test plan

- [x] `mix precommit` — 4362 passed, 0 failures (compile w/ warnings-as-errors, format, credo high, lint_typography, full suite).
- [x] 9 admin `correct_attendance` tests preserved + 8 new `actor_role` tests added (provider/staff parameterized).
- [x] 6 new provider LiveView edit-flow tests + 3 new staff LiveView edit-flow tests.
- [x] 5-path Tidewave smoke test against real Postgres dev DB: admin reason-required, provider notes-only patch, `:no_changes` guard, retroactive checkout via compound payload, admin path still works after a provider edit.
- [x] Playwright UI test-drive on `/provider/participation/:id` (logged in as `lena.hartmann@example.com`): pill reads "Present" → click Edit → inline form expands → notes-only edit persists → notes + departure-time flips status to "Departed", preserves prior check-in note. Mobile (375×667) layout holds.

Screenshots in `.test-drive-reports/test-drive-2026-04-20-693.md` (local-only).

## Out of scope

- No status-flip back from `:checked_out` → `:checked_in` from the provider/staff edit form (admin still has that via the status dropdown).
- No bulk edit. Single-record only.
- Pre-existing seed bug at `priv/repo/seeds.exs:493` (uitest-staff user missing `:name` field) — should be filed as a separate issue; out of scope here.