### PR TITLE
feat: allow providers to manually invite individual participants

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -59,6 +59,7 @@ defmodule KlassHero.Enrollment do
     CreateEnrollment,
     DeleteInvite,
     ImportEnrollmentCsv,
+    InviteSingleParticipant,
     ResendInvite,
     SetParticipantPolicy,
     UpsertEnrollmentPolicy
@@ -81,6 +82,7 @@ defmodule KlassHero.Enrollment do
     ListProgramInvites
   }
 
+  alias KlassHero.Enrollment.Application.SingleInviteForm
   alias KlassHero.Enrollment.Domain.Services.EnrollmentClassifier
 
   # ===========================================================================
@@ -172,6 +174,42 @@ defmodule KlassHero.Enrollment do
   """
   def import_enrollment_csv(provider_id, csv_binary) when is_binary(provider_id) and is_binary(csv_binary) do
     ImportEnrollmentCsv.execute(provider_id, csv_binary)
+  end
+
+  @doc """
+  Creates a single enrollment invite from the provider's manual form.
+
+  Unlike `import_enrollment_csv/2`, the caller supplies a pre-resolved
+  `program_id` (picked from the provider's own catalog). Runs the same
+  `:bulk_invites_imported` event path with `count: 1`, so the downstream
+  email worker pipeline is reused verbatim.
+
+  Returns:
+  - `{:ok, %{invite_id: id}}` on success
+  - `{:error, :no_programs}` if the provider has no catalog entries
+  - `{:error, :duplicate}` when the same child+email is already invited
+  - `{:error, %{validation_errors: [{field, msg}]}}` for form/authorisation errors
+  """
+  def invite_single_participant(provider_id, attrs) when is_binary(provider_id) and is_map(attrs) do
+    InviteSingleParticipant.execute(provider_id, attrs)
+  end
+
+  @doc """
+  Returns a changeset for the single-invite form. The LiveView is responsible
+  for setting `:action` to `:validate` when it wants `<.input>` to render
+  errors, matching the Phoenix generator convention.
+  """
+  def change_single_invite(attrs \\ %{}) do
+    SingleInviteForm.changeset(%SingleInviteForm{}, attrs)
+  end
+
+  @doc """
+  Attaches domain-layer `[{field, msg}]` errors returned by
+  `invite_single_participant/2` onto a single-invite changeset so the web
+  layer can re-render the form without reaching into context internals.
+  """
+  def apply_single_invite_domain_errors(%Ecto.Changeset{} = changeset, field_errors) when is_list(field_errors) do
+    SingleInviteForm.apply_domain_errors(changeset, field_errors)
   end
 
   @doc """

--- a/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/bulk_enrollment_invite_repository.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/bulk_enrollment_invite_repository.ex
@@ -21,6 +21,7 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.BulkEnro
     as: Mapper
 
   alias KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.BulkEnrollmentInviteSchema
+  alias KlassHero.Enrollment.Domain.Models.BulkEnrollmentInvite
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.MapperHelpers
 
@@ -78,6 +79,40 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.BulkEnro
 
   @impl true
   @doc """
+  Inserts a single invite and returns the persisted domain struct.
+
+  Runs the same `import_changeset/2` used by `create_batch/1`, so a row that
+  passes one would pass the other. Kept separate from the batch path so
+  callers who need the created id don't pay for a `{_, index}` lookup or a
+  follow-up read.
+  """
+  def create_one(attrs) when is_map(attrs) do
+    span do
+      set_attributes("db", operation: "insert", entity: "bulk_enrollment_invite")
+
+      %BulkEnrollmentInviteSchema{}
+      |> BulkEnrollmentInviteSchema.import_changeset(attrs)
+      |> Repo.insert()
+      |> case do
+        {:ok, schema} ->
+          Logger.info("[BulkEnrollmentInvite.Repository] Single invite created",
+            invite_id: schema.id
+          )
+
+          {:ok, Mapper.to_domain(schema)}
+
+        {:error, changeset} ->
+          Logger.error("[BulkEnrollmentInvite.Repository] Single invite insert failed",
+            errors: inspect(changeset.errors)
+          )
+
+          {:error, changeset}
+      end
+    end
+  end
+
+  @impl true
+  @doc """
   Returns existing invite keys for the given program IDs.
 
   Used for duplicate detection before batch insert. Keys are
@@ -97,8 +132,28 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.BulkEnro
       |> select([i], {i.program_id, i.guardian_email, i.child_first_name, i.child_last_name})
       |> Repo.all()
       |> MapSet.new(fn {pid, email, first, last} ->
-        {pid, String.downcase(email), String.downcase(first), String.downcase(last)}
+        BulkEnrollmentInvite.dedup_key(pid, email, first, last)
       end)
+    end
+  end
+
+  @impl true
+  def invite_exists?(program_id, guardian_email, child_first_name, child_last_name)
+      when is_binary(program_id) and is_binary(guardian_email) and is_binary(child_first_name) and
+             is_binary(child_last_name) do
+    span do
+      set_attributes("db", operation: "select", entity: "bulk_enrollment_invite")
+
+      email_down = String.downcase(guardian_email)
+      first_down = String.downcase(child_first_name)
+      last_down = String.downcase(child_last_name)
+
+      BulkEnrollmentInviteSchema
+      |> where([i], i.program_id == ^program_id)
+      |> where([i], fragment("lower(?)", i.guardian_email) == ^email_down)
+      |> where([i], fragment("lower(?)", i.child_first_name) == ^first_down)
+      |> where([i], fragment("lower(?)", i.child_last_name) == ^last_down)
+      |> Repo.exists?()
     end
   end
 

--- a/lib/klass_hero/enrollment/adapters/driven/persistence/schemas/bulk_enrollment_invite_schema.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/persistence/schemas/bulk_enrollment_invite_schema.ex
@@ -11,6 +11,8 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.BulkEnrollmen
 
   import Ecto.Changeset
 
+  alias KlassHero.Enrollment.Domain.Services.InviteFieldValidations
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime]
@@ -82,19 +84,7 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.BulkEnrollmen
     schema
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
-    |> validate_length(:child_first_name, min: 1, max: 100)
-    |> validate_length(:child_last_name, min: 1, max: 100)
-    |> validate_length(:guardian_email, max: 160)
-    |> validate_format(:guardian_email, ~r/^[^@,;\s]+@[^@,;\s]+$/, message: "must be a valid email")
-    |> validate_length(:guardian_first_name, max: 100)
-    |> validate_length(:guardian_last_name, max: 100)
-    |> validate_length(:guardian2_email, max: 160)
-    |> maybe_validate_guardian2_email()
-    |> validate_length(:guardian2_first_name, max: 100)
-    |> validate_length(:guardian2_last_name, max: 100)
-    |> validate_length(:school_name, max: 255)
-    |> validate_number(:school_grade, greater_than_or_equal_to: 1, less_than_or_equal_to: 13)
-    |> validate_date_in_past(:child_date_of_birth)
+    |> InviteFieldValidations.apply()
     |> validate_inclusion(:status, @valid_statuses)
     |> unique_constraint([:program_id, :guardian_email, :child_first_name, :child_last_name],
       name: :bulk_invites_program_guardian_child_unique
@@ -123,19 +113,7 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.BulkEnrollmen
     schema
     |> cast(attrs, @import_fields)
     |> validate_required(@required_fields)
-    |> validate_length(:child_first_name, min: 1, max: 100)
-    |> validate_length(:child_last_name, min: 1, max: 100)
-    |> validate_length(:guardian_email, max: 160)
-    |> validate_format(:guardian_email, ~r/^[^@,;\s]+@[^@,;\s]+$/, message: "must be a valid email")
-    |> validate_length(:guardian_first_name, max: 100)
-    |> validate_length(:guardian_last_name, max: 100)
-    |> validate_length(:guardian2_email, max: 160)
-    |> maybe_validate_guardian2_email()
-    |> validate_length(:guardian2_first_name, max: 100)
-    |> validate_length(:guardian2_last_name, max: 100)
-    |> validate_length(:school_name, max: 255)
-    |> validate_number(:school_grade, greater_than_or_equal_to: 1, less_than_or_equal_to: 13)
-    |> validate_date_in_past(:child_date_of_birth)
+    |> InviteFieldValidations.apply()
     |> unique_constraint([:program_id, :guardian_email, :child_first_name, :child_last_name],
       name: :bulk_invites_program_guardian_child_unique
     )
@@ -159,32 +137,6 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.BulkEnrollmen
     |> unique_constraint(:invite_token)
     |> foreign_key_constraint(:enrollment_id)
     |> check_constraint(:status, name: :valid_status)
-  end
-
-  # Trigger: guardian2_email is present and non-nil
-  # Why: if a second guardian email is provided, it must be valid
-  # Outcome: format validation applied only when field has a value
-  defp maybe_validate_guardian2_email(changeset) do
-    case get_field(changeset, :guardian2_email) do
-      nil ->
-        changeset
-
-      "" ->
-        changeset
-
-      _email ->
-        validate_format(changeset, :guardian2_email, ~r/^[^@,;\s]+@[^@,;\s]+$/, message: "must be a valid email")
-    end
-  end
-
-  defp validate_date_in_past(changeset, field) do
-    validate_change(changeset, field, fn ^field, date ->
-      if Date.before?(date, Date.utc_today()) do
-        []
-      else
-        [{field, "must be in the past"}]
-      end
-    end)
   end
 
   # Trigger: status is being changed

--- a/lib/klass_hero/enrollment/application/changeset_errors.ex
+++ b/lib/klass_hero/enrollment/application/changeset_errors.ex
@@ -1,0 +1,27 @@
+defmodule KlassHero.Enrollment.Application.ChangesetErrors do
+  @moduledoc """
+  Converts an `Ecto.Changeset`'s errors into the flat
+  `[{field :: atom, message :: String.t()}]` list that enrollment commands
+  surface to the LiveView layer. Expands `%{count}`-style placeholders so
+  messages like `"should be at most %{count} character(s)"` don't leak to
+  end users.
+  """
+
+  @doc """
+  Flatten a changeset's errors into `[{field, expanded_message}]` pairs.
+  """
+  @spec field_list(Ecto.Changeset.t()) :: [{atom(), String.t()}]
+  def field_list(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(&expand/1)
+    |> Enum.flat_map(fn {field, messages} ->
+      Enum.map(messages, fn msg -> {field, msg} end)
+    end)
+  end
+
+  defp expand({msg, opts}) do
+    Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+      opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+    end)
+  end
+end

--- a/lib/klass_hero/enrollment/application/changeset_errors.ex
+++ b/lib/klass_hero/enrollment/application/changeset_errors.ex
@@ -5,6 +5,10 @@ defmodule KlassHero.Enrollment.Application.ChangesetErrors do
   surface to the LiveView layer. Expands `%{count}`-style placeholders so
   messages like `"should be at most %{count} character(s)"` don't leak to
   end users.
+
+  Formatting must never raise — this helper is called on the error path
+  where throwing would swallow the real validation errors. Unknown
+  placeholders fall through unchanged.
   """
 
   @doc """
@@ -20,8 +24,20 @@ defmodule KlassHero.Enrollment.Application.ChangesetErrors do
   end
 
   defp expand({msg, opts}) do
-    Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
-      opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
-    end)
+    Regex.replace(~r"%{(\w+)}", msg, fn match, key -> lookup(opts, key, match) end)
+  end
+
+  # Returns the opts value for `key` as a string, or `default` when the atom
+  # isn't loaded or the key is absent. Catches ArgumentError narrowly; any
+  # other failure would still surface.
+  defp lookup(opts, key, default) do
+    atom = String.to_existing_atom(key)
+
+    case Keyword.fetch(opts, atom) do
+      {:ok, value} -> to_string(value)
+      :error -> default
+    end
+  rescue
+    ArgumentError -> default
   end
 end

--- a/lib/klass_hero/enrollment/application/commands/import_enrollment_csv.ex
+++ b/lib/klass_hero/enrollment/application/commands/import_enrollment_csv.ex
@@ -6,7 +6,10 @@ defmodule KlassHero.Enrollment.Application.Commands.ImportEnrollmentCsv do
   All-or-nothing: if any row fails, nothing is persisted.
   """
 
+  alias KlassHero.Enrollment.Application.ChangesetErrors
+  alias KlassHero.Enrollment.Application.ProviderProgramContext
   alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Enrollment.Domain.Models.BulkEnrollmentInvite
   alias KlassHero.Enrollment.Domain.Services.CsvParser
   alias KlassHero.Enrollment.Domain.Services.ImportRowValidator
   alias KlassHero.Shared.EventDispatchHelper
@@ -19,10 +22,6 @@ defmodule KlassHero.Enrollment.Application.Commands.ImportEnrollmentCsv do
                        :enrollment,
                        :for_storing_bulk_enrollment_invites
                      ])
-  @program_catalog_acl Application.compile_env!(:klass_hero, [
-                         :enrollment,
-                         :for_resolving_program_catalog
-                       ])
 
   @spec execute(binary(), binary()) ::
           {:ok, %{created: non_neg_integer()}}
@@ -58,55 +57,27 @@ defmodule KlassHero.Enrollment.Application.Commands.ImportEnrollmentCsv do
     end
   end
 
+  # LiveView renders parse_errors in the CSV uploader; wrap the shared
+  # helper's generic errors into that shape so no new UI paths are needed.
   defp build_context(provider_id) do
-    programs_by_title = @program_catalog_acl.list_program_titles_for_provider(provider_id)
+    case ProviderProgramContext.for_provider(provider_id) do
+      {:ok, context} ->
+        {:ok, context}
 
-    # Trigger: provider has no programs in the catalog
-    # Why: every CSV row requires a valid program reference; importing with
-    #      zero programs would fail on every row with a confusing per-row error
-    # Outcome: single clear error telling the provider to create programs first
-    if programs_by_title == %{} do
-      {:error,
-       %{
-         parse_errors: [
-           {0, "No programs found for this provider. Create programs before importing."}
-         ]
-       }}
-    else
-      with {:ok, downcased} <- check_title_collisions(programs_by_title) do
-        {:ok, %{provider_id: provider_id, programs_by_title: downcased}}
-      end
-    end
-  end
+      {:error, :no_programs} ->
+        {:error,
+         %{
+           parse_errors: [
+             {0, "No programs found for this provider. Create programs before importing."}
+           ]
+         }}
 
-  # Trigger: two programs whose titles differ only by case (e.g. "Yoga" vs "YOGA")
-  # Why: downcasing would silently collapse them into one key, mapping rows
-  #      to the wrong program_id without any error
-  # Outcome: early error listing the conflicting titles so the provider can rename
-  defp check_title_collisions(programs_by_title) do
-    collisions =
-      programs_by_title
-      |> Map.keys()
-      |> Enum.group_by(&String.downcase/1)
-      |> Enum.filter(fn {_downcased, titles} -> length(titles) > 1 end)
+      {:error, {:title_collisions, titles}} ->
+        msg =
+          "Program titles must be unique ignoring case. Conflicting titles: " <>
+            Enum.join(titles, ", ")
 
-    if collisions == [] do
-      # Trigger: CSV program names may differ in casing from the catalog
-      # Why: spreadsheet apps may auto-capitalize or users may type lowercase
-      # Outcome: downcased keys allow case-insensitive lookup in the validator
-      downcased =
-        Map.new(programs_by_title, fn {title, id} -> {String.downcase(title), id} end)
-
-      {:ok, downcased}
-    else
-      conflicting =
-        Enum.flat_map(collisions, fn {_downcased, titles} -> titles end)
-
-      msg =
-        "Program titles must be unique ignoring case. Conflicting titles: " <>
-          Enum.join(conflicting, ", ")
-
-      {:error, %{parse_errors: [{0, msg}]}}
+        {:error, %{parse_errors: [{0, msg}]}}
     end
   end
 
@@ -128,16 +99,14 @@ defmodule KlassHero.Enrollment.Application.Commands.ImportEnrollmentCsv do
     end
   end
 
-  # Trigger: two rows in the same CSV have the same program + email + child name
-  # Why: the DB unique constraint would reject the batch anyway, but catching
-  #      it here gives a better error message with row numbers
-  # Outcome: duplicate rows flagged before hitting the database
+  # Catching duplicates in-batch gives the user row-number errors; the DB
+  # unique constraint would also reject them but with a less helpful shape.
   defp check_batch_duplicates(rows) do
     {_seen, duplicates} =
       rows
       |> Enum.with_index(1)
       |> Enum.reduce({MapSet.new(), []}, fn {row, row_num}, {seen, dupes} ->
-        key = duplicate_key(row)
+        key = dedup_key(row)
 
         if MapSet.member?(seen, key) do
           {seen,
@@ -157,9 +126,6 @@ defmodule KlassHero.Enrollment.Application.Commands.ImportEnrollmentCsv do
     end
   end
 
-  # Trigger: rows match invites already in the database
-  # Why: re-importing the same children would violate the unique constraint
-  # Outcome: already-imported rows flagged with a clear message
   defp check_existing_duplicates(rows) do
     program_ids = rows |> Enum.map(& &1.program_id) |> Enum.uniq()
     existing_keys = @invite_reader.list_existing_keys_for_programs(program_ids)
@@ -168,9 +134,7 @@ defmodule KlassHero.Enrollment.Application.Commands.ImportEnrollmentCsv do
       rows
       |> Enum.with_index(1)
       |> Enum.reduce([], fn {row, row_num}, dupes ->
-        key = duplicate_key(row)
-
-        if MapSet.member?(existing_keys, key) do
+        if MapSet.member?(existing_keys, dedup_key(row)) do
           [{row_num, "Invite already exists for this child and program"} | dupes]
         else
           dupes
@@ -184,41 +148,27 @@ defmodule KlassHero.Enrollment.Application.Commands.ImportEnrollmentCsv do
     end
   end
 
-  # Trigger: create_batch returns {index, changeset} on failure
-  # Why: callers expect structured error maps, not raw changesets
-  # Outcome: changeset errors formatted into the standard error report shape
   defp persist_batch(validated_rows) do
     case @invite_repository.create_batch(validated_rows) do
       {:ok, count} ->
         {:ok, count}
 
       {:error, {index, %Ecto.Changeset{} = changeset}} ->
-        errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
-
-        formatted =
-          Enum.map(errors, fn {field, messages} ->
-            {field, Enum.join(messages, ", ")}
-          end)
-
-        {:error, %{validation_errors: [{index + 1, formatted}]}}
+        {:error, %{validation_errors: [{index + 1, ChangesetErrors.field_list(changeset)}]}}
     end
   end
 
-  # Trigger: CSV import persisted successfully
-  # Why: downstream handlers (e.g. invite email sending) need to know
-  #      that new invites exist and should be processed
-  # Outcome: DomainEventBus delivers to registered handlers (fire-and-forget)
   defp publish_event(provider_id, program_ids, count) do
     EnrollmentEvents.bulk_invites_imported(provider_id, program_ids, count)
     |> EventDispatchHelper.dispatch(KlassHero.Enrollment)
   end
 
-  defp duplicate_key(row) do
-    {
+  defp dedup_key(row) do
+    BulkEnrollmentInvite.dedup_key(
       row.program_id,
-      String.downcase(row.guardian_email),
-      String.downcase(row.child_first_name),
-      String.downcase(row.child_last_name)
-    }
+      row.guardian_email,
+      row.child_first_name,
+      row.child_last_name
+    )
   end
 end

--- a/lib/klass_hero/enrollment/application/commands/invite_single_participant.ex
+++ b/lib/klass_hero/enrollment/application/commands/invite_single_participant.ex
@@ -1,0 +1,116 @@
+defmodule KlassHero.Enrollment.Application.Commands.InviteSingleParticipant do
+  @moduledoc """
+  Creates one enrollment invite from a manual single-invite form submission.
+
+  Mirrors the validate → authorise → dedup → persist → publish tail of
+  `ImportEnrollmentCsv`, but for a single row with a pre-resolved
+  `program_id`. Emits `:bulk_invites_imported` with `count: 1` so the
+  existing `EnqueueInviteEmails` handler picks the new invite up on the
+  next dispatch — no handler changes needed.
+  """
+
+  alias KlassHero.Enrollment.Application.ChangesetErrors
+  alias KlassHero.Enrollment.Application.ProviderProgramContext
+  alias KlassHero.Enrollment.Application.SingleInviteForm
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Shared.EventDispatchHelper
+
+  require Logger
+
+  @invite_reader Application.compile_env!(
+                   :klass_hero,
+                   [:enrollment, :for_querying_bulk_enrollment_invites]
+                 )
+  @invite_repository Application.compile_env!(
+                       :klass_hero,
+                       [:enrollment, :for_storing_bulk_enrollment_invites]
+                     )
+
+  @type result ::
+          {:ok, %{invite_id: binary()}}
+          | {:error, :no_programs}
+          | {:error, :duplicate}
+          | {:error, %{validation_errors: [{atom(), String.t()}]}}
+
+  @spec execute(binary(), map()) :: result()
+  def execute(provider_id, attrs) when is_binary(provider_id) and is_map(attrs) do
+    with {:ok, context} <- provider_context(provider_id),
+         {:ok, form_changeset} <- validate_form(attrs),
+         {:ok, row} <- SingleInviteForm.to_invite_row(form_changeset),
+         :ok <- authorize_program(row.program_id, context.programs_by_title),
+         :ok <- check_duplicate(row),
+         {:ok, invite} <- persist(row, provider_id) do
+      publish_event(provider_id, invite.program_id)
+
+      Logger.info("[InviteSingleParticipant] Invite created",
+        invite_id: invite.id,
+        program_id: invite.program_id
+      )
+
+      {:ok, %{invite_id: invite.id}}
+    end
+  end
+
+  defp provider_context(provider_id) do
+    case ProviderProgramContext.for_provider(provider_id) do
+      {:ok, context} ->
+        {:ok, context}
+
+      {:error, :no_programs} ->
+        {:error, :no_programs}
+
+      {:error, {:title_collisions, titles}} ->
+        {:error,
+         %{
+           validation_errors: [
+             {:program_id, "program catalog has titles differing only by case: #{Enum.join(titles, ", ")}"}
+           ]
+         }}
+    end
+  end
+
+  defp validate_form(attrs) do
+    case SingleInviteForm.changeset(attrs) do
+      %Ecto.Changeset{valid?: true} = cs -> {:ok, cs}
+      %Ecto.Changeset{} = cs -> {:error, %{validation_errors: ChangesetErrors.field_list(cs)}}
+    end
+  end
+
+  # program_id comes from the client — verify the provider owns it before
+  # we use it for anything else.
+  defp authorize_program(program_id, programs_by_title) do
+    if program_id in Map.values(programs_by_title) do
+      :ok
+    else
+      {:error, %{validation_errors: [{:program_id, "program does not belong to this provider"}]}}
+    end
+  end
+
+  defp check_duplicate(row) do
+    if @invite_reader.invite_exists?(
+         row.program_id,
+         row.guardian_email,
+         row.child_first_name,
+         row.child_last_name
+       ) do
+      {:error, :duplicate}
+    else
+      :ok
+    end
+  end
+
+  defp persist(row, provider_id) do
+    case @invite_repository.create_one(Map.put(row, :provider_id, provider_id)) do
+      {:ok, invite} ->
+        {:ok, invite}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, %{validation_errors: ChangesetErrors.field_list(changeset)}}
+    end
+  end
+
+  defp publish_event(provider_id, program_id) do
+    EnrollmentEvents.bulk_invites_imported(provider_id, [program_id], 1)
+    |> EventDispatchHelper.dispatch(KlassHero.Enrollment)
+  end
+end

--- a/lib/klass_hero/enrollment/application/provider_program_context.ex
+++ b/lib/klass_hero/enrollment/application/provider_program_context.ex
@@ -1,0 +1,60 @@
+defmodule KlassHero.Enrollment.Application.ProviderProgramContext do
+  @moduledoc """
+  Builds the shared `programs_by_title` lookup context that invite-creation
+  commands use to resolve a human-readable program name into a `program_id`.
+
+  Shared by `ImportEnrollmentCsv` (CSV path) and `InviteSingleParticipant`
+  (manual form). Centralising the title-collision check here guarantees both
+  commands reject the same ambiguous catalog state.
+
+  Returned map uses downcased keys for case-insensitive lookup downstream.
+  """
+
+  @program_catalog_acl Application.compile_env!(:klass_hero, [
+                         :enrollment,
+                         :for_resolving_program_catalog
+                       ])
+
+  @type context :: %{
+          provider_id: binary(),
+          programs_by_title: %{String.t() => binary()}
+        }
+
+  @spec for_provider(binary()) ::
+          {:ok, context()}
+          | {:error, :no_programs}
+          | {:error, {:title_collisions, [String.t()]}}
+  def for_provider(provider_id) when is_binary(provider_id) do
+    programs_by_title = @program_catalog_acl.list_program_titles_for_provider(provider_id)
+
+    if programs_by_title == %{} do
+      {:error, :no_programs}
+    else
+      with {:ok, downcased} <- check_title_collisions(programs_by_title) do
+        {:ok, %{provider_id: provider_id, programs_by_title: downcased}}
+      end
+    end
+  end
+
+  # Trigger: two programs whose titles differ only by case (e.g. "Yoga" vs "YOGA")
+  # Why: downcasing would silently collapse them into one key, mapping rows
+  #      to the wrong program_id without any error
+  # Outcome: early error listing the conflicting titles so the provider can rename
+  defp check_title_collisions(programs_by_title) do
+    collisions =
+      programs_by_title
+      |> Map.keys()
+      |> Enum.group_by(&String.downcase/1)
+      |> Enum.filter(fn {_downcased, titles} -> length(titles) > 1 end)
+
+    if collisions == [] do
+      downcased =
+        Map.new(programs_by_title, fn {title, id} -> {String.downcase(title), id} end)
+
+      {:ok, downcased}
+    else
+      conflicting = Enum.flat_map(collisions, fn {_downcased, titles} -> titles end)
+      {:error, {:title_collisions, conflicting}}
+    end
+  end
+end

--- a/lib/klass_hero/enrollment/application/single_invite_form.ex
+++ b/lib/klass_hero/enrollment/application/single_invite_form.ex
@@ -1,0 +1,86 @@
+defmodule KlassHero.Enrollment.Application.SingleInviteForm do
+  @moduledoc """
+  Schemaless embedded form backing the provider's manual single-invite
+  LiveView. Delegates field-shape validations to
+  `InviteFieldValidations` so the form can't drift from the persistence
+  schema's rules.
+
+  The form carries `program_id` directly (UI picks from a dropdown of the
+  provider's programs). Ownership of the chosen program is re-checked at
+  the command layer.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias KlassHero.Enrollment.Domain.Services.InviteFieldValidations
+
+  @primary_key false
+  embedded_schema do
+    field :program_id, :binary_id
+    field :child_first_name, :string
+    field :child_last_name, :string
+    field :child_date_of_birth, :date
+    field :guardian_email, :string
+    field :guardian_first_name, :string
+    field :guardian_last_name, :string
+    field :guardian2_email, :string
+    field :guardian2_first_name, :string
+    field :guardian2_last_name, :string
+    field :school_grade, :integer
+    field :school_name, :string
+    field :medical_conditions, :string
+    field :nut_allergy, :boolean, default: false
+    field :consent_photo_marketing, :boolean, default: false
+    field :consent_photo_social_media, :boolean, default: false
+  end
+
+  @required_fields ~w(program_id child_first_name child_last_name child_date_of_birth guardian_email)a
+
+  @optional_fields ~w(
+    guardian_first_name guardian_last_name
+    guardian2_email guardian2_first_name guardian2_last_name
+    school_grade school_name medical_conditions nut_allergy
+    consent_photo_marketing consent_photo_social_media
+  )a
+
+  @type t :: %__MODULE__{}
+
+  @spec changeset(t() | map(), map()) :: Ecto.Changeset.t()
+  def changeset(form \\ %__MODULE__{}, attrs) do
+    form
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> InviteFieldValidations.apply()
+  end
+
+  @doc """
+  Converts a valid changeset to the attribute map the persistence layer
+  expects. `provider_id` is set to nil here — the command layer is the
+  only trust-boundary that can bind it from the current scope.
+  """
+  @spec to_invite_row(Ecto.Changeset.t()) :: {:ok, map()} | {:error, Ecto.Changeset.t()}
+  def to_invite_row(%Ecto.Changeset{valid?: true} = changeset) do
+    row =
+      changeset
+      |> apply_changes()
+      |> Map.from_struct()
+      |> Map.put(:provider_id, nil)
+
+    {:ok, row}
+  end
+
+  def to_invite_row(%Ecto.Changeset{} = changeset), do: {:error, changeset}
+
+  @doc """
+  Merges domain-layer field errors returned by the command back into a
+  changeset, with `:action` pre-set so `<.input>` renders them.
+  """
+  @spec apply_domain_errors(Ecto.Changeset.t(), [{atom(), String.t()}]) :: Ecto.Changeset.t()
+  def apply_domain_errors(%Ecto.Changeset{} = changeset, field_errors) when is_list(field_errors) do
+    field_errors
+    |> Enum.reduce(changeset, fn {field, msg}, acc -> add_error(acc, field, msg) end)
+    |> Map.put(:action, :validate)
+  end
+end

--- a/lib/klass_hero/enrollment/domain/models/bulk_enrollment_invite.ex
+++ b/lib/klass_hero/enrollment/domain/models/bulk_enrollment_invite.ex
@@ -113,4 +113,23 @@ defmodule KlassHero.Enrollment.Domain.Models.BulkEnrollmentInvite do
   def generate_token do
     :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false)
   end
+
+  @doc """
+  Natural dedup key for an invite — program_id plus downcased guardian
+  email and child name. The DB unique index is case-insensitive via
+  downcased tuple matching, and both write paths use this shape so the
+  key in application code always equals the key materialised from the DB.
+  """
+  @spec dedup_key(binary(), String.t(), String.t(), String.t()) ::
+          {binary(), String.t(), String.t(), String.t()}
+  def dedup_key(program_id, guardian_email, child_first_name, child_last_name)
+      when is_binary(program_id) and is_binary(guardian_email) and is_binary(child_first_name) and
+             is_binary(child_last_name) do
+    {
+      program_id,
+      String.downcase(guardian_email),
+      String.downcase(child_first_name),
+      String.downcase(child_last_name)
+    }
+  end
 end

--- a/lib/klass_hero/enrollment/domain/ports/for_querying_bulk_enrollment_invites.ex
+++ b/lib/klass_hero/enrollment/domain/ports/for_querying_bulk_enrollment_invites.ex
@@ -46,4 +46,12 @@ defmodule KlassHero.Enrollment.Domain.Ports.ForQueryingBulkEnrollmentInvites do
   of `{program_id, guardian_email, child_first_name, child_last_name}` tuples.
   """
   @callback list_existing_keys_for_programs([binary()]) :: MapSet.t()
+
+  @doc """
+  Returns true if an invite already exists for the given dedup tuple.
+
+  Used on the single-invite path where a full `list_existing_keys_*` scan
+  would transfer O(n) invites only to check one membership.
+  """
+  @callback invite_exists?(binary(), String.t(), String.t(), String.t()) :: boolean()
 end

--- a/lib/klass_hero/enrollment/domain/ports/for_storing_bulk_enrollment_invites.ex
+++ b/lib/klass_hero/enrollment/domain/ports/for_storing_bulk_enrollment_invites.ex
@@ -6,6 +6,8 @@ defmodule KlassHero.Enrollment.Domain.Ports.ForStoringBulkEnrollmentInvites do
   Read operations have been moved to `ForQueryingBulkEnrollmentInvites`.
   """
 
+  alias KlassHero.Enrollment.Domain.Models.BulkEnrollmentInvite
+
   @doc """
   Inserts all invite records atomically in a single transaction.
 
@@ -16,6 +18,22 @@ defmodule KlassHero.Enrollment.Domain.Ports.ForStoringBulkEnrollmentInvites do
   - `{:error, term()}` — first changeset error from the batch
   """
   @callback create_batch([map()]) :: {:ok, non_neg_integer()} | {:error, term()}
+
+  @doc """
+  Inserts a single invite record and returns the persisted domain struct.
+
+  Used by the manual single-invite flow where the caller needs the created
+  invite's id (e.g. to acknowledge which row was created, to drive UI
+  focus, or for tests). The batch path stays strictly count-returning to
+  preserve its existing contract.
+
+  Returns:
+  - `{:ok, BulkEnrollmentInvite.t()}` on success
+  - `{:error, Ecto.Changeset.t()}` if the row fails schema validation
+  """
+  @callback create_one(map()) ::
+              {:ok, BulkEnrollmentInvite.t()}
+              | {:error, Ecto.Changeset.t()}
 
   @doc """
   Assigns invite tokens to multiple invites in bulk.

--- a/lib/klass_hero/enrollment/domain/services/invite_field_validations.ex
+++ b/lib/klass_hero/enrollment/domain/services/invite_field_validations.ex
@@ -1,0 +1,61 @@
+defmodule KlassHero.Enrollment.Domain.Services.InviteFieldValidations do
+  @moduledoc """
+  Shared field-shape validations for enrollment invites — the rules that
+  must hold whether the row came from the CSV importer or the manual
+  single-invite form. Kept in one place so bumping a length limit or the
+  email regex can't silently diverge between entry points.
+
+  Operates on any `Ecto.Changeset` whose fields include the invite field
+  set; does not cast — callers decide what to cast first.
+  """
+
+  import Ecto.Changeset
+
+  @email_regex ~r/^[^@,;\s]+@[^@,;\s]+$/
+
+  @spec apply(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def apply(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_length(:child_first_name, min: 1, max: 100)
+    |> validate_length(:child_last_name, min: 1, max: 100)
+    |> validate_length(:guardian_email, max: 160)
+    |> validate_format(:guardian_email, @email_regex, message: "must be a valid email")
+    |> validate_length(:guardian_first_name, max: 100)
+    |> validate_length(:guardian_last_name, max: 100)
+    |> validate_length(:guardian2_email, max: 160)
+    |> maybe_validate_guardian2_email()
+    |> validate_length(:guardian2_first_name, max: 100)
+    |> validate_length(:guardian2_last_name, max: 100)
+    |> validate_length(:school_name, max: 255)
+    |> validate_number(:school_grade,
+      greater_than_or_equal_to: 1,
+      less_than_or_equal_to: 13
+    )
+    |> validate_date_in_past(:child_date_of_birth)
+  end
+
+  # When guardian2_email is blank, skip the format check — a missing second
+  # guardian is valid. Only a non-empty value must match the regex.
+  defp maybe_validate_guardian2_email(changeset) do
+    case get_field(changeset, :guardian2_email) do
+      nil ->
+        changeset
+
+      "" ->
+        changeset
+
+      _ ->
+        validate_format(changeset, :guardian2_email, @email_regex, message: "must be a valid email")
+    end
+  end
+
+  defp validate_date_in_past(changeset, field) do
+    validate_change(changeset, field, fn ^field, date ->
+      if Date.before?(date, Date.utc_today()) do
+        []
+      else
+        [{field, "must be in the past"}]
+      end
+    end)
+  end
+end

--- a/lib/klass_hero/participation/domain/models/participation_record.ex
+++ b/lib/klass_hero/participation/domain/models/participation_record.ex
@@ -222,19 +222,23 @@ defmodule KlassHero.Participation.Domain.Models.ParticipationRecord do
   end
 
   defp validate_has_changes(record, attrs) do
-    has_status_change = Map.has_key?(attrs, :status) and attrs.status != record.status
+    if any_change?(record, attrs), do: :ok, else: {:error, :no_changes}
+  end
 
-    has_time_change =
-      (Map.has_key?(attrs, :check_in_at) and attrs.check_in_at != record.check_in_at) or
-        (Map.has_key?(attrs, :check_out_at) and attrs.check_out_at != record.check_out_at)
+  defp any_change?(record, attrs) do
+    status_changed?(record, attrs) or
+      field_changed?(record, attrs, :check_in_at) or
+      field_changed?(record, attrs, :check_out_at) or
+      field_changed?(record, attrs, :check_in_notes) or
+      field_changed?(record, attrs, :check_out_notes)
+  end
 
-    has_notes_change =
-      (Map.has_key?(attrs, :check_in_notes) and attrs.check_in_notes != record.check_in_notes) or
-        (Map.has_key?(attrs, :check_out_notes) and attrs.check_out_notes != record.check_out_notes)
+  defp status_changed?(record, attrs) do
+    Map.has_key?(attrs, :status) and attrs.status != record.status
+  end
 
-    if has_status_change or has_time_change or has_notes_change,
-      do: :ok,
-      else: {:error, :no_changes}
+  defp field_changed?(record, attrs, field) do
+    Map.has_key?(attrs, field) and Map.get(attrs, field) != Map.get(record, field)
   end
 
   defp validate_status(%{status: status}) when status not in @valid_statuses, do: {:error, :invalid_status}

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1774,17 +1774,20 @@ defmodule KlassHeroWeb.ProviderComponents do
   defp invites_tab(assigns) do
     ~H"""
     <div>
+      <%!-- Two mutually-exclusive toggle buttons, not a true tablist.
+            Uses role=group + aria-pressed rather than role=tablist/tab
+            because the content panels aren't siblings — they replace each
+            other — so aria-controls/tabpanel wiring would be misleading. --%>
       <div
         id="invite-mode-toggle"
-        role="tablist"
+        role="group"
         aria-label={gettext("Invite mode")}
         class="flex flex-col sm:flex-row gap-2 mb-5 sm:max-w-md"
       >
         <button
           id="invite-mode-single"
           type="button"
-          role="tab"
-          aria-selected={to_string(@invite_mode == "single")}
+          aria-pressed={to_string(@invite_mode == "single")}
           phx-click="switch_invite_mode"
           phx-value-mode="single"
           class={[
@@ -1802,8 +1805,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         <button
           id="invite-mode-csv"
           type="button"
-          role="tab"
-          aria-selected={to_string(@invite_mode == "csv")}
+          aria-pressed={to_string(@invite_mode == "csv")}
           phx-click="switch_invite_mode"
           phx-value-mode="csv"
           class={[

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1459,6 +1459,8 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :uploads, :map, required: true
   attr :import_errors, :any, default: nil
   attr :can_message?, :boolean, default: false
+  attr :invite_mode, :string, default: "single"
+  attr :single_invite_form, :any, default: nil
 
   def roster_modal(assigns) do
     ~H"""
@@ -1570,6 +1572,8 @@ defmodule KlassHeroWeb.ProviderComponents do
                   program_id={@program_id}
                   uploads={@uploads}
                   import_errors={@import_errors}
+                  invite_mode={@invite_mode}
+                  single_invite_form={@single_invite_form}
                 />
               </div>
             <% end %>
@@ -1764,90 +1768,141 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :program_id, :string, required: true
   attr :uploads, :map, required: true
   attr :import_errors, :any, default: nil
+  attr :invite_mode, :string, default: "single"
+  attr :single_invite_form, :any, default: nil
 
   defp invites_tab(assigns) do
     ~H"""
     <div>
-      <%!-- Upload + Template buttons --%>
-      <div class="flex items-center gap-3 mb-4">
-        <form
-          id="csv-upload-form"
-          phx-change="validate_csv_upload"
-          phx-submit="import_csv"
-          class="inline"
+      <div
+        id="invite-mode-toggle"
+        role="tablist"
+        aria-label={gettext("Invite mode")}
+        class="flex flex-col sm:flex-row gap-2 mb-5 sm:max-w-md"
+      >
+        <button
+          id="invite-mode-single"
+          type="button"
+          role="tab"
+          aria-selected={to_string(@invite_mode == "single")}
+          phx-click="switch_invite_mode"
+          phx-value-mode="single"
+          class={[
+            "flex-1 px-4 py-2 text-sm font-medium border text-center",
+            Theme.rounded(:lg),
+            Theme.transition(:normal),
+            if(@invite_mode == "single",
+              do: "border-hero-primary bg-hero-primary/5 text-hero-primary",
+              else: "border-hero-grey-300 text-hero-grey-600 hover:bg-hero-grey-50"
+            )
+          ]}
         >
-          <label
-            for={@uploads.csv_file.ref}
-            class={[
-              "inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white cursor-pointer",
-              Theme.rounded(:lg),
-              Theme.gradient(:primary)
-            ]}
-          >
-            <.icon name="hero-arrow-up-tray-mini" class="w-4 h-4" />
-            {gettext("Upload CSV")}
-          </label>
-          <.live_file_input upload={@uploads.csv_file} class="hidden" />
+          {gettext("Invite one person")}
+        </button>
+        <button
+          id="invite-mode-csv"
+          type="button"
+          role="tab"
+          aria-selected={to_string(@invite_mode == "csv")}
+          phx-click="switch_invite_mode"
+          phx-value-mode="csv"
+          class={[
+            "flex-1 px-4 py-2 text-sm font-medium border text-center",
+            Theme.rounded(:lg),
+            Theme.transition(:normal),
+            if(@invite_mode == "csv",
+              do: "border-hero-primary bg-hero-primary/5 text-hero-primary",
+              else: "border-hero-grey-300 text-hero-grey-600 hover:bg-hero-grey-50"
+            )
+          ]}
+        >
+          {gettext("Upload a list")}
+        </button>
+      </div>
 
-          <%!-- Show selected file + import button --%>
-          <div :for={entry <- @uploads.csv_file.entries} class="mt-3 flex items-center gap-3">
-            <span class="text-sm text-hero-charcoal">{entry.client_name}</span>
-            <button
-              type="submit"
+      <%= if @invite_mode == "single" and @single_invite_form do %>
+        <.single_invite_form form={@single_invite_form} program_id={@program_id} />
+      <% else %>
+        <div class="flex items-center gap-3 mb-4">
+          <form
+            id="csv-upload-form"
+            phx-change="validate_csv_upload"
+            phx-submit="import_csv"
+            class="inline"
+          >
+            <label
+              for={@uploads.csv_file.ref}
               class={[
-                "px-3 py-1.5 text-sm font-medium text-white",
+                "inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white cursor-pointer",
                 Theme.rounded(:lg),
                 Theme.gradient(:primary)
               ]}
             >
-              {gettext("Import")}
-            </button>
-            <button
-              type="button"
-              phx-click="cancel_csv_upload"
-              phx-value-ref={entry.ref}
-              class="text-sm text-hero-grey-500 hover:text-hero-charcoal"
-            >
-              {gettext("Cancel")}
-            </button>
-          </div>
+              <.icon name="hero-arrow-up-tray-mini" class="w-4 h-4" />
+              {gettext("Upload CSV")}
+            </label>
+            <.live_file_input upload={@uploads.csv_file} class="hidden" />
 
-          <%!-- Upload errors --%>
-          <div :for={err <- upload_errors(@uploads.csv_file)} class="mt-2 text-sm text-red-600">
-            {upload_error_to_string(err)}
-          </div>
-        </form>
+            <%!-- Show selected file + import button --%>
+            <div :for={entry <- @uploads.csv_file.entries} class="mt-3 flex items-center gap-3">
+              <span class="text-sm text-hero-charcoal">{entry.client_name}</span>
+              <button
+                type="submit"
+                class={[
+                  "px-3 py-1.5 text-sm font-medium text-white",
+                  Theme.rounded(:lg),
+                  Theme.gradient(:primary)
+                ]}
+              >
+                {gettext("Import")}
+              </button>
+              <button
+                type="button"
+                phx-click="cancel_csv_upload"
+                phx-value-ref={entry.ref}
+                class="text-sm text-hero-grey-500 hover:text-hero-charcoal"
+              >
+                {gettext("Cancel")}
+              </button>
+            </div>
 
-        <a
-          href="/downloads/enrollment-import-template.csv"
-          download="enrollment-import-template.csv"
+            <%!-- Upload errors --%>
+            <div :for={err <- upload_errors(@uploads.csv_file)} class="mt-2 text-sm text-red-600">
+              {upload_error_to_string(err)}
+            </div>
+          </form>
+
+          <a
+            href="/downloads/enrollment-import-template.csv"
+            download="enrollment-import-template.csv"
+            class={[
+              "inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-hero-grey-600",
+              "border border-hero-grey-300 hover:bg-hero-grey-50",
+              Theme.rounded(:lg)
+            ]}
+          >
+            <.icon name="hero-arrow-down-tray-mini" class="w-4 h-4" />
+            {gettext("Download Template")}
+          </a>
+        </div>
+
+        <%!-- Import errors (CSV path only) --%>
+        <div
+          :if={@import_errors}
+          id="import-errors"
           class={[
-            "inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-hero-grey-600",
-            "border border-hero-grey-300 hover:bg-hero-grey-50",
+            "mt-3 p-3 bg-red-50 border border-red-200 text-sm text-red-700",
             Theme.rounded(:lg)
           ]}
         >
-          <.icon name="hero-arrow-down-tray-mini" class="w-4 h-4" />
-          {gettext("Download Template")}
-        </a>
-      </div>
-
-      <%!-- Import errors --%>
-      <div
-        :if={@import_errors}
-        id="import-errors"
-        class={[
-          "mt-3 p-3 bg-red-50 border border-red-200 text-sm text-red-700",
-          Theme.rounded(:lg)
-        ]}
-      >
-        <p class="font-semibold mb-2">{gettext("Import failed")}</p>
-        <ul class="list-disc pl-5 space-y-1">
-          <li :for={msg <- format_import_errors(@import_errors)}>
-            {msg}
-          </li>
-        </ul>
-      </div>
+          <p class="font-semibold mb-2">{gettext("Import failed")}</p>
+          <ul class="list-disc pl-5 space-y-1">
+            <li :for={msg <- format_import_errors(@import_errors)}>
+              {msg}
+            </li>
+          </ul>
+        </div>
+      <% end %>
 
       <%!-- Empty state --%>
       <div :if={@invites == []} id="invites-empty" class="text-center py-8">
@@ -1912,6 +1967,146 @@ defmodule KlassHeroWeb.ProviderComponents do
         </table>
       </div>
     </div>
+    """
+  end
+
+  @doc false
+  attr :form, :any, required: true
+  attr :program_id, :string, required: true
+
+  defp single_invite_form(assigns) do
+    ~H"""
+    <.form
+      id="single-invite-form"
+      for={@form}
+      phx-change="validate_single_invite"
+      phx-submit="submit_single_invite"
+      class="space-y-6"
+    >
+      <%!-- Program is implicit from the roster modal; set as hidden so the
+            changeset still casts and validates it. --%>
+      <input type="hidden" name={@form[:program_id].name} value={@program_id} />
+
+      <section aria-labelledby="single-invite-child-heading">
+        <h4
+          id="single-invite-child-heading"
+          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+        >
+          {gettext("Child")}
+        </h4>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <.input field={@form[:child_first_name]} label={gettext("First name")} required />
+          <.input field={@form[:child_last_name]} label={gettext("Last name")} required />
+          <div class="md:col-span-2">
+            <.input
+              field={@form[:child_date_of_birth]}
+              type="date"
+              label={gettext("Date of birth")}
+              required
+            />
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="single-invite-guardian-heading">
+        <h4
+          id="single-invite-guardian-heading"
+          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+        >
+          {gettext("Primary guardian")}
+        </h4>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="md:col-span-2">
+            <.input
+              field={@form[:guardian_email]}
+              type="email"
+              label={gettext("Email")}
+              required
+            />
+          </div>
+          <.input field={@form[:guardian_first_name]} label={gettext("First name")} />
+          <.input field={@form[:guardian_last_name]} label={gettext("Last name")} />
+        </div>
+      </section>
+
+      <section aria-labelledby="single-invite-guardian2-heading">
+        <h4
+          id="single-invite-guardian2-heading"
+          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+        >
+          {gettext("Second guardian (optional)")}
+        </h4>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="md:col-span-2">
+            <.input field={@form[:guardian2_email]} type="email" label={gettext("Email")} />
+          </div>
+          <.input field={@form[:guardian2_first_name]} label={gettext("First name")} />
+          <.input field={@form[:guardian2_last_name]} label={gettext("Last name")} />
+        </div>
+      </section>
+
+      <section aria-labelledby="single-invite-school-heading">
+        <h4
+          id="single-invite-school-heading"
+          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+        >
+          {gettext("School (optional)")}
+        </h4>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <.input
+            field={@form[:school_grade]}
+            type="number"
+            label={gettext("Grade")}
+            min="1"
+            max="13"
+          />
+          <.input field={@form[:school_name]} label={gettext("School name")} />
+        </div>
+      </section>
+
+      <section aria-labelledby="single-invite-medical-heading">
+        <h4
+          id="single-invite-medical-heading"
+          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+        >
+          {gettext("Medical & consents (optional)")}
+        </h4>
+        <div class="space-y-3">
+          <.input
+            field={@form[:medical_conditions]}
+            type="textarea"
+            label={gettext("Medical conditions")}
+          />
+          <.input field={@form[:nut_allergy]} type="checkbox" label={gettext("Nut allergy")} />
+          <.input
+            field={@form[:consent_photo_marketing]}
+            type="checkbox"
+            label={gettext("Photos may appear in marketing materials")}
+          />
+          <.input
+            field={@form[:consent_photo_social_media]}
+            type="checkbox"
+            label={gettext("Photos may appear on social media")}
+          />
+        </div>
+      </section>
+
+      <div class="flex justify-end pt-2">
+        <button
+          id="single-invite-submit"
+          type="submit"
+          phx-disable-with={gettext("Sending...")}
+          class={[
+            "inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white",
+            Theme.rounded(:lg),
+            Theme.gradient(:primary)
+          ]}
+        >
+          <.icon name="hero-paper-airplane-mini" class="w-4 h-4" />
+          {gettext("Send invite")}
+        </button>
+      </div>
+    </.form>
     """
   end
 

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -112,7 +112,9 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
             roster_enrolled_count: 0,
             roster_invite_count: 0,
             import_errors: nil,
-            can_message?: false
+            can_message?: false,
+            invite_mode: "single",
+            single_invite_form: blank_single_invite_form()
           )
           |> assign(:sessions_modal, nil)
           |> assign(program_form: to_form(ProgramCatalog.new_program_changeset()))
@@ -554,7 +556,9 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
          roster_enrolled_count: length(roster),
          roster_invite_count: invite_count,
          import_errors: nil,
-         can_message?: Entitlements.can_initiate_messaging?(socket.assigns.current_scope)
+         can_message?: Entitlements.can_initiate_messaging?(socket.assigns.current_scope),
+         invite_mode: "single",
+         single_invite_form: blank_single_invite_form()
        )}
     else
       false ->
@@ -582,7 +586,9 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
        roster_invite_count: 0,
        roster_enrolled_count: 0,
        import_errors: nil,
-       can_message?: false
+       can_message?: false,
+       invite_mode: "single",
+       single_invite_form: blank_single_invite_form()
      )}
   end
 
@@ -756,6 +762,51 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
           {:error, error_report} ->
             {:noreply, assign(socket, import_errors: error_report)}
         end
+    end
+  end
+
+  @impl true
+  def handle_event("switch_invite_mode", %{"mode" => mode}, socket) when mode in ~w(single csv) do
+    {:noreply, assign(socket, invite_mode: mode)}
+  end
+
+  @impl true
+  def handle_event("validate_single_invite", %{"single_invite" => params}, socket) do
+    changeset = params |> Enrollment.change_single_invite() |> Map.put(:action, :validate)
+    {:noreply, assign(socket, single_invite_form: to_form(changeset, as: "single_invite"))}
+  end
+
+  @impl true
+  def handle_event("submit_single_invite", %{"single_invite" => params}, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    case Enrollment.invite_single_participant(provider_id, params) do
+      {:ok, _} ->
+        socket = refresh_invites_silent(socket, socket.assigns.roster_program_id)
+
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Invite sent."))
+         |> assign(single_invite_form: blank_single_invite_form())}
+
+      {:error, :no_programs} ->
+        {:noreply, put_flash(socket, :error, gettext("Create a program before inviting participants."))}
+
+      {:error, :duplicate} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("An invite for this child and program already exists.")
+         )}
+
+      {:error, %{validation_errors: field_errors}} ->
+        changeset =
+          params
+          |> Enrollment.change_single_invite()
+          |> Enrollment.apply_single_invite_domain_errors(field_errors)
+
+        {:noreply, assign(socket, single_invite_form: to_form(changeset, as: "single_invite"))}
     end
   end
 
@@ -1167,6 +1218,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
                   import_errors={@import_errors}
                   can_message?={@can_message?}
                   sessions_modal={@sessions_modal}
+                  invite_mode={@invite_mode}
+                  single_invite_form={@single_invite_form}
                 />
             <% end %>
         <% end %>
@@ -1477,6 +1530,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   attr :import_errors, :any, default: nil
   attr :can_message?, :boolean, default: false
   attr :sessions_modal, :any, default: nil
+  attr :invite_mode, :string, default: "single"
+  attr :single_invite_form, :any, default: nil
 
   defp programs_section(assigns) do
     ~H"""
@@ -1512,6 +1567,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
         uploads={@uploads}
         import_errors={@import_errors}
         can_message?={@can_message?}
+        invite_mode={@invite_mode}
+        single_invite_form={@single_invite_form}
       />
 
       <.sessions_modal :if={@sessions_modal} modal={@sessions_modal} />
@@ -1599,6 +1656,10 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
       {:ok, socket} -> socket
       {:error, :no_program} -> socket
     end
+  end
+
+  defp blank_single_invite_form do
+    to_form(Enrollment.change_single_invite(), as: "single_invite")
   end
 
   defp fetch_verification_docs(provider_id) do

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -770,6 +770,12 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     {:noreply, assign(socket, invite_mode: mode)}
   end
 
+  # Catch-all: ignore unknown modes rather than crash the LV. The pills
+  # above only emit "single" / "csv", but a buggy Hook or crafted channel
+  # message could send anything; we want the socket to stay alive.
+  @impl true
+  def handle_event("switch_invite_mode", _params, socket), do: {:noreply, socket}
+
   @impl true
   def handle_event("validate_single_invite", %{"single_invite" => params}, socket) do
     changeset = params |> Enrollment.change_single_invite() |> Map.put(:action, :validate)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1515
+#: lib/klass_hero_web/components/provider_components.ex:1516
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -499,14 +499,14 @@ msgstr "Wird geändert..."
 msgid "Check out our FAQ section for answers to common questions."
 msgstr "Schauen Sie in unsere FAQ für Antworten auf häufige Fragen."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:67
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:67
+#: lib/klass_hero_web/live/provider/participation_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr "Kind erfolgreich eingecheckt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:130
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:130
+#: lib/klass_hero_web/live/provider/participation_live.ex:133
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr "Kind erfolgreich ausgecheckt"
@@ -629,6 +629,8 @@ msgid "Don't have an account?"
 msgstr "Noch kein Konto?"
 
 #: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:2023
+#: lib/klass_hero_web/components/provider_components.ex:2041
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
 #: lib/klass_hero_web/live/user_live/login.ex:49
@@ -665,14 +667,14 @@ msgstr "Kinder für Programme anmelden"
 msgid "Enter your password to confirm"
 msgstr "Geben Sie Ihr Passwort zur Bestätigung ein"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:82
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:82
+#: lib/klass_hero_web/live/provider/participation_live.ex:85
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr "Einchecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:147
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:147
+#: lib/klass_hero_web/live/provider/participation_live.ex:150
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
@@ -688,10 +690,10 @@ msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:328
-#: lib/klass_hero_web/live/provider/participation_live.ex:329
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:283
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
+#: lib/klass_hero_web/live/provider/participation_live.ex:399
+#: lib/klass_hero_web/live/provider/participation_live.ex:400
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:354
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Failed to load session data"
 msgstr "Sitzungsdaten konnten nicht geladen werden"
@@ -931,10 +933,14 @@ msgid "Questions About These Terms?"
 msgstr "Fragen zu diesen Bedingungen?"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:270
-#: lib/klass_hero_web/live/provider/participation_live.ex:57
-#: lib/klass_hero_web/live/provider/participation_live.ex:119
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:57
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:119
+#: lib/klass_hero_web/live/provider/participation_live.ex:60
+#: lib/klass_hero_web/live/provider/participation_live.ex:122
+#: lib/klass_hero_web/live/provider/participation_live.ex:269
+#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:208
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr "Eintrag nicht gefunden"
@@ -981,9 +987,9 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Magic Link"
 msgstr "Magic-Link senden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1720
-#: lib/klass_hero_web/components/provider_components.ex:1721
-#: lib/klass_hero_web/components/provider_components.ex:1760
+#: lib/klass_hero_web/components/provider_components.ex:1723
+#: lib/klass_hero_web/components/provider_components.ex:1724
+#: lib/klass_hero_web/components/provider_components.ex:1763
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1005,8 +1011,8 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:69
 #: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:317
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:272
+#: lib/klass_hero_web/live/provider/participation_live.ex:388
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
@@ -1544,9 +1550,9 @@ msgstr "WhatsApp-Community"
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:16
+#: lib/klass_hero_web/live/provider/participation_live.ex:17
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:22
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:23
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
@@ -1902,25 +1908,25 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1319
-#: lib/klass_hero_web/components/provider_components.ex:1693
-#: lib/klass_hero_web/components/provider_components.ex:1876
+#: lib/klass_hero_web/components/provider_components.ex:1696
+#: lib/klass_hero_web/components/provider_components.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1407
+#: lib/klass_hero_web/components/provider_components.ex:1406
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr "Aktive Familien"
 
 #: lib/klass_hero_web/components/provider_components.ex:598
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1477
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
 
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:81
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1623
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1721
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
@@ -1947,26 +1953,30 @@ msgstr "Geschäftsprofil"
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:540
-#: lib/klass_hero_web/components/provider_components.ex:1388
+#: lib/klass_hero_web/components/provider_components.ex:1387
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:49
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:76
 #: lib/klass_hero_web/live/settings/children_live.ex:467
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:49
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
 #: lib/klass_hero_web/components/provider_components.ex:194
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:166
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:169
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/components/provider_components.ex:1408
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1988,9 +1998,9 @@ msgid "Overview"
 msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1408
-#: lib/klass_hero_web/components/provider_components.ex:1923
-#: lib/klass_hero_web/components/provider_components.ex:1943
+#: lib/klass_hero_web/components/provider_components.ex:1407
+#: lib/klass_hero_web/components/provider_components.ex:2117
+#: lib/klass_hero_web/components/provider_components.ex:2137
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
@@ -2033,9 +2043,9 @@ msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1313
-#: lib/klass_hero_web/components/provider_components.ex:1632
-#: lib/klass_hero_web/components/provider_components.ex:1687
-#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1927
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2048,7 +2058,7 @@ msgstr "Status"
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1457
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -2059,14 +2069,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
 #: lib/klass_hero_web/components/provider_components.ex:1343
-#: lib/klass_hero_web/components/provider_components.ex:1647
+#: lib/klass_hero_web/components/provider_components.ex:1650
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1410
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -2077,7 +2087,7 @@ msgstr "Unbekannt"
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1382
+#: lib/klass_hero_web/components/provider_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -2128,8 +2138,8 @@ msgstr "Besondere Bedürfnisse oder Unterstützungsbedarf..."
 msgid "Back to Settings"
 msgstr "Zurück zu Einstellungen"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:182
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:180
+#: lib/klass_hero_web/live/provider/participation_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr "Verhaltensnotiz zur Überprüfung eingereicht"
@@ -2146,10 +2156,11 @@ msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
-#: lib/klass_hero_web/components/participation_components.ex:635
+#: lib/klass_hero_web/components/participation_components.ex:627
+#: lib/klass_hero_web/components/participation_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:765
 #: lib/klass_hero_web/components/provider_components.ex:1169
-#: lib/klass_hero_web/components/provider_components.ex:1812
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2213,6 +2224,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -2249,7 +2261,7 @@ msgstr "Ausstehende Notizen konnten nicht geladen werden"
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:258
+#: lib/klass_hero_web/live/provider/participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
@@ -2260,17 +2272,23 @@ msgstr "Notiz konnte nicht erneut eingereicht werden"
 msgid "Failed to send broadcast"
 msgstr "Sitzungsdaten konnten nicht geladen werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:199
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:197
+#: lib/klass_hero_web/live/provider/participation_live.ex:202
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
+#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
+#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2044
 #: lib/klass_hero_web/live/settings/children_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2339,9 +2357,9 @@ msgstr ""
 msgid "Note approved"
 msgstr "Notiz genehmigt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:188
-#: lib/klass_hero_web/live/provider/participation_live.ex:250
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:186
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/provider/participation_live.ex:253
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
@@ -2351,7 +2369,7 @@ msgstr "Notizinhalt darf nicht leer sein"
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:244
+#: lib/klass_hero_web/live/provider/participation_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
@@ -2407,7 +2425,7 @@ msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
 #: lib/klass_hero_web/components/provider_components.ex:750
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
@@ -2418,8 +2436,8 @@ msgstr "Änderungen speichern"
 msgid "Search for programs..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1493
 #: lib/klass_hero_web/components/provider_components.ex:1494
+#: lib/klass_hero_web/components/provider_components.ex:1495
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2437,6 +2455,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:2098
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
 #, elixir-autogen, elixir-format, fuzzy
@@ -2460,8 +2479,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:348
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:303
+#: lib/klass_hero_web/live/provider/participation_live.ex:419
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
@@ -2478,8 +2497,8 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
+#: lib/klass_hero_web/live/provider/participation_live.ex:194
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr "Sie haben bereits eine Notiz für diesen Eintrag eingereicht"
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Add Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1412
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1499
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2612,7 +2631,7 @@ msgstr "Alter %{range}"
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:2182
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
@@ -2623,7 +2642,7 @@ msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:832
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
@@ -2651,7 +2670,7 @@ msgstr ""
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1199
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
 #: lib/klass_hero_web/live/provider/subscription_live.ex:100
 #, elixir-autogen, elixir-format
@@ -2698,17 +2717,17 @@ msgstr ""
 msgid "Business"
 msgstr "Business-Plan"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1221
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1308
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business Description"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1208
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1295
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1316
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
@@ -2724,8 +2743,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1684
-#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1921
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2745,7 +2764,7 @@ msgstr ""
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1283
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1924
+#: lib/klass_hero_web/components/provider_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2785,13 +2804,13 @@ msgstr ""
 msgid "Could not load verification documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:711
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:668
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:676
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2824,7 +2843,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2852,12 +2871,12 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:463
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:466
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2888,13 +2907,13 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1690
-#: lib/klass_hero_web/components/provider_components.ex:1946
+#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:2140
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1540
+#: lib/klass_hero_web/components/provider_components.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2909,7 +2928,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1947
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2925,12 +2944,12 @@ msgstr "Notiz konnte nicht genehmigt werden"
 msgid "Failed to reject document."
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:689
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:472
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:475
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to upload document."
 msgstr "Sitzungsdaten konnten nicht geladen werden"
@@ -2952,12 +2971,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2220
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2222
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2992,7 +3011,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1870
+#: lib/klass_hero_web/components/provider_components.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -3007,17 +3026,17 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr "Wichtig:"
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
+#: lib/klass_hero_web/components/provider_components.ex:1898
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:720
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:759
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} families."
 msgstr ""
@@ -3032,22 +3051,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr "Versicherung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:665
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:662
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:639
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1557
+#: lib/klass_hero_web/components/provider_components.ex:1558
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -3058,7 +3077,7 @@ msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1144
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
@@ -3100,7 +3119,7 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:390
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:393
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
@@ -3158,18 +3177,18 @@ msgstr "Mo-Fr, 9-17 Uhr"
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1677
+#: lib/klass_hero_web/components/provider_components.ex:1680
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -3179,7 +3198,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1857
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -3209,7 +3228,7 @@ msgstr "Keine Programme gefunden"
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1411
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -3242,7 +3261,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2130
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3257,17 +3276,17 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:831
 #: lib/klass_hero_web/components/provider_components.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:884
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:945
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:980
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1052
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:412
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:968
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1029
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1064
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1136
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
@@ -3288,7 +3307,7 @@ msgstr ""
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:405
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:408
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
@@ -3298,30 +3317,30 @@ msgstr "Kind erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmplätze"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1937
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2035
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr "Benutzer erfolgreich bestätigt."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1944
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:529
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:565
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:568
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:532
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:570
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:573
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1004
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr "Programm nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:909
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:993
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:414
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
@@ -3331,8 +3350,8 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1945
+#: lib/klass_hero_web/components/participation_components.ex:809
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3399,7 +3418,7 @@ msgstr "Anmeldegebühr:"
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: lib/klass_hero_web/components/participation_components.ex:753
+#: lib/klass_hero_web/components/participation_components.ex:833
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
@@ -3414,15 +3433,15 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:1120
-#: lib/klass_hero_web/components/provider_components.ex:1905
-#: lib/klass_hero_web/components/provider_components.ex:2149
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
+#: lib/klass_hero_web/components/provider_components.ex:1959
+#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3437,15 +3456,15 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1483
+#: lib/klass_hero_web/components/provider_components.ex:1484
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1955
-#: lib/klass_hero_web/components/provider_components.ex:1967
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:2149
+#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2172
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
@@ -3470,7 +3489,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2127
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr "Kind auswählen"
@@ -3481,13 +3500,13 @@ msgstr "Kind auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:874
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:935
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:958
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2138
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3513,14 +3532,14 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:268
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:271
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:332
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3551,32 +3570,32 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1001
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:326
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1024
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1109
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1222
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
@@ -3586,12 +3605,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:642
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:927
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1011
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3606,7 +3625,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3626,32 +3645,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1789
+#: lib/klass_hero_web/components/provider_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2173
+#: lib/klass_hero_web/components/provider_components.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2082
+#: lib/klass_hero_web/components/provider_components.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
+#: lib/klass_hero_web/components/provider_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2223
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2045
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3834,7 +3853,7 @@ msgstr ""
 msgid "Current Plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1346
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1433
 #, elixir-autogen, elixir-format
 msgid "Current Plan: %{plan}"
 msgstr ""
@@ -3935,7 +3954,7 @@ msgstr ""
 msgid "Invalid subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Manage Plan →"
 msgstr ""
@@ -3970,7 +3989,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr "Programmname"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1781
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -4075,7 +4094,7 @@ msgstr ""
 msgid "Unlimited programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to unlock more features"
 msgstr ""
@@ -4202,7 +4221,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:815
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -4303,7 +4322,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:614
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:653
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -4329,22 +4348,19 @@ msgstr "Auschecken"
 msgid "Check-out time"
 msgstr "Auscheckzeit"
 
-#: lib/klass_hero_web/components/participation_components.ex:733
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr "Eingecheckt"
 
-#: lib/klass_hero_web/components/participation_components.ex:734
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
+#: lib/klass_hero_web/components/provider_components.ex:1995
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -4360,7 +4376,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:732
+#: lib/klass_hero_web/components/participation_components.ex:812
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr "Abgeschlossen"
@@ -4391,7 +4407,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:177
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4427,7 +4443,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1759
+#: lib/klass_hero_web/components/provider_components.ex:1762
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -4488,7 +4504,7 @@ msgstr ""
 msgid "Immediate account suspension"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/components/participation_components.ex:811
 #: lib/klass_hero_web/live/admin/sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -4555,7 +4571,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1509
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -4571,6 +4587,7 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
+#: lib/klass_hero_web/components/participation_components.ex:836
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:161
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
@@ -4582,7 +4599,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1761
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4693,7 +4710,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr "Korrektur speichern"
 
-#: lib/klass_hero_web/components/participation_components.ex:730
+#: lib/klass_hero_web/components/participation_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Geplant"
@@ -4738,13 +4755,13 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1754
+#: lib/klass_hero_web/components/provider_components.ex:1757
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:164
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:608
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:647
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -4865,8 +4882,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:88
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:88
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:112
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
@@ -4887,7 +4904,7 @@ msgstr "Programme"
 msgid "All providers"
 msgstr "Anbieter-Dashboard"
 
-#: lib/klass_hero_web/components/participation_components.ex:655
+#: lib/klass_hero_web/components/participation_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr "Allergien: %{details}"
@@ -4934,17 +4951,11 @@ msgstr "Verhaltensnotiz"
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:67
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:67
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:91
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr "Einchecken"
-
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:48
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:48
-#, elixir-autogen, elixir-format
-msgid "Check Out"
-msgstr "Auschecken"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:276
 #, elixir-autogen, elixir-format
@@ -5061,7 +5072,7 @@ msgstr ""
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:120
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr "Bearbeiten & erneut einreichen"
@@ -5089,7 +5100,7 @@ msgstr "Kind nicht gefunden."
 msgid "Emails"
 msgstr "E-Mails"
 
-#: lib/klass_hero_web/components/participation_components.ex:667
+#: lib/klass_hero_web/components/participation_components.ex:747
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
@@ -5099,7 +5110,7 @@ msgstr "Notfall: %{details}"
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:736
+#: lib/klass_hero_web/components/participation_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr "Erwartet"
@@ -5124,7 +5135,7 @@ msgstr "Notiz konnte nicht abgelehnt werden"
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:364
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr "Notiz konnte nicht abgelehnt werden"
@@ -5192,7 +5203,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:342
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -5275,7 +5286,7 @@ msgstr ""
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
 
-#: lib/klass_hero_web/components/participation_components.ex:574
+#: lib/klass_hero_web/components/participation_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Notiz:"
@@ -5323,6 +5334,7 @@ msgstr "Absenden"
 
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:26
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -5440,7 +5452,7 @@ msgstr "Sitzung erfolgreich gestartet"
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:987
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -5461,7 +5473,7 @@ msgstr "Notiz absenden"
 msgid "Submit Participation"
 msgstr "Teilnahme bestätigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:661
+#: lib/klass_hero_web/components/participation_components.ex:741
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
@@ -5471,7 +5483,7 @@ msgstr "Unterstützung: %{details}"
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:352
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5531,8 +5543,8 @@ msgstr "Ungelesen"
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:456
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:459
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
@@ -5610,7 +5622,7 @@ msgid "View and manage your assigned sessions"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
@@ -5635,7 +5647,7 @@ msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes s
 msgid "Business Name"
 msgstr "Business-Plan"
 
-#: lib/klass_hero_web/components/participation_components.ex:737
+#: lib/klass_hero_web/components/participation_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Abgesagt"
@@ -5645,7 +5657,7 @@ msgstr "Abgesagt"
 msgid "Categories"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1179
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1266
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete Profile"
@@ -5661,7 +5673,7 @@ msgstr ""
 msgid "Complete Your Provider Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1162
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1249
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
 msgstr ""
@@ -5691,7 +5703,7 @@ msgstr ""
 msgid "File type not accepted (images only)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
@@ -5737,7 +5749,7 @@ msgstr "Programm nicht gefunden"
 msgid "Remove attachment"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1328
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1415
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions Completed"
 msgstr "Sitzungen"
@@ -5785,7 +5797,7 @@ msgstr ""
 msgid "Upload failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1093
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1177
 #, elixir-autogen, elixir-format
 msgid "View your assignments"
 msgstr ""
@@ -5796,7 +5808,7 @@ msgid "Website"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:435
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:866
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "You've reached your program limit. Upgrade your plan to add more programs."
 msgstr ""
@@ -5822,37 +5834,37 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1629
+#: lib/klass_hero_web/components/provider_components.ex:1632
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1631
+#: lib/klass_hero_web/components/provider_components.ex:1634
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1613
+#: lib/klass_hero_web/components/provider_components.ex:1616
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1630
+#: lib/klass_hero_web/components/provider_components.ex:1633
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1628
+#: lib/klass_hero_web/components/provider_components.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1622
+#: lib/klass_hero_web/components/provider_components.ex:1625
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1611
+#: lib/klass_hero_web/components/provider_components.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
@@ -5861,3 +5873,153 @@ msgstr "Sessions — %{title}"
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:793
+#, elixir-autogen, elixir-format
+msgid "Create a program before inviting participants."
+msgstr "Erstelle zuerst ein Programm, bevor du Teilnehmer einlädst."
+
+#: lib/klass_hero_web/components/participation_components.ex:814
+#, elixir-autogen, elixir-format
+msgid "Departed"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:835
+#, elixir-autogen, elixir-format
+msgid "Departure notes"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:318
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Departure time is not a valid date and time"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:329
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Failed to update record"
+msgstr "Sitzungsdaten konnten nicht geladen werden"
+
+#: lib/klass_hero_web/components/provider_components.ex:2059
+#, elixir-autogen, elixir-format
+msgid "Grade"
+msgstr "Klassenstufe"
+
+#: lib/klass_hero_web/components/provider_components.ex:1780
+#, elixir-autogen, elixir-format
+msgid "Invite mode"
+msgstr "Einladungsmodus"
+
+#: lib/klass_hero_web/components/provider_components.ex:1800
+#, elixir-autogen, elixir-format
+msgid "Invite one person"
+msgstr "Einzelperson einladen"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:789
+#, elixir-autogen, elixir-format
+msgid "Invite sent."
+msgstr "Einladung verschickt."
+
+#: lib/klass_hero_web/components/participation_components.ex:600
+#, elixir-autogen, elixir-format
+msgid "Leave blank to keep this child marked as present."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2072
+#, elixir-autogen, elixir-format
+msgid "Medical & consents (optional)"
+msgstr "Gesundheit & Einwilligungen (optional)"
+
+#: lib/klass_hero_web/components/provider_components.ex:2078
+#, elixir-autogen, elixir-format
+msgid "Medical conditions"
+msgstr "Gesundheitliche Besonderheiten"
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:321
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:260
+#, elixir-autogen, elixir-format
+msgid "Nothing to update"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2080
+#, elixir-autogen, elixir-format
+msgid "Nut allergy"
+msgstr "Nussallergie"
+
+#: lib/klass_hero_web/components/provider_components.ex:2084
+#, elixir-autogen, elixir-format
+msgid "Photos may appear in marketing materials"
+msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
+
+#: lib/klass_hero_web/components/provider_components.ex:2089
+#, elixir-autogen, elixir-format
+msgid "Photos may appear on social media"
+msgstr "Fotos dürfen in sozialen Medien erscheinen"
+
+#: lib/klass_hero_web/components/participation_components.ex:813
+#, elixir-autogen, elixir-format
+msgid "Present"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2016
+#, elixir-autogen, elixir-format
+msgid "Primary guardian"
+msgstr "Hauptansprechpartner"
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:61
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:61
+#, elixir-autogen, elixir-format
+msgid "Record departure"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:597
+#, elixir-autogen, elixir-format
+msgid "Record departure time (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#, elixir-autogen, elixir-format
+msgid "Record updated"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:614
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Save changes"
+msgstr "Änderungen speichern"
+
+#: lib/klass_hero_web/components/provider_components.ex:2053
+#, elixir-autogen, elixir-format
+msgid "School (optional)"
+msgstr "Schule (optional)"
+
+#: lib/klass_hero_web/components/provider_components.ex:2063
+#, elixir-autogen, elixir-format
+msgid "School name"
+msgstr "Schulname"
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Second guardian (optional)"
+msgstr "Zweiter Ansprechpartner (optional)"
+
+#: lib/klass_hero_web/components/provider_components.ex:2106
+#, elixir-autogen, elixir-format
+msgid "Send invite"
+msgstr "Einladung senden"
+
+#: lib/klass_hero_web/components/participation_components.ex:589
+#, elixir-autogen, elixir-format
+msgid "Update the note for this child (e.g. clarify what happened)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1819
+#, elixir-autogen, elixir-format
+msgid "Upload a list"
+msgstr "Liste hochladen"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#, elixir-autogen, elixir-format
+msgid "An invite for this child and program already exists."
+msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2003
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:2199
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2210
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2006
+#: lib/klass_hero_web/components/provider_components.ex:2200
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2007
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2008
+#: lib/klass_hero_web/components/provider_components.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2211
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2011
+#: lib/klass_hero_web/components/provider_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2013
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1515
+#: lib/klass_hero_web/components/provider_components.ex:1516
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -499,14 +499,14 @@ msgstr ""
 msgid "Check out our FAQ section for answers to common questions."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:67
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:67
+#: lib/klass_hero_web/live/provider/participation_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:130
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:130
+#: lib/klass_hero_web/live/provider/participation_live.ex:133
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -629,6 +629,8 @@ msgid "Don't have an account?"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:2023
+#: lib/klass_hero_web/components/provider_components.ex:2041
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
 #: lib/klass_hero_web/live/user_live/login.ex:49
@@ -665,14 +667,14 @@ msgstr ""
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:82
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:82
+#: lib/klass_hero_web/live/provider/participation_live.ex:85
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:147
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:147
+#: lib/klass_hero_web/live/provider/participation_live.ex:150
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
@@ -688,10 +690,10 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:328
-#: lib/klass_hero_web/live/provider/participation_live.ex:329
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:283
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
+#: lib/klass_hero_web/live/provider/participation_live.ex:399
+#: lib/klass_hero_web/live/provider/participation_live.ex:400
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:354
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Failed to load session data"
 msgstr ""
@@ -931,10 +933,14 @@ msgid "Questions About These Terms?"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:270
-#: lib/klass_hero_web/live/provider/participation_live.ex:57
-#: lib/klass_hero_web/live/provider/participation_live.ex:119
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:57
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:119
+#: lib/klass_hero_web/live/provider/participation_live.ex:60
+#: lib/klass_hero_web/live/provider/participation_live.ex:122
+#: lib/klass_hero_web/live/provider/participation_live.ex:269
+#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:208
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -981,9 +987,9 @@ msgstr ""
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1720
-#: lib/klass_hero_web/components/provider_components.ex:1721
-#: lib/klass_hero_web/components/provider_components.ex:1760
+#: lib/klass_hero_web/components/provider_components.ex:1723
+#: lib/klass_hero_web/components/provider_components.ex:1724
+#: lib/klass_hero_web/components/provider_components.ex:1763
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1005,8 +1011,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:69
 #: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:317
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:272
+#: lib/klass_hero_web/live/provider/participation_live.ex:388
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1544,9 +1550,9 @@ msgstr ""
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:16
+#: lib/klass_hero_web/live/provider/participation_live.ex:17
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:22
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:23
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
@@ -1902,25 +1908,25 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1319
-#: lib/klass_hero_web/components/provider_components.ex:1693
-#: lib/klass_hero_web/components/provider_components.ex:1876
+#: lib/klass_hero_web/components/provider_components.ex:1696
+#: lib/klass_hero_web/components/provider_components.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1407
+#: lib/klass_hero_web/components/provider_components.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:598
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1477
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:81
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1623
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1721
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1947,26 +1953,30 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:540
-#: lib/klass_hero_web/components/provider_components.ex:1388
+#: lib/klass_hero_web/components/provider_components.ex:1387
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:49
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:76
 #: lib/klass_hero_web/live/settings/children_live.ex:467
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:49
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:194
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:166
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:169
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/components/provider_components.ex:1408
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1988,9 +1998,9 @@ msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1408
-#: lib/klass_hero_web/components/provider_components.ex:1923
-#: lib/klass_hero_web/components/provider_components.ex:1943
+#: lib/klass_hero_web/components/provider_components.ex:1407
+#: lib/klass_hero_web/components/provider_components.ex:2117
+#: lib/klass_hero_web/components/provider_components.ex:2137
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
@@ -2033,9 +2043,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1313
-#: lib/klass_hero_web/components/provider_components.ex:1632
-#: lib/klass_hero_web/components/provider_components.ex:1687
-#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1927
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2048,7 +2058,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1457
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2059,14 +2069,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1343
-#: lib/klass_hero_web/components/provider_components.ex:1647
+#: lib/klass_hero_web/components/provider_components.ex:1650
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1410
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -2077,7 +2087,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1382
+#: lib/klass_hero_web/components/provider_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -2128,8 +2138,8 @@ msgstr ""
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:182
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:180
+#: lib/klass_hero_web/live/provider/participation_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr ""
@@ -2146,10 +2156,11 @@ msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
-#: lib/klass_hero_web/components/participation_components.ex:635
+#: lib/klass_hero_web/components/participation_components.ex:627
+#: lib/klass_hero_web/components/participation_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:765
 #: lib/klass_hero_web/components/provider_components.ex:1169
-#: lib/klass_hero_web/components/provider_components.ex:1812
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2213,6 +2224,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -2249,7 +2261,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:258
+#: lib/klass_hero_web/live/provider/participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -2260,17 +2272,23 @@ msgstr ""
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:199
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:197
+#: lib/klass_hero_web/live/provider/participation_live.ex:202
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2044
 #: lib/klass_hero_web/live/settings/children_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2339,9 +2357,9 @@ msgstr ""
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:188
-#: lib/klass_hero_web/live/provider/participation_live.ex:250
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:186
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/provider/participation_live.ex:253
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -2351,7 +2369,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:244
+#: lib/klass_hero_web/live/provider/participation_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -2407,7 +2425,7 @@ msgid "Provider data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:750
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
@@ -2418,8 +2436,8 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1493
 #: lib/klass_hero_web/components/provider_components.ex:1494
+#: lib/klass_hero_web/components/provider_components.ex:1495
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2437,6 +2455,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:2098
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
 #, elixir-autogen, elixir-format
@@ -2460,8 +2479,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:348
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:303
+#: lib/klass_hero_web/live/provider/participation_live.ex:419
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -2478,8 +2497,8 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
+#: lib/klass_hero_web/live/provider/participation_live.ex:194
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1412
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1499
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2612,7 +2631,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:2182
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2623,7 +2642,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:832
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
@@ -2651,7 +2670,7 @@ msgstr ""
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1199
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
 #: lib/klass_hero_web/live/provider/subscription_live.ex:100
 #, elixir-autogen, elixir-format
@@ -2698,17 +2717,17 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1221
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1308
 #, elixir-autogen, elixir-format
 msgid "Business Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1208
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1295
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1316
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
@@ -2724,8 +2743,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1684
-#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1921
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2745,7 +2764,7 @@ msgstr ""
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1283
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1924
+#: lib/klass_hero_web/components/provider_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2785,13 +2804,13 @@ msgstr ""
 msgid "Could not load verification documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:711
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:668
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:676
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2824,7 +2843,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2852,12 +2871,12 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:463
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:466
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2888,13 +2907,13 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1690
-#: lib/klass_hero_web/components/provider_components.ex:1946
+#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:2140
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1540
+#: lib/klass_hero_web/components/provider_components.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2909,7 +2928,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1947
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2925,12 +2944,12 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:689
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:472
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Failed to upload document."
 msgstr ""
@@ -2952,12 +2971,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2220
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2222
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2992,7 +3011,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1870
+#: lib/klass_hero_web/components/provider_components.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -3007,17 +3026,17 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
+#: lib/klass_hero_web/components/provider_components.ex:1898
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:720
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:759
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} families."
 msgstr ""
@@ -3032,22 +3051,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:665
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:662
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:639
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1557
+#: lib/klass_hero_web/components/provider_components.ex:1558
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -3058,7 +3077,7 @@ msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1144
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
@@ -3100,7 +3119,7 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:390
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:393
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
@@ -3158,18 +3177,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1677
+#: lib/klass_hero_web/components/provider_components.ex:1680
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -3179,7 +3198,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1857
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -3209,7 +3228,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1411
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -3242,7 +3261,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2130
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3257,17 +3276,17 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:831
 #: lib/klass_hero_web/components/provider_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:884
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:945
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:980
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1052
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:412
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:968
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1029
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1064
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1136
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
@@ -3288,7 +3307,7 @@ msgstr ""
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:405
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
 msgstr ""
@@ -3298,30 +3317,30 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1937
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1944
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:529
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:565
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:568
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:532
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:570
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:573
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:909
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:993
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:414
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
@@ -3331,8 +3350,8 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1945
+#: lib/klass_hero_web/components/participation_components.ex:809
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3399,7 +3418,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:753
+#: lib/klass_hero_web/components/participation_components.ex:833
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
@@ -3414,15 +3433,15 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:1120
-#: lib/klass_hero_web/components/provider_components.ex:1905
-#: lib/klass_hero_web/components/provider_components.ex:2149
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
+#: lib/klass_hero_web/components/provider_components.ex:1959
+#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3437,15 +3456,15 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1483
+#: lib/klass_hero_web/components/provider_components.ex:1484
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1955
-#: lib/klass_hero_web/components/provider_components.ex:1967
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:2149
+#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2172
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
@@ -3470,7 +3489,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2127
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3481,13 +3500,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:874
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:935
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:958
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2138
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3513,14 +3532,14 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:268
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:271
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:332
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3551,32 +3570,32 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1001
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:326
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1024
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1109
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1222
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
@@ -3586,12 +3605,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:642
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:927
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1011
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3606,7 +3625,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3626,32 +3645,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1789
+#: lib/klass_hero_web/components/provider_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2173
+#: lib/klass_hero_web/components/provider_components.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2082
+#: lib/klass_hero_web/components/provider_components.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
+#: lib/klass_hero_web/components/provider_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2223
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2045
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3834,7 +3853,7 @@ msgstr ""
 msgid "Current Plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1346
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1433
 #, elixir-autogen, elixir-format
 msgid "Current Plan: %{plan}"
 msgstr ""
@@ -3935,7 +3954,7 @@ msgstr ""
 msgid "Invalid subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Manage Plan →"
 msgstr ""
@@ -3970,7 +3989,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1781
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -4075,7 +4094,7 @@ msgstr ""
 msgid "Unlimited programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to unlock more features"
 msgstr ""
@@ -4202,7 +4221,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:815
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -4303,7 +4322,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:614
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:653
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -4329,22 +4348,19 @@ msgstr ""
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:733
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:734
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:1995
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -4360,7 +4376,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:732
+#: lib/klass_hero_web/components/participation_components.ex:812
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -4391,7 +4407,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:177
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4427,7 +4443,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1759
+#: lib/klass_hero_web/components/provider_components.ex:1762
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -4488,7 +4504,7 @@ msgstr ""
 msgid "Immediate account suspension"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/components/participation_components.ex:811
 #: lib/klass_hero_web/live/admin/sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -4555,7 +4571,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1509
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -4571,6 +4587,7 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
+#: lib/klass_hero_web/components/participation_components.ex:836
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:161
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
@@ -4582,7 +4599,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1761
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4693,7 +4710,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:730
+#: lib/klass_hero_web/components/participation_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
@@ -4738,13 +4755,13 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1754
+#: lib/klass_hero_web/components/provider_components.ex:1757
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:164
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:608
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:647
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -4865,8 +4882,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:88
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:88
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:112
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -4887,7 +4904,7 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:655
+#: lib/klass_hero_web/components/participation_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr ""
@@ -4934,16 +4951,10 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:67
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:67
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:91
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Check In"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:48
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:48
-#, elixir-autogen, elixir-format
-msgid "Check Out"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:276
@@ -5061,7 +5072,7 @@ msgstr ""
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:120
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -5089,7 +5100,7 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:667
+#: lib/klass_hero_web/components/participation_components.ex:747
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
@@ -5099,7 +5110,7 @@ msgstr ""
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:736
+#: lib/klass_hero_web/components/participation_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -5124,7 +5135,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -5192,7 +5203,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:342
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
@@ -5275,7 +5286,7 @@ msgstr ""
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:574
+#: lib/klass_hero_web/components/participation_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
@@ -5323,6 +5334,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:26
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -5440,7 +5452,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:987
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -5461,7 +5473,7 @@ msgstr ""
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:661
+#: lib/klass_hero_web/components/participation_components.ex:741
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -5471,7 +5483,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:352
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5531,8 +5543,8 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:456
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:459
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
@@ -5610,7 +5622,7 @@ msgid "View and manage your assigned sessions"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
@@ -5635,7 +5647,7 @@ msgstr ""
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:737
+#: lib/klass_hero_web/components/participation_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
@@ -5645,7 +5657,7 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1179
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1266
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Complete Profile"
@@ -5661,7 +5673,7 @@ msgstr ""
 msgid "Complete Your Provider Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1162
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1249
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
 msgstr ""
@@ -5691,7 +5703,7 @@ msgstr ""
 msgid "File type not accepted (images only)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
@@ -5737,7 +5749,7 @@ msgstr ""
 msgid "Remove attachment"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1328
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Sessions Completed"
 msgstr ""
@@ -5785,7 +5797,7 @@ msgstr ""
 msgid "Upload failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1093
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1177
 #, elixir-autogen, elixir-format
 msgid "View your assignments"
 msgstr ""
@@ -5796,7 +5808,7 @@ msgid "Website"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:435
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:866
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "You've reached your program limit. Upgrade your plan to add more programs."
 msgstr ""
@@ -5822,37 +5834,37 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1629
+#: lib/klass_hero_web/components/provider_components.ex:1632
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1631
+#: lib/klass_hero_web/components/provider_components.ex:1634
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1613
+#: lib/klass_hero_web/components/provider_components.ex:1616
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1630
+#: lib/klass_hero_web/components/provider_components.ex:1633
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1628
+#: lib/klass_hero_web/components/provider_components.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1622
+#: lib/klass_hero_web/components/provider_components.ex:1625
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1611
+#: lib/klass_hero_web/components/provider_components.ex:1614
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
@@ -5860,4 +5872,154 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "View sessions"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:793
+#, elixir-autogen, elixir-format
+msgid "Create a program before inviting participants."
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:814
+#, elixir-autogen, elixir-format
+msgid "Departed"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:835
+#, elixir-autogen, elixir-format
+msgid "Departure notes"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:318
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Departure time is not a valid date and time"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:329
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#, elixir-autogen, elixir-format
+msgid "Failed to update record"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2059
+#, elixir-autogen, elixir-format
+msgid "Grade"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1780
+#, elixir-autogen, elixir-format
+msgid "Invite mode"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1800
+#, elixir-autogen, elixir-format
+msgid "Invite one person"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:789
+#, elixir-autogen, elixir-format
+msgid "Invite sent."
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:600
+#, elixir-autogen, elixir-format
+msgid "Leave blank to keep this child marked as present."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2072
+#, elixir-autogen, elixir-format
+msgid "Medical & consents (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2078
+#, elixir-autogen, elixir-format
+msgid "Medical conditions"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:321
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:260
+#, elixir-autogen, elixir-format
+msgid "Nothing to update"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2080
+#, elixir-autogen, elixir-format
+msgid "Nut allergy"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2084
+#, elixir-autogen, elixir-format
+msgid "Photos may appear in marketing materials"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2089
+#, elixir-autogen, elixir-format
+msgid "Photos may appear on social media"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:813
+#, elixir-autogen, elixir-format
+msgid "Present"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2016
+#, elixir-autogen, elixir-format
+msgid "Primary guardian"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:61
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:61
+#, elixir-autogen, elixir-format
+msgid "Record departure"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:597
+#, elixir-autogen, elixir-format
+msgid "Record departure time (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#, elixir-autogen, elixir-format
+msgid "Record updated"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:614
+#, elixir-autogen, elixir-format
+msgid "Save changes"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2053
+#, elixir-autogen, elixir-format
+msgid "School (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2063
+#, elixir-autogen, elixir-format
+msgid "School name"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Second guardian (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2106
+#, elixir-autogen, elixir-format
+msgid "Send invite"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:589
+#, elixir-autogen, elixir-format
+msgid "Update the note for this child (e.g. clarify what happened)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1819
+#, elixir-autogen, elixir-format
+msgid "Upload a list"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#, elixir-autogen, elixir-format
+msgid "An invite for this child and program already exists."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -128,7 +128,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1515
+#: lib/klass_hero_web/components/provider_components.ex:1516
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -499,14 +499,14 @@ msgstr ""
 msgid "Check out our FAQ section for answers to common questions."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:67
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:67
+#: lib/klass_hero_web/live/provider/participation_live.ex:70
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:130
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:130
+#: lib/klass_hero_web/live/provider/participation_live.ex:133
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -629,6 +629,8 @@ msgid "Don't have an account?"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:645
+#: lib/klass_hero_web/components/provider_components.ex:2023
+#: lib/klass_hero_web/components/provider_components.ex:2041
 #: lib/klass_hero_web/live/contact_live.ex:65
 #: lib/klass_hero_web/live/contact_live.ex:141
 #: lib/klass_hero_web/live/user_live/login.ex:49
@@ -665,14 +667,14 @@ msgstr ""
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:82
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:82
+#: lib/klass_hero_web/live/provider/participation_live.ex:85
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:147
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:147
+#: lib/klass_hero_web/live/provider/participation_live.ex:150
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
@@ -688,10 +690,10 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:328
-#: lib/klass_hero_web/live/provider/participation_live.ex:329
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:283
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:284
+#: lib/klass_hero_web/live/provider/participation_live.ex:399
+#: lib/klass_hero_web/live/provider/participation_live.ex:400
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:354
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Failed to load session data"
 msgstr ""
@@ -931,10 +933,14 @@ msgid "Questions About These Terms?"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:270
-#: lib/klass_hero_web/live/provider/participation_live.ex:57
-#: lib/klass_hero_web/live/provider/participation_live.ex:119
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:57
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:119
+#: lib/klass_hero_web/live/provider/participation_live.ex:60
+#: lib/klass_hero_web/live/provider/participation_live.ex:122
+#: lib/klass_hero_web/live/provider/participation_live.ex:269
+#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:208
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -981,9 +987,9 @@ msgstr ""
 msgid "Send Magic Link"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1720
-#: lib/klass_hero_web/components/provider_components.ex:1721
-#: lib/klass_hero_web/components/provider_components.ex:1760
+#: lib/klass_hero_web/components/provider_components.ex:1723
+#: lib/klass_hero_web/components/provider_components.ex:1724
+#: lib/klass_hero_web/components/provider_components.ex:1763
 #: lib/klass_hero_web/live/contact_live.ex:184
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:281
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:282
@@ -1005,8 +1011,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:69
 #: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:317
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:272
+#: lib/klass_hero_web/live/provider/participation_live.ex:388
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1544,9 +1550,9 @@ msgstr ""
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:16
+#: lib/klass_hero_web/live/provider/participation_live.ex:17
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:22
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:23
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
@@ -1902,25 +1908,25 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1319
-#: lib/klass_hero_web/components/provider_components.ex:1693
-#: lib/klass_hero_web/components/provider_components.ex:1876
+#: lib/klass_hero_web/components/provider_components.ex:1696
+#: lib/klass_hero_web/components/provider_components.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1407
+#: lib/klass_hero_web/components/provider_components.ex:1406
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:598
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1477
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:81
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1623
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1721
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1947,26 +1953,30 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:540
-#: lib/klass_hero_web/components/provider_components.ex:1388
+#: lib/klass_hero_web/components/provider_components.ex:1387
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:49
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:76
 #: lib/klass_hero_web/live/settings/children_live.ex:467
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:49
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:194
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:166
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1203
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:169
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/components/provider_components.ex:1408
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1988,9 +1998,9 @@ msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1408
-#: lib/klass_hero_web/components/provider_components.ex:1923
-#: lib/klass_hero_web/components/provider_components.ex:1943
+#: lib/klass_hero_web/components/provider_components.ex:1407
+#: lib/klass_hero_web/components/provider_components.ex:2117
+#: lib/klass_hero_web/components/provider_components.ex:2137
 #: lib/klass_hero_web/live/admin/sessions_live.ex:318
 #: lib/klass_hero_web/live/admin/verifications_live.ex:209
 #, elixir-autogen, elixir-format
@@ -2033,9 +2043,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1313
-#: lib/klass_hero_web/components/provider_components.ex:1632
-#: lib/klass_hero_web/components/provider_components.ex:1687
-#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:1690
+#: lib/klass_hero_web/components/provider_components.ex:1927
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
@@ -2048,7 +2058,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1457
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2059,14 +2069,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1343
-#: lib/klass_hero_web/components/provider_components.ex:1647
+#: lib/klass_hero_web/components/provider_components.ex:1650
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1410
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -2077,7 +2087,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1382
+#: lib/klass_hero_web/components/provider_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -2128,8 +2138,8 @@ msgstr ""
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:182
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:180
+#: lib/klass_hero_web/live/provider/participation_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr ""
@@ -2146,10 +2156,11 @@ msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:436
-#: lib/klass_hero_web/components/participation_components.ex:635
+#: lib/klass_hero_web/components/participation_components.ex:627
+#: lib/klass_hero_web/components/participation_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:765
 #: lib/klass_hero_web/components/provider_components.ex:1169
-#: lib/klass_hero_web/components/provider_components.ex:1812
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
 #: lib/klass_hero_web/live/admin/verifications_live.ex:424
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
@@ -2213,6 +2224,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:2004
 #: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -2249,7 +2261,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:258
+#: lib/klass_hero_web/live/provider/participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -2260,17 +2272,23 @@ msgstr ""
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:199
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:197
+#: lib/klass_hero_web/live/provider/participation_live.ex:202
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2044
 #: lib/klass_hero_web/live/settings/children_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2339,9 +2357,9 @@ msgstr ""
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:188
-#: lib/klass_hero_web/live/provider/participation_live.ex:250
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:186
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/provider/participation_live.ex:253
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -2351,7 +2369,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:244
+#: lib/klass_hero_web/live/provider/participation_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -2407,7 +2425,7 @@ msgid "Provider data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:750
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1303
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #: lib/klass_hero_web/live/settings/children_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
@@ -2418,8 +2436,8 @@ msgstr ""
 msgid "Search for programs..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1493
 #: lib/klass_hero_web/components/provider_components.ex:1494
+#: lib/klass_hero_web/components/provider_components.ex:1495
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:37
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:128
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:227
@@ -2437,6 +2455,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:2098
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
 #, elixir-autogen, elixir-format, fuzzy
@@ -2460,8 +2479,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:348
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:303
+#: lib/klass_hero_web/live/provider/participation_live.ex:419
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -2478,8 +2497,8 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
+#: lib/klass_hero_web/live/provider/participation_live.ex:194
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
@@ -2592,7 +2611,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1412
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1499
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2612,7 +2631,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:2182
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2623,7 +2642,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:832
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:315
 #: lib/klass_hero_web/live/admin/verifications_live.ex:214
@@ -2651,7 +2670,7 @@ msgstr ""
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1199
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
 #: lib/klass_hero_web/live/provider/subscription_live.ex:100
 #, elixir-autogen, elixir-format
@@ -2698,17 +2717,17 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1221
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1308
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1208
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1295
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1229
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1316
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
@@ -2724,8 +2743,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1684
-#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1921
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2745,7 +2764,7 @@ msgstr ""
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1283
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
@@ -2770,7 +2789,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1924
+#: lib/klass_hero_web/components/provider_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2785,13 +2804,13 @@ msgstr ""
 msgid "Could not load verification documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:711
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:668
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:676
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2824,7 +2843,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2852,12 +2871,12 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:463
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:466
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2888,13 +2907,13 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1690
-#: lib/klass_hero_web/components/provider_components.ex:1946
+#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:2140
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1540
+#: lib/klass_hero_web/components/provider_components.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2909,7 +2928,7 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1947
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #: lib/klass_hero_web/live/admin/emails_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2925,12 +2944,12 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:689
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:472
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:475
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to upload document."
 msgstr ""
@@ -2952,12 +2971,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2220
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2222
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2992,7 +3011,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1870
+#: lib/klass_hero_web/components/provider_components.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -3007,17 +3026,17 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
+#: lib/klass_hero_web/components/provider_components.ex:1898
 #, elixir-autogen, elixir-format
 msgid "Import failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:720
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:759
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} families."
 msgstr ""
@@ -3032,22 +3051,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:665
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:662
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:639
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1557
+#: lib/klass_hero_web/components/provider_components.ex:1558
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -3058,7 +3077,7 @@ msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1144
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1286
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1373
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
@@ -3100,7 +3119,7 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:390
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:393
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
@@ -3158,18 +3177,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1677
+#: lib/klass_hero_web/components/provider_components.ex:1680
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:707
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -3179,7 +3198,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1857
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -3209,7 +3228,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1411
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -3242,7 +3261,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2130
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -3257,17 +3276,17 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:831
 #: lib/klass_hero_web/components/provider_components.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:884
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:945
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:980
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1052
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:412
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:968
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1029
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1064
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1136
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
@@ -3288,7 +3307,7 @@ msgstr ""
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:405
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:408
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile updated successfully."
 msgstr ""
@@ -3298,30 +3317,30 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1937
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2035
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1944
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:529
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:565
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:568
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:920
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:532
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:570
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:573
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1004
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:909
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:993
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:414
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
@@ -3331,8 +3350,8 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:1945
+#: lib/klass_hero_web/components/participation_components.ex:809
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -3399,7 +3418,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:753
+#: lib/klass_hero_web/components/participation_components.ex:833
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:219
 #, elixir-autogen, elixir-format
@@ -3414,15 +3433,15 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:715
 #: lib/klass_hero_web/components/provider_components.ex:1120
-#: lib/klass_hero_web/components/provider_components.ex:1905
-#: lib/klass_hero_web/components/provider_components.ex:2149
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1262
+#: lib/klass_hero_web/components/provider_components.ex:1959
+#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3437,15 +3456,15 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1483
+#: lib/klass_hero_web/components/provider_components.ex:1484
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1955
-#: lib/klass_hero_web/components/provider_components.ex:1967
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:2149
+#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2172
 #, elixir-autogen, elixir-format
 msgid "Row %{row}: %{msg}"
 msgstr ""
@@ -3470,7 +3489,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2127
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3481,13 +3500,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:874
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:935
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:958
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2138
 #: lib/klass_hero_web/live/admin/emails_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3513,14 +3532,14 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:268
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:271
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:332
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3551,32 +3570,32 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1001
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:326
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1024
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1109
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1222
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
@@ -3586,12 +3605,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:642
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:927
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1011
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3606,7 +3625,7 @@ msgstr ""
 msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3626,32 +3645,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1789
+#: lib/klass_hero_web/components/provider_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2173
+#: lib/klass_hero_web/components/provider_components.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2082
+#: lib/klass_hero_web/components/provider_components.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
+#: lib/klass_hero_web/components/provider_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2223
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2045
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3834,7 +3853,7 @@ msgstr ""
 msgid "Current Plan"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1346
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1433
 #, elixir-autogen, elixir-format
 msgid "Current Plan: %{plan}"
 msgstr ""
@@ -3935,7 +3954,7 @@ msgstr ""
 msgid "Invalid subscription tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Manage Plan →"
 msgstr ""
@@ -3970,7 +3989,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1781
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -4075,7 +4094,7 @@ msgstr ""
 msgid "Unlimited programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1349
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to unlock more features"
 msgstr ""
@@ -4202,7 +4221,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:815
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -4303,7 +4322,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:614
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:653
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -4329,22 +4348,19 @@ msgstr ""
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:733
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:734
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:1995
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -4360,7 +4376,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:732
+#: lib/klass_hero_web/components/participation_components.ex:812
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -4391,7 +4407,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:177
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:650
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4427,7 +4443,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1759
+#: lib/klass_hero_web/components/provider_components.ex:1762
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -4488,7 +4504,7 @@ msgstr ""
 msgid "Immediate account suspension"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:731
+#: lib/klass_hero_web/components/participation_components.ex:811
 #: lib/klass_hero_web/live/admin/sessions_live.ex:296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
@@ -4555,7 +4571,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1509
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -4571,6 +4587,7 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
+#: lib/klass_hero_web/components/participation_components.ex:836
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:161
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
@@ -4582,7 +4599,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1761
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4693,7 +4710,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:730
+#: lib/klass_hero_web/components/participation_components.ex:810
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scheduled"
 msgstr ""
@@ -4738,13 +4755,13 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1754
+#: lib/klass_hero_web/components/provider_components.ex:1757
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Professional to message parents"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:164
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:608
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:647
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -4865,8 +4882,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:88
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:88
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:112
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -4887,7 +4904,7 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:655
+#: lib/klass_hero_web/components/participation_components.ex:735
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies: %{details}"
 msgstr ""
@@ -4934,16 +4951,10 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:67
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:67
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:91
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:91
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check In"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:48
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:48
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Check Out"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:276
@@ -5061,7 +5072,7 @@ msgstr ""
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:120
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -5089,7 +5100,7 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:667
+#: lib/klass_hero_web/components/participation_components.ex:747
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
@@ -5099,7 +5110,7 @@ msgstr ""
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:736
+#: lib/klass_hero_web/components/participation_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -5124,7 +5135,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:361
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:364
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -5192,7 +5203,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:342
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:345
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -5275,7 +5286,7 @@ msgstr ""
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:574
+#: lib/klass_hero_web/components/participation_components.ex:654
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Note:"
 msgstr ""
@@ -5323,6 +5334,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:26
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:611
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -5440,7 +5452,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:987
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -5461,7 +5473,7 @@ msgstr ""
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:661
+#: lib/klass_hero_web/components/participation_components.ex:741
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -5471,7 +5483,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:352
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5531,8 +5543,8 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:456
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:704
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:459
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:743
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
@@ -5610,7 +5622,7 @@ msgid "View and manage your assigned sessions"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
@@ -5635,7 +5647,7 @@ msgstr ""
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:737
+#: lib/klass_hero_web/components/participation_components.ex:817
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancelled"
 msgstr ""
@@ -5645,7 +5657,7 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1179
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1266
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete Profile"
@@ -5661,7 +5673,7 @@ msgstr ""
 msgid "Complete Your Provider Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1162
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1249
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
 msgstr ""
@@ -5691,7 +5703,7 @@ msgstr ""
 msgid "File type not accepted (images only)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
@@ -5737,7 +5749,7 @@ msgstr ""
 msgid "Remove attachment"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1328
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1415
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions Completed"
 msgstr ""
@@ -5785,7 +5797,7 @@ msgstr ""
 msgid "Upload failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1093
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1177
 #, elixir-autogen, elixir-format
 msgid "View your assignments"
 msgstr ""
@@ -5796,7 +5808,7 @@ msgid "Website"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:435
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:866
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "You've reached your program limit. Upgrade your plan to add more programs."
 msgstr ""
@@ -5822,37 +5834,37 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1629
+#: lib/klass_hero_web/components/provider_components.ex:1632
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1631
+#: lib/klass_hero_web/components/provider_components.ex:1634
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1613
+#: lib/klass_hero_web/components/provider_components.ex:1616
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1630
+#: lib/klass_hero_web/components/provider_components.ex:1633
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1628
+#: lib/klass_hero_web/components/provider_components.ex:1631
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1622
+#: lib/klass_hero_web/components/provider_components.ex:1625
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1611
+#: lib/klass_hero_web/components/provider_components.ex:1614
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
@@ -5860,4 +5872,154 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "View sessions"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:793
+#, elixir-autogen, elixir-format
+msgid "Create a program before inviting participants."
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:814
+#, elixir-autogen, elixir-format
+msgid "Departed"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:835
+#, elixir-autogen, elixir-format
+msgid "Departure notes"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:318
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Departure time is not a valid date and time"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:329
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Failed to update record"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2059
+#, elixir-autogen, elixir-format
+msgid "Grade"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1780
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invite mode"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1800
+#, elixir-autogen, elixir-format
+msgid "Invite one person"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:789
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invite sent."
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:600
+#, elixir-autogen, elixir-format
+msgid "Leave blank to keep this child marked as present."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2072
+#, elixir-autogen, elixir-format
+msgid "Medical & consents (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2078
+#, elixir-autogen, elixir-format
+msgid "Medical conditions"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:321
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:260
+#, elixir-autogen, elixir-format
+msgid "Nothing to update"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2080
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Nut allergy"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2084
+#, elixir-autogen, elixir-format
+msgid "Photos may appear in marketing materials"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2089
+#, elixir-autogen, elixir-format
+msgid "Photos may appear on social media"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:813
+#, elixir-autogen, elixir-format
+msgid "Present"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2016
+#, elixir-autogen, elixir-format
+msgid "Primary guardian"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:61
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:61
+#, elixir-autogen, elixir-format
+msgid "Record departure"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:597
+#, elixir-autogen, elixir-format
+msgid "Record departure time (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#, elixir-autogen, elixir-format
+msgid "Record updated"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:614
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Save changes"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2053
+#, elixir-autogen, elixir-format, fuzzy
+msgid "School (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2063
+#, elixir-autogen, elixir-format
+msgid "School name"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Second guardian (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2106
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Send invite"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:589
+#, elixir-autogen, elixir-format
+msgid "Update the note for this child (e.g. clarify what happened)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1819
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Upload a list"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#, elixir-autogen, elixir-format
+msgid "An invite for this child and program already exists."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2003
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:2199
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2210
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2006
+#: lib/klass_hero_web/components/provider_components.ex:2200
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2007
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2008
+#: lib/klass_hero_web/components/provider_components.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2211
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2011
+#: lib/klass_hero_web/components/provider_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2013
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2003
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:2199
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2210
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2006
+#: lib/klass_hero_web/components/provider_components.ex:2200
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2007
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2008
+#: lib/klass_hero_web/components/provider_components.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2211
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2011
+#: lib/klass_hero_web/components/provider_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2013
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/test/klass_hero/enrollment/adapters/driven/persistence/repositories/bulk_enrollment_invite_repository_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/persistence/repositories/bulk_enrollment_invite_repository_test.exs
@@ -95,6 +95,93 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.BulkEnro
     end
   end
 
+  describe "create_one/1" do
+    setup :setup_program
+
+    test "inserts a single row and returns the persisted domain struct", %{
+      program: program,
+      provider: provider
+    } do
+      attrs = valid_invite_attrs(program, provider)
+
+      assert {:ok, invite} = BulkEnrollmentInviteRepository.create_one(attrs)
+      assert is_binary(invite.id)
+      assert invite.program_id == program.id
+      assert invite.provider_id == provider.id
+      assert invite.guardian_email == "parent@example.com"
+      assert invite.status == "pending"
+      assert Repo.aggregate(BulkEnrollmentInviteSchema, :count) == 1
+    end
+
+    test "returns {:error, changeset} when required fields are missing", %{
+      program: program,
+      provider: provider
+    } do
+      attrs = valid_invite_attrs(program, provider, %{child_last_name: nil})
+
+      assert {:error, %Ecto.Changeset{valid?: false} = changeset} =
+               BulkEnrollmentInviteRepository.create_one(attrs)
+
+      assert %{child_last_name: ["can't be blank"]} = errors_on(changeset)
+      assert Repo.aggregate(BulkEnrollmentInviteSchema, :count) == 0
+    end
+
+    test "rejects duplicate (program, email, first, last) via unique constraint", %{
+      program: program,
+      provider: provider
+    } do
+      attrs = valid_invite_attrs(program, provider)
+      assert {:ok, _} = BulkEnrollmentInviteRepository.create_one(attrs)
+
+      assert {:error, %Ecto.Changeset{valid?: false}} =
+               BulkEnrollmentInviteRepository.create_one(attrs)
+
+      assert Repo.aggregate(BulkEnrollmentInviteSchema, :count) == 1
+    end
+  end
+
+  describe "invite_exists?/4" do
+    setup :setup_program
+
+    test "returns false when no invite exists", %{program: program} do
+      refute BulkEnrollmentInviteRepository.invite_exists?(
+               program.id,
+               "new@example.com",
+               "Emma",
+               "Schmidt"
+             )
+    end
+
+    test "returns true for an exact-case-insensitive match", %{
+      program: program,
+      provider: provider
+    } do
+      {:ok, _} = BulkEnrollmentInviteRepository.create_one(valid_invite_attrs(program, provider))
+
+      assert BulkEnrollmentInviteRepository.invite_exists?(
+               program.id,
+               "PARENT@example.com",
+               "emma",
+               "SCHMIDT"
+             )
+    end
+
+    test "returns false for the same names under a different program_id", %{
+      program: program,
+      provider: provider
+    } do
+      other_program = insert(:program_schema, provider_id: provider.id, title: "Other")
+      {:ok, _} = BulkEnrollmentInviteRepository.create_one(valid_invite_attrs(program, provider))
+
+      refute BulkEnrollmentInviteRepository.invite_exists?(
+               other_program.id,
+               "parent@example.com",
+               "Emma",
+               "Schmidt"
+             )
+    end
+  end
+
   describe "list_existing_keys_for_programs/1" do
     setup :setup_program
 

--- a/test/klass_hero/enrollment/application/changeset_errors_test.exs
+++ b/test/klass_hero/enrollment/application/changeset_errors_test.exs
@@ -1,0 +1,103 @@
+defmodule KlassHero.Enrollment.Application.ChangesetErrorsTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Changeset
+
+  alias KlassHero.Enrollment.Application.ChangesetErrors
+
+  # A small inline changeset module so these tests don't depend on a
+  # persistence schema — the helper works on any Ecto.Changeset regardless
+  # of where it was produced.
+  defmodule Sample do
+    use Ecto.Schema
+
+    @primary_key false
+    embedded_schema do
+      field :name, :string
+      field :quantity, :integer
+    end
+  end
+
+  defp changeset(attrs) do
+    %Sample{}
+    |> cast(attrs, [:name, :quantity])
+    |> validate_required([:name])
+    |> validate_length(:name, min: 2, max: 10)
+    |> validate_number(:quantity, greater_than_or_equal_to: 0)
+  end
+
+  describe "field_list/1" do
+    test "returns [] for a valid changeset" do
+      assert ChangesetErrors.field_list(changeset(%{"name" => "ok"})) == []
+    end
+
+    test "flattens one-message-per-field errors" do
+      errors = ChangesetErrors.field_list(changeset(%{"name" => ""}))
+      assert {:name, "can't be blank"} in errors
+    end
+
+    test "expands %{count} placeholder using opts values" do
+      errors = ChangesetErrors.field_list(changeset(%{"name" => "a"}))
+
+      assert Enum.any?(errors, fn
+               {:name, msg} -> msg =~ "should be at least 2 character"
+               _ -> false
+             end),
+             "expected expanded count=2, got: #{inspect(errors)}"
+    end
+
+    test "surfaces multiple errors on the same field as separate list entries" do
+      errors = ChangesetErrors.field_list(changeset(%{"name" => "verylongvalueindeed"}))
+
+      # validate_length returns one 'should be at most' error
+      length_errors = Enum.filter(errors, fn {field, _} -> field == :name end)
+      assert length(length_errors) >= 1
+      assert Enum.all?(length_errors, fn {:name, msg} -> is_binary(msg) end)
+    end
+
+    test "expands number validation placeholder" do
+      errors = ChangesetErrors.field_list(changeset(%{"name" => "ok", "quantity" => -1}))
+
+      assert Enum.any?(errors, fn
+               {:quantity, msg} -> msg =~ "must be greater than or equal to 0"
+               _ -> false
+             end),
+             "expected expanded :number placeholder, got: #{inspect(errors)}"
+    end
+
+    test "leaves an unknown-atom placeholder intact instead of raising" do
+      # Simulate a custom validator that injects a placeholder whose key
+      # isn't a loaded atom. String.to_existing_atom would raise — the
+      # helper must swallow that and leave the literal `%{foo}` in place.
+      cs =
+        %Sample{}
+        |> cast(%{"name" => "ok"}, [:name])
+        |> add_error(:name, "bad %{definitely_not_a_loaded_atom_xyz123}")
+
+      assert [{:name, msg}] = ChangesetErrors.field_list(cs)
+      assert msg == "bad %{definitely_not_a_loaded_atom_xyz123}"
+    end
+
+    test "leaves a placeholder intact when the atom is loaded but not in opts" do
+      # `:count` is always loaded (Ecto uses it), but if a handcrafted error
+      # references it without providing the value, we should not corrupt the
+      # message with the raw key — keep the `%{count}` text so the gap is
+      # visible.
+      cs =
+        %Sample{}
+        |> cast(%{"name" => "ok"}, [:name])
+        |> add_error(:name, "needs %{count} things", validation: :custom)
+
+      assert [{:name, "needs %{count} things"}] = ChangesetErrors.field_list(cs)
+    end
+
+    test "replaces multiple placeholders within the same message" do
+      cs =
+        %Sample{}
+        |> cast(%{"name" => "ok"}, [:name])
+        |> add_error(:name, "expected %{min} to %{max}", min: 1, max: 10)
+
+      assert [{:name, "expected 1 to 10"}] = ChangesetErrors.field_list(cs)
+    end
+  end
+end

--- a/test/klass_hero/enrollment/application/changeset_errors_test.exs
+++ b/test/klass_hero/enrollment/application/changeset_errors_test.exs
@@ -51,7 +51,7 @@ defmodule KlassHero.Enrollment.Application.ChangesetErrorsTest do
 
       # validate_length returns one 'should be at most' error
       length_errors = Enum.filter(errors, fn {field, _} -> field == :name end)
-      assert length(length_errors) >= 1
+      assert length_errors != []
       assert Enum.all?(length_errors, fn {:name, msg} -> is_binary(msg) end)
     end
 

--- a/test/klass_hero/enrollment/application/commands/invite_single_participant_test.exs
+++ b/test/klass_hero/enrollment/application/commands/invite_single_participant_test.exs
@@ -1,0 +1,175 @@
+defmodule KlassHero.Enrollment.Application.Commands.InviteSingleParticipantTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.BulkEnrollmentInviteSchema
+  alias KlassHero.Enrollment.Application.Commands.InviteSingleParticipant
+  alias KlassHero.Repo
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Ballsports")
+    %{provider: provider, program: program}
+  end
+
+  defp valid_attrs(program, overrides \\ %{}) do
+    Map.merge(
+      %{
+        "program_id" => program.id,
+        "child_first_name" => "Emma",
+        "child_last_name" => "Schmidt",
+        "child_date_of_birth" => "2016-03-15",
+        "guardian_email" => "parent@example.com"
+      },
+      overrides
+    )
+  end
+
+  describe "execute/2 — happy path" do
+    test "persists the invite, returns its id, and drives the email pipeline", %{
+      provider: provider,
+      program: program
+    } do
+      assert {:ok, %{invite_id: invite_id}} =
+               InviteSingleParticipant.execute(provider.id, valid_attrs(program))
+
+      assert is_binary(invite_id)
+      invite = Repo.get!(BulkEnrollmentInviteSchema, invite_id)
+      assert invite.program_id == program.id
+      assert invite.provider_id == provider.id
+      assert invite.guardian_email == "parent@example.com"
+      # Trigger: downstream EnqueueInviteEmails handler runs synchronously in tests,
+      # same as the CSV pipeline — the invite advances past "pending" the moment the
+      # event dispatches. Matches what import_enrollment_csv_test asserts.
+      assert invite.status == "invite_sent"
+      assert is_binary(invite.invite_token)
+    end
+
+    test "persists optional fields when provided", %{provider: provider, program: program} do
+      attrs =
+        valid_attrs(program, %{
+          "guardian_first_name" => "Hans",
+          "guardian_last_name" => "Schmidt",
+          "guardian2_email" => "other@example.com",
+          "school_grade" => 3,
+          "school_name" => "Grundschule Mitte",
+          "nut_allergy" => true,
+          "consent_photo_marketing" => true
+        })
+
+      assert {:ok, %{invite_id: id}} = InviteSingleParticipant.execute(provider.id, attrs)
+      invite = Repo.get!(BulkEnrollmentInviteSchema, id)
+      assert invite.school_grade == 3
+      assert invite.nut_allergy == true
+      assert invite.consent_photo_marketing == true
+      assert invite.guardian2_email == "other@example.com"
+    end
+  end
+
+  describe "execute/2 — validation failures" do
+    test "returns validation_errors when required fields are blank", %{provider: provider} do
+      assert {:error, %{validation_errors: errors}} =
+               InviteSingleParticipant.execute(provider.id, %{})
+
+      fields = errors |> Enum.map(fn {f, _} -> f end) |> Enum.uniq()
+      assert :program_id in fields
+      assert :child_first_name in fields
+      assert :guardian_email in fields
+      assert :child_date_of_birth in fields
+    end
+
+    test "returns validation_errors for malformed guardian email", %{
+      provider: provider,
+      program: program
+    } do
+      attrs = valid_attrs(program, %{"guardian_email" => "not-an-email"})
+
+      assert {:error, %{validation_errors: errors}} =
+               InviteSingleParticipant.execute(provider.id, attrs)
+
+      assert {:guardian_email, "must be a valid email"} in errors
+    end
+
+    test "returns validation_errors for future date of birth", %{
+      provider: provider,
+      program: program
+    } do
+      future = Date.utc_today() |> Date.add(1) |> Date.to_iso8601()
+      attrs = valid_attrs(program, %{"child_date_of_birth" => future})
+
+      assert {:error, %{validation_errors: errors}} =
+               InviteSingleParticipant.execute(provider.id, attrs)
+
+      assert Enum.any?(errors, fn {f, m} -> f == :child_date_of_birth and m =~ "past" end)
+    end
+
+    test "returns validation_errors when program_id does not belong to the provider", %{
+      program: program
+    } do
+      # Trigger: other_provider needs at least one program so the pipeline reaches
+      # authorize_program — a bare catalog short-circuits with :no_programs earlier.
+      other_provider = insert(:provider_profile_schema)
+      insert(:program_schema, provider_id: other_provider.id, title: "Other Program")
+
+      assert {:error, %{validation_errors: errors}} =
+               InviteSingleParticipant.execute(other_provider.id, valid_attrs(program))
+
+      assert Enum.any?(errors, fn {f, m} ->
+               f == :program_id and m =~ "does not belong"
+             end)
+
+      assert Repo.aggregate(BulkEnrollmentInviteSchema, :count) == 0
+    end
+  end
+
+  describe "execute/2 — dedup & catalog state" do
+    test "returns :duplicate when the same child+email already invited to program", %{
+      provider: provider,
+      program: program
+    } do
+      assert {:ok, _} = InviteSingleParticipant.execute(provider.id, valid_attrs(program))
+
+      # Case-insensitive on email + names to match the unique key shape
+      retry =
+        valid_attrs(program, %{
+          "guardian_email" => "PARENT@example.com",
+          "child_first_name" => "EMMA"
+        })
+
+      assert {:error, :duplicate} = InviteSingleParticipant.execute(provider.id, retry)
+      assert Repo.aggregate(BulkEnrollmentInviteSchema, :count) == 1
+    end
+
+    test "returns :no_programs when the provider has an empty catalog" do
+      bare_provider = insert(:provider_profile_schema)
+
+      assert {:error, :no_programs} =
+               InviteSingleParticipant.execute(bare_provider.id, %{
+                 "program_id" => Ecto.UUID.generate(),
+                 "child_first_name" => "X",
+                 "child_last_name" => "Y",
+                 "child_date_of_birth" => "2016-01-01",
+                 "guardian_email" => "x@y.com"
+               })
+    end
+  end
+
+  describe "execute/2 — pipeline continuity" do
+    test "runs the SendInviteEmailWorker inline and tokenises the invite", %{
+      provider: provider,
+      program: program
+    } do
+      # Trigger: Oban is configured with testing: :inline, so enqueued jobs run
+      # immediately. That means we can't use assert_enqueued — we verify end-state
+      # instead: the invite was persisted, processed by the worker, and advanced
+      # out of "pending without token" into "invite_sent" with a token.
+      assert {:ok, %{invite_id: id}} =
+               InviteSingleParticipant.execute(provider.id, valid_attrs(program))
+
+      invite = Repo.get!(BulkEnrollmentInviteSchema, id)
+      assert invite.status == "invite_sent"
+      assert is_binary(invite.invite_token)
+    end
+  end
+end

--- a/test/klass_hero/enrollment/application/provider_program_context_test.exs
+++ b/test/klass_hero/enrollment/application/provider_program_context_test.exs
@@ -1,0 +1,42 @@
+defmodule KlassHero.Enrollment.Application.ProviderProgramContextTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment.Application.ProviderProgramContext
+
+  describe "for_provider/1" do
+    test "returns downcased programs_by_title for a provider with catalog entries" do
+      provider = insert(:provider_profile_schema)
+      insert(:program_schema, provider_id: provider.id, title: "Ballsports & Parkour")
+      insert(:program_schema, provider_id: provider.id, title: "Organic Arts")
+
+      assert {:ok,
+              %{
+                provider_id: provider_id,
+                programs_by_title: lookup
+              }} = ProviderProgramContext.for_provider(provider.id)
+
+      assert provider_id == provider.id
+      assert Map.has_key?(lookup, "ballsports & parkour")
+      assert Map.has_key?(lookup, "organic arts")
+      assert map_size(lookup) == 2
+    end
+
+    test "returns {:error, :no_programs} when the provider has no catalog entries" do
+      provider = insert(:provider_profile_schema)
+      assert {:error, :no_programs} = ProviderProgramContext.for_provider(provider.id)
+    end
+
+    test "returns {:error, {:title_collisions, titles}} when titles differ only by case" do
+      provider = insert(:provider_profile_schema)
+      insert(:program_schema, provider_id: provider.id, title: "Yoga")
+      insert(:program_schema, provider_id: provider.id, title: "YOGA")
+
+      assert {:error, {:title_collisions, titles}} =
+               ProviderProgramContext.for_provider(provider.id)
+
+      assert Enum.sort(titles) == ["YOGA", "Yoga"]
+    end
+  end
+end

--- a/test/klass_hero/enrollment/application/single_invite_form_test.exs
+++ b/test/klass_hero/enrollment/application/single_invite_form_test.exs
@@ -1,0 +1,101 @@
+defmodule KlassHero.Enrollment.Application.SingleInviteFormTest do
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Enrollment.Application.SingleInviteForm
+
+  @valid_attrs %{
+    "program_id" => "11111111-1111-1111-1111-111111111111",
+    "child_first_name" => "Emma",
+    "child_last_name" => "Schmidt",
+    "child_date_of_birth" => "2016-03-15",
+    "guardian_email" => "parent@example.com"
+  }
+
+  describe "changeset/2" do
+    test "is valid with the minimum required fields" do
+      changeset = SingleInviteForm.changeset(@valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "reports required-field errors when blank" do
+      changeset = SingleInviteForm.changeset(%{})
+
+      errors = errors_on(changeset)
+      assert errors[:program_id] == ["can't be blank"]
+      assert errors[:child_first_name] == ["can't be blank"]
+      assert errors[:child_last_name] == ["can't be blank"]
+      assert errors[:child_date_of_birth] == ["can't be blank"]
+      assert errors[:guardian_email] == ["can't be blank"]
+    end
+
+    test "rejects malformed guardian email" do
+      changeset = SingleInviteForm.changeset(Map.put(@valid_attrs, "guardian_email", "not-an-email"))
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:guardian_email] == ["must be a valid email"]
+    end
+
+    test "rejects guardian2_email when provided but invalid" do
+      changeset =
+        SingleInviteForm.changeset(Map.put(@valid_attrs, "guardian2_email", "nope"))
+
+      assert errors_on(changeset)[:guardian2_email] == ["must be a valid email"]
+    end
+
+    test "accepts empty guardian2_email (optional second guardian)" do
+      changeset = SingleInviteForm.changeset(Map.put(@valid_attrs, "guardian2_email", ""))
+      assert changeset.valid?
+    end
+
+    test "rejects future date of birth" do
+      future = Date.utc_today() |> Date.add(1) |> Date.to_iso8601()
+
+      changeset =
+        SingleInviteForm.changeset(Map.put(@valid_attrs, "child_date_of_birth", future))
+
+      assert errors_on(changeset)[:child_date_of_birth] == ["must be in the past"]
+    end
+
+    test "rejects school_grade outside 1..13" do
+      changeset = SingleInviteForm.changeset(Map.put(@valid_attrs, "school_grade", "14"))
+      assert errors_on(changeset)[:school_grade]
+    end
+  end
+
+  describe "to_invite_row/1" do
+    test "returns the persistence-ready attribute map for a valid changeset" do
+      {:ok, row} =
+        @valid_attrs
+        |> SingleInviteForm.changeset()
+        |> SingleInviteForm.to_invite_row()
+
+      assert row.child_first_name == "Emma"
+      assert row.guardian_email == "parent@example.com"
+      assert row.child_date_of_birth == ~D[2016-03-15]
+      # provider_id is set by the command from the current scope, not the form
+      assert row.provider_id == nil
+    end
+
+    test "returns {:error, changeset} for an invalid changeset" do
+      assert {:error, %Ecto.Changeset{valid?: false}} =
+               %{} |> SingleInviteForm.changeset() |> SingleInviteForm.to_invite_row()
+    end
+  end
+
+  describe "apply_domain_errors/2" do
+    test "adds each field error onto the changeset with :action=:validate" do
+      changeset = SingleInviteForm.changeset(@valid_attrs)
+
+      updated =
+        SingleInviteForm.apply_domain_errors(changeset, [
+          {:program_id, "does not belong to this provider"},
+          {:guardian_email, "already invited for this program"}
+        ])
+
+      assert updated.action == :validate
+      errors = errors_on(updated)
+      assert errors[:program_id] == ["does not belong to this provider"]
+      assert errors[:guardian_email] == ["already invited for this program"]
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_live_test.exs
@@ -575,8 +575,8 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
     test "defaults to single-invite mode with the form rendered", %{conn: conn, program: program} do
       view = open_invites_tab(conn, program.id)
 
-      assert has_element?(view, "#invite-mode-single[aria-selected=true]")
-      assert has_element?(view, "#invite-mode-csv[aria-selected=false]")
+      assert has_element?(view, "#invite-mode-single[aria-pressed=true]")
+      assert has_element?(view, "#invite-mode-csv[aria-pressed=false]")
       assert has_element?(view, "#single-invite-form")
       # CSV upload form should NOT be present in single mode
       refute has_element?(view, "#csv-upload-form")
@@ -587,13 +587,28 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
 
       view |> element("#invite-mode-csv") |> render_click()
 
-      assert has_element?(view, "#invite-mode-csv[aria-selected=true]")
+      assert has_element?(view, "#invite-mode-csv[aria-pressed=true]")
       assert has_element?(view, "#csv-upload-form")
       refute has_element?(view, "#single-invite-form")
 
       view |> element("#invite-mode-single") |> render_click()
 
-      assert has_element?(view, "#invite-mode-single[aria-selected=true]")
+      assert has_element?(view, "#invite-mode-single[aria-pressed=true]")
+      assert has_element?(view, "#single-invite-form")
+    end
+
+    test "ignores switch_invite_mode with an unknown mode without crashing", %{
+      conn: conn,
+      program: program
+    } do
+      view = open_invites_tab(conn, program.id)
+
+      # Bypass the markup (which only emits "single"/"csv") and push a
+      # raw event, simulating a buggy Hook or a crafted channel message.
+      render_hook(view, "switch_invite_mode", %{"mode" => "hacked"})
+
+      # Socket stays alive and the mode is unchanged from its default.
+      assert has_element?(view, "#invite-mode-single[aria-pressed=true]")
       assert has_element?(view, "#single-invite-form")
     end
 

--- a/test/klass_hero_web/live/provider/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_live_test.exs
@@ -551,6 +551,139 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
   end
 
   # ===========================================================================
+  # Issue #546: manual single-invite form
+  # ===========================================================================
+
+  describe "single invite form" do
+    setup %{provider: provider} do
+      program =
+        insert_program_with_listing(
+          provider_id: provider.id,
+          title: "Single Invite Program"
+        )
+
+      %{program: program}
+    end
+
+    defp open_invites_tab(conn, program_id) do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+      view |> element("#view-roster-#{program_id}") |> render_click()
+      view |> element("#roster-tab-invites") |> render_click()
+      view
+    end
+
+    test "defaults to single-invite mode with the form rendered", %{conn: conn, program: program} do
+      view = open_invites_tab(conn, program.id)
+
+      assert has_element?(view, "#invite-mode-single[aria-selected=true]")
+      assert has_element?(view, "#invite-mode-csv[aria-selected=false]")
+      assert has_element?(view, "#single-invite-form")
+      # CSV upload form should NOT be present in single mode
+      refute has_element?(view, "#csv-upload-form")
+    end
+
+    test "switches to CSV mode and back", %{conn: conn, program: program} do
+      view = open_invites_tab(conn, program.id)
+
+      view |> element("#invite-mode-csv") |> render_click()
+
+      assert has_element?(view, "#invite-mode-csv[aria-selected=true]")
+      assert has_element?(view, "#csv-upload-form")
+      refute has_element?(view, "#single-invite-form")
+
+      view |> element("#invite-mode-single") |> render_click()
+
+      assert has_element?(view, "#invite-mode-single[aria-selected=true]")
+      assert has_element?(view, "#single-invite-form")
+    end
+
+    test "shows inline error on invalid email via phx-change", %{conn: conn, program: program} do
+      view = open_invites_tab(conn, program.id)
+
+      html =
+        view
+        |> form("#single-invite-form",
+          single_invite: %{
+            "program_id" => program.id,
+            "child_first_name" => "Emma",
+            "child_last_name" => "Schmidt",
+            "child_date_of_birth" => "2016-03-15",
+            "guardian_email" => "not-an-email"
+          }
+        )
+        |> render_change()
+
+      assert html =~ "must be a valid email"
+    end
+
+    test "successful submit adds the invite to the table and flashes", %{
+      conn: conn,
+      program: program
+    } do
+      view = open_invites_tab(conn, program.id)
+
+      html =
+        view
+        |> form("#single-invite-form",
+          single_invite: %{
+            "program_id" => program.id,
+            "child_first_name" => "Emma",
+            "child_last_name" => "Schmidt",
+            "child_date_of_birth" => "2016-03-15",
+            "guardian_email" => "new-parent@example.com"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "Invite sent"
+      assert has_element?(view, "#invites-table")
+      assert render(view) =~ "Emma"
+      assert render(view) =~ "new-parent@example.com"
+    end
+
+    test "duplicate submit surfaces an error flash and adds no new row", %{
+      conn: conn,
+      provider: provider,
+      program: program
+    } do
+      # Seed an existing invite matching the form submission
+      {:ok, _} =
+        BulkEnrollmentInviteRepository.create_batch([
+          %{
+            program_id: program.id,
+            provider_id: provider.id,
+            child_first_name: "Emma",
+            child_last_name: "Schmidt",
+            child_date_of_birth: ~D[2016-03-15],
+            guardian_email: "existing@example.com"
+          }
+        ])
+
+      view = open_invites_tab(conn, program.id)
+
+      html =
+        view
+        |> form("#single-invite-form",
+          single_invite: %{
+            "program_id" => program.id,
+            "child_first_name" => "Emma",
+            "child_last_name" => "Schmidt",
+            "child_date_of_birth" => "2016-03-15",
+            "guardian_email" => "existing@example.com"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "already exists"
+
+      # Still only one invite in the table
+      rendered = render(view)
+      existing_count = rendered |> String.split("existing@example.com") |> length() |> Kernel.-(1)
+      assert existing_count == 1
+    end
+  end
+
+  # ===========================================================================
   # T3: close_roster handler
   # ===========================================================================
 
@@ -808,6 +941,9 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
     defp navigate_to_invites_tab(view, program) do
       view |> element("#view-roster-#{program.id}") |> render_click()
       view |> element("#roster-tab-invites") |> render_click()
+      # Issue #546: Invites tab now defaults to the single-invite form; switch to
+      # CSV mode so the upload form is present for these CSV-specific tests.
+      view |> element("#invite-mode-csv") |> render_click()
     end
 
     test "successful import shows flash and refreshes invites", %{

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -642,15 +642,25 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
 
       view |> element("#edit-btn-#{record.id}") |> render_click()
 
+      # Pick a check-out time strictly after check_in_at (which was just set
+      # to DateTime.utc_now/0). HTML datetime-local drops seconds, so we align
+      # to minute precision to get an exact round-trip through the parser.
+      expected_check_out =
+        DateTime.utc_now()
+        |> DateTime.add(60, :second)
+        |> Map.merge(%{second: 0, microsecond: {0, 0}})
+
+      form_value = Calendar.strftime(expected_check_out, "%Y-%m-%dT%H:%M")
+
       view
       |> form("#edit-record-form-#{record.id}",
-        edit: %{notes: "Picked up by dad", check_out_at: "2026-04-20T15:30"}
+        edit: %{notes: "Picked up by dad", check_out_at: form_value}
       )
       |> render_submit()
 
       reloaded = KlassHero.Repo.get!(ParticipationRecordSchema, record.id)
       assert reloaded.status == :checked_out
-      assert reloaded.check_out_at == ~U[2026-04-20 15:30:00Z]
+      assert reloaded.check_out_at == expected_check_out
       assert reloaded.check_out_notes == "Picked up by dad"
     end
 

--- a/test/klass_hero_web/live/staff/staff_participation_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_participation_live_test.exs
@@ -223,9 +223,19 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
 
       view |> element("#edit-btn-#{record.id}") |> render_click()
 
+      # Pick a check-out time strictly after check_in_at (which was just set
+      # to DateTime.utc_now/0). HTML datetime-local drops seconds, so we align
+      # to minute precision to get an exact round-trip through the parser.
+      expected_check_out =
+        DateTime.utc_now()
+        |> DateTime.add(60, :second)
+        |> Map.merge(%{second: 0, microsecond: {0, 0}})
+
+      form_value = Calendar.strftime(expected_check_out, "%Y-%m-%dT%H:%M")
+
       view
       |> form("#edit-record-form-#{record.id}",
-        edit: %{notes: "Mum collected", check_out_at: "2026-04-20T16:15"}
+        edit: %{notes: "Mum collected", check_out_at: form_value}
       )
       |> render_submit()
 
@@ -236,7 +246,7 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
         )
 
       assert reloaded.status == :checked_out
-      assert reloaded.check_out_at == ~U[2026-04-20 16:15:00Z]
+      assert reloaded.check_out_at == expected_check_out
       assert reloaded.check_out_notes == "Mum collected"
     end
   end

--- a/test/klass_hero_web/presenters/tier_presenter_test.exs
+++ b/test/klass_hero_web/presenters/tier_presenter_test.exs
@@ -11,7 +11,10 @@ defmodule KlassHeroWeb.Presenters.TierPresenterTest do
     end
 
     test "raises FunctionClauseError for unknown tier" do
+      # apply/3 defeats the compile-time type tracker, which otherwise
+      # warns that :unknown can never match the function's clauses
       assert_raise FunctionClauseError, fn ->
+        # credo:disable-for-next-line Credo.Check.Refactor.Apply
         apply(TierPresenter, :tier_label, [:unknown])
       end
     end


### PR DESCRIPTION
Closes #546.

## Summary

- Adds a **single-invite form** alongside the CSV uploader on the provider roster modal's invites tab, so providers can invite one family in ~60 seconds instead of preparing a CSV for one row.
- Reuses the existing `:bulk_invites_imported` event pipeline (`EnqueueInviteEmails` → `SendInviteEmailWorker`) with `count: 1`. Zero downstream handler changes.
- Extracts three shared helpers so the new path and the CSV path can't drift: `InviteFieldValidations` (all field-shape rules), `BulkEnrollmentInvite.dedup_key/4` (the natural uniqueness tuple), and `ChangesetErrors.field_list/1` (canonical `%{count}`-aware error formatter — also fixes a latent placeholder leak in the CSV path's error formatting).

## Review Focus

- **`InviteSingleParticipant` command** (`lib/klass_hero/enrollment/application/commands/invite_single_participant.ex`) — validate → authorize → dedup → persist → publish. Returns `{:ok, %{invite_id: _}}` / `{:error, :no_programs | :duplicate | %{validation_errors: _}}`.
- **Port additions** (`ForStoringBulkEnrollmentInvites.create_one/1` + `ForQueryingBulkEnrollmentInvites.invite_exists?/4`) and their repo implementations — the new path no longer full-scans program invites just to check one membership; it uses a scalar `EXISTS` query.
- **`SingleInviteForm`** (embedded schema) and how it delegates all field validation to `InviteFieldValidations` so the form can't diverge from `BulkEnrollmentInviteSchema.import_changeset/2`.
- **`Provider.DashboardLive` handlers** (`switch_invite_mode`, `validate_single_invite`, `submit_single_invite`) and the `invite_mode` / `single_invite_form` assigns threaded through `programs_section` → `roster_modal` → `invites_tab`.
- **UI component** (`ProviderComponents.single_invite_form/1`) — five accessible `<section>` groups with `aria-labelledby`, mobile-first (pills stack on <md, grid collapses to 1-col), submit disabled-with `Sending...`.

## Test Plan

- [x] `mix precommit` clean (compile --warnings-as-errors, format, credo, full suite; the 2 pre-existing attendance-test failures from PR #709 are unrelated — confirmed on pristine branch).
- [x] 631 tests pass across Enrollment + LiveView touch range:
  - [x] Command: happy, no_programs, duplicate, bad email, future dob, unknown program.
  - [x] Form changeset: required, format, range, cast-and-attach-domain-errors.
  - [x] Repo: `create_one/1` persists + returns struct; `invite_exists?/4` case-insensitive.
  - [x] LiveView: default-mode render, mode toggle, inline validation, happy submit, duplicate flash.
- [x] Architecture review clean (18/18 checks): structural and semantic-boundary agents ran clean.
- [x] Test-drive clean (25/25 checks via Tidewave + Chrome DevTools MCP):
  - [x] End-to-end: submit → DB row → event → `EnqueueInviteEmails` → token → `invite_sent` status; confirmed via Tidewave logs.
  - [x] Case-insensitive duplicate detection against existing row.
  - [x] Mode toggle round-trip.
  - [x] Mobile viewport: pills stack, form collapses to 1-col.
  - [x] CSV regression: switching back to CSV mode preserves existing uploader unchanged.
- [x] Gettext: 21 new strings with German translations populated.

## Non-goals

- No changes to the CSV import flow beyond adding the sibling mode toggle.
- No new route; single-invite lives inside the existing roster modal on `/provider/dashboard/programs`.
- No migration, no new config keys.
- No email template changes; pipeline reused verbatim.