### PR TITLE
feat: pay rates per staff member with Money value object

### DIFF
--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -28,6 +28,7 @@ defmodule KlassHero.Provider do
     exports: [
       Domain.Models.ProviderProfile,
       Domain.Models.StaffMember,
+      Domain.Models.PayRate,
       Domain.Models.VerificationDocument,
       Domain.Models.ProgramStaffAssignment,
       Domain.ReadModels.SessionStats,

--- a/lib/klass_hero/provider/adapters/driven/persistence/change_staff_member.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/change_staff_member.ex
@@ -21,6 +21,14 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.ChangeStaffMember do
   end
 
   defp staff_to_schema(%StaffMember{} = staff) do
+    # Flatten pay_rate so the form renders current values. Without this the Edit
+    # form always shows "None" and a no-touch save would wipe the persisted rate.
+    {rate_type, rate_amount, rate_currency} =
+      case staff.pay_rate do
+        nil -> {nil, nil, nil}
+        %{type: type, money: %{amount: amount, currency: currency}} -> {type, amount, currency}
+      end
+
     %StaffMemberSchema{
       id: staff.id,
       provider_id: staff.provider_id,
@@ -32,7 +40,10 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.ChangeStaffMember do
       headshot_url: staff.headshot_url,
       tags: staff.tags,
       qualifications: staff.qualifications,
-      active: staff.active
+      active: staff.active,
+      rate_type: rate_type,
+      rate_amount: rate_amount,
+      rate_currency: rate_currency
     }
   end
 end

--- a/lib/klass_hero/provider/adapters/driven/persistence/mappers/staff_member_mapper.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/mappers/staff_member_mapper.ex
@@ -7,7 +7,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapp
     only: [maybe_add_id: 2]
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSchema
-  alias KlassHero.Provider.Domain.Models.StaffMember
+  alias KlassHero.Provider.Domain.Models.{PayRate, StaffMember}
+  alias KlassHero.Shared.Domain.Types.Money
 
   @spec to_domain(StaffMemberSchema.t()) :: StaffMember.t()
   def to_domain(%StaffMemberSchema{} = schema) do
@@ -27,6 +28,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapp
       invitation_status: atomize_invitation_status(schema.invitation_status),
       invitation_token_hash: schema.invitation_token_hash,
       invitation_sent_at: schema.invitation_sent_at,
+      pay_rate: build_pay_rate(schema),
       inserted_at: schema.inserted_at,
       updated_at: schema.updated_at
     }
@@ -50,6 +52,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapp
       invitation_token_hash: staff.invitation_token_hash,
       invitation_sent_at: staff.invitation_sent_at
     }
+    |> Map.merge(flatten_pay_rate(staff.pay_rate))
     |> maybe_add_id(staff.id)
   end
 
@@ -58,4 +61,22 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapp
   defp atomize_invitation_status(status) when is_binary(status), do: String.to_existing_atom(status)
 
   defp atomize_invitation_status(status) when is_atom(status), do: status
+
+  defp build_pay_rate(%StaffMemberSchema{rate_type: type, rate_amount: %Decimal{} = amount, rate_currency: currency})
+       when is_atom(type) and is_atom(currency) and not is_nil(type) and not is_nil(currency) do
+    with {:ok, money} <- Money.from_persistence(%{amount: amount, currency: currency}),
+         {:ok, pay_rate} <- PayRate.from_persistence(%{type: type, money: money}) do
+      pay_rate
+    else
+      _ -> nil
+    end
+  end
+
+  defp build_pay_rate(_), do: nil
+
+  defp flatten_pay_rate(nil), do: %{rate_type: nil, rate_amount: nil, rate_currency: nil}
+
+  defp flatten_pay_rate(%PayRate{type: type, money: %Money{amount: amount, currency: currency}}) do
+    %{rate_type: type, rate_amount: amount, rate_currency: currency}
+  end
 end

--- a/lib/klass_hero/provider/adapters/driven/persistence/schemas/staff_member_schema.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/schemas/staff_member_schema.ex
@@ -10,8 +10,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
   import Ecto.Changeset
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProfileSchema
-  alias KlassHero.Provider.Domain.Models.StaffMember
+  alias KlassHero.Provider.Domain.Models.{PayRate, StaffMember}
   alias KlassHero.Shared.Categories
+  alias KlassHero.Shared.Domain.Types.Money
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @timestamps_opts [type: :utc_datetime]
@@ -31,9 +32,14 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
     field :invitation_token_hash, :binary
     field :invitation_sent_at, :utc_datetime_usec
     field :user_id, :binary_id
+    field :rate_type, Ecto.Enum, values: PayRate.valid_types()
+    field :rate_amount, :decimal
+    field :rate_currency, Ecto.Enum, values: Money.valid_currencies()
 
     timestamps()
   end
+
+  @pay_rate_fields [:rate_type, :rate_amount, :rate_currency]
 
   @doc """
   Changeset for creating a new staff member.
@@ -45,6 +51,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
   Keep both in sync when changing constraints.
   """
   def create_changeset(schema, attrs) do
+    attrs = apply_pay_rate_struct(attrs)
     provider_id = attrs[:provider_id] || attrs["provider_id"]
 
     schema
@@ -59,7 +66,10 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
       :qualifications,
       :active,
       :invitation_status,
-      :invitation_token_hash
+      :invitation_token_hash,
+      :rate_type,
+      :rate_amount,
+      :rate_currency
     ])
     |> put_change(:provider_id, provider_id)
     |> validate_required([:provider_id, :first_name, :last_name])
@@ -74,6 +84,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
       :invitation_status,
       Enum.map(StaffMember.valid_invitation_statuses(), &to_string/1)
     )
+    |> validate_pay_rate()
     |> foreign_key_constraint(:provider_id)
   end
 
@@ -86,6 +97,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
   Keep both in sync when changing constraints.
   """
   def edit_changeset(schema, attrs) do
+    attrs = apply_pay_rate_struct(attrs)
+
     schema
     |> cast(attrs, [
       :first_name,
@@ -100,7 +113,10 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
       :invitation_status,
       :invitation_token_hash,
       :invitation_sent_at,
-      :user_id
+      :user_id,
+      :rate_type,
+      :rate_amount,
+      :rate_currency
     ])
     |> validate_required([:first_name, :last_name])
     |> validate_length(:first_name, min: 1, max: 100)
@@ -114,6 +130,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
       :invitation_status,
       Enum.map(StaffMember.valid_invitation_statuses(), &to_string/1)
     )
+    |> validate_pay_rate()
     |> foreign_key_constraint(:user_id)
   end
 
@@ -161,4 +178,51 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
         end
     end
   end
+
+  # rate_type and rate_currency use Ecto.Enum (value inclusion handled at cast).
+  # This validates non-negativity and enforces the all-or-none invariant —
+  # mirrors the DB CHECK constraint pay_rate_all_or_none.
+  defp validate_pay_rate(changeset) do
+    changeset
+    |> validate_number(:rate_amount, greater_than_or_equal_to: 0)
+    |> validate_pay_rate_all_or_none()
+    |> check_constraint(:rate_type,
+      name: :pay_rate_all_or_none,
+      message: "must set type, amount, and currency together"
+    )
+  end
+
+  defp validate_pay_rate_all_or_none(changeset) do
+    set_count = Enum.count(@pay_rate_fields, &(not is_nil(resolved_field(changeset, &1))))
+
+    if set_count in [0, length(@pay_rate_fields)] do
+      changeset
+    else
+      add_error(changeset, :rate_type, "must set type, amount, and currency together")
+    end
+  end
+
+  defp resolved_field(changeset, field) do
+    case Map.fetch(changeset.changes, field) do
+      {:ok, value} -> value
+      :error -> Map.get(changeset.data, field)
+    end
+  end
+
+  # Callers may hand us a `%PayRate{}` via a `:pay_rate` key (e.g. use-case flow)
+  # or the three flat fields directly (e.g. a LiveView form). Normalize to flat
+  # so `cast/2` picks them up.
+  defp apply_pay_rate_struct(%{pay_rate: nil} = attrs) do
+    attrs
+    |> Map.delete(:pay_rate)
+    |> Map.merge(%{rate_type: nil, rate_amount: nil, rate_currency: nil})
+  end
+
+  defp apply_pay_rate_struct(%{pay_rate: %PayRate{type: type, money: %Money{} = money}} = attrs) do
+    attrs
+    |> Map.delete(:pay_rate)
+    |> Map.merge(%{rate_type: type, rate_amount: money.amount, rate_currency: money.currency})
+  end
+
+  defp apply_pay_rate_struct(attrs), do: attrs
 end

--- a/lib/klass_hero/provider/application/commands/staff_members/update_staff_member.ex
+++ b/lib/klass_hero/provider/application/commands/staff_members/update_staff_member.ex
@@ -10,7 +10,7 @@ defmodule KlassHero.Provider.Application.Commands.StaffMembers.UpdateStaffMember
   @query Application.compile_env!(:klass_hero, [:provider, :for_querying_staff_members])
   @repository Application.compile_env!(:klass_hero, [:provider, :for_storing_staff_members])
 
-  @allowed_fields ~w(first_name last_name role email bio headshot_url tags qualifications active)a
+  @allowed_fields ~w(first_name last_name role email bio headshot_url tags qualifications active pay_rate)a
 
   def execute(staff_id, attrs) when is_binary(staff_id) and is_map(attrs) do
     attrs = Map.take(attrs, @allowed_fields)

--- a/lib/klass_hero/provider/domain/models/pay_rate.ex
+++ b/lib/klass_hero/provider/domain/models/pay_rate.ex
@@ -1,0 +1,82 @@
+defmodule KlassHero.Provider.Domain.Models.PayRate do
+  @moduledoc """
+  Value object pairing a rate type (`:hourly` | `:per_session`) with a `Money` amount.
+
+  Staff members may have no rate (nil), an hourly rate, or a per-session rate —
+  never both. Mutual exclusivity is guaranteed by the type tag: a single `PayRate`
+  can only carry one type.
+  """
+
+  alias KlassHero.Shared.Domain.Types.Money
+
+  @enforce_keys [:type, :money]
+  defstruct [:type, :money]
+
+  @type rate_type :: :hourly | :per_session
+  @type t :: %__MODULE__{type: rate_type(), money: Money.t()}
+
+  @valid_types [:hourly, :per_session]
+
+  @doc "Supported rate types."
+  @spec valid_types() :: [rate_type()]
+  def valid_types, do: @valid_types
+
+  @doc "Smart constructor for an hourly rate."
+  @spec hourly(Decimal.t() | number() | String.t(), atom()) ::
+          {:ok, t()} | {:error, [String.t()]}
+  def hourly(amount, currency \\ :EUR), do: build(:hourly, amount, currency)
+
+  @doc "Smart constructor for a per-session rate."
+  @spec per_session(Decimal.t() | number() | String.t(), atom()) ::
+          {:ok, t()} | {:error, [String.t()]}
+  def per_session(amount, currency \\ :EUR), do: build(:per_session, amount, currency)
+
+  @doc """
+  Raw constructor. Validates that `type` is supported and `money` is a valid `%Money{}`.
+  Use the smart constructors (`hourly/2`, `per_session/2`) at call sites when possible.
+  """
+  @spec new(%{type: rate_type(), money: Money.t() | nil}) ::
+          {:ok, t()} | {:error, [String.t()]}
+  def new(%{type: type, money: money}) do
+    with :ok <- validate_type(type),
+         :ok <- validate_money(money) do
+      {:ok, %__MODULE__{type: type, money: money}}
+    end
+  end
+
+  @doc """
+  Reconstructs a PayRate from persisted parts without revalidating.
+  The caller (mapper) has already reconstructed the Money value object.
+  """
+  @spec from_persistence(%{type: rate_type() | String.t(), money: Money.t()}) ::
+          {:ok, t()} | {:error, :invalid_persistence_data}
+  def from_persistence(%{type: type, money: %Money{} = money}) when type in @valid_types do
+    {:ok, %__MODULE__{type: type, money: money}}
+  end
+
+  def from_persistence(%{type: type, money: %Money{} = money}) when is_binary(type) do
+    from_persistence(%{type: String.to_existing_atom(type), money: money})
+  rescue
+    ArgumentError -> {:error, :invalid_persistence_data}
+  end
+
+  def from_persistence(_), do: {:error, :invalid_persistence_data}
+
+  @doc "Predicate — true when the struct passes all validations."
+  @spec valid?(t()) :: boolean()
+  def valid?(%__MODULE__{type: type, money: %Money{}}) when type in @valid_types, do: true
+  def valid?(_), do: false
+
+  defp build(type, amount, currency) do
+    with {:ok, money} <- Money.new(amount, currency) do
+      {:ok, %__MODULE__{type: type, money: money}}
+    end
+  end
+
+  defp validate_type(type) when type in @valid_types, do: :ok
+
+  defp validate_type(_), do: {:error, ["type must be one of #{inspect(@valid_types)}"]}
+
+  defp validate_money(%Money{}), do: :ok
+  defp validate_money(_), do: {:error, ["money must be a valid %Money{} struct"]}
+end

--- a/lib/klass_hero/provider/domain/models/pay_rate.ex
+++ b/lib/klass_hero/provider/domain/models/pay_rate.ex
@@ -22,12 +22,12 @@ defmodule KlassHero.Provider.Domain.Models.PayRate do
   def valid_types, do: @valid_types
 
   @doc "Smart constructor for an hourly rate."
-  @spec hourly(Decimal.t() | number() | String.t(), atom()) ::
+  @spec hourly(Decimal.t() | integer() | String.t(), atom() | String.t()) ::
           {:ok, t()} | {:error, [String.t()]}
   def hourly(amount, currency \\ :EUR), do: build(:hourly, amount, currency)
 
   @doc "Smart constructor for a per-session rate."
-  @spec per_session(Decimal.t() | number() | String.t(), atom()) ::
+  @spec per_session(Decimal.t() | integer() | String.t(), atom() | String.t()) ::
           {:ok, t()} | {:error, [String.t()]}
   def per_session(amount, currency \\ :EUR), do: build(:per_session, amount, currency)
 

--- a/lib/klass_hero/provider/domain/models/staff_member.ex
+++ b/lib/klass_hero/provider/domain/models/staff_member.ex
@@ -9,6 +9,7 @@ defmodule KlassHero.Provider.Domain.Models.StaffMember do
   Qualifications are freeform text entries (e.g., "First Aid", "UEFA B License").
   """
 
+  alias KlassHero.Provider.Domain.Models.PayRate
   alias KlassHero.Shared.Categories
 
   @enforce_keys [:id, :provider_id, :first_name, :last_name]
@@ -26,6 +27,7 @@ defmodule KlassHero.Provider.Domain.Models.StaffMember do
     :invitation_status,
     :invitation_token_hash,
     :invitation_sent_at,
+    :pay_rate,
     tags: [],
     qualifications: [],
     active: true,
@@ -46,6 +48,7 @@ defmodule KlassHero.Provider.Domain.Models.StaffMember do
           invitation_status: :pending | :sent | :failed | :accepted | :expired | nil,
           invitation_token_hash: binary() | nil,
           invitation_sent_at: DateTime.t() | nil,
+          pay_rate: PayRate.t() | nil,
           tags: [String.t()],
           qualifications: [String.t()],
           active: boolean(),
@@ -114,6 +117,7 @@ defmodule KlassHero.Provider.Domain.Models.StaffMember do
     |> validate_headshot_url(staff.headshot_url)
     |> validate_tags(staff.tags)
     |> validate_qualifications(staff.qualifications)
+    |> validate_pay_rate(staff.pay_rate)
   end
 
   defp validate_provider_id(errors, id) when is_binary(id) do
@@ -209,6 +213,16 @@ defmodule KlassHero.Provider.Domain.Models.StaffMember do
   end
 
   defp validate_qualifications(errors, _), do: ["Qualifications must be a list" | errors]
+
+  defp validate_pay_rate(errors, nil), do: errors
+
+  defp validate_pay_rate(errors, %PayRate{} = pay_rate) do
+    if PayRate.valid?(pay_rate),
+      do: errors,
+      else: ["Pay rate is invalid" | errors]
+  end
+
+  defp validate_pay_rate(errors, _), do: ["Pay rate must be a %PayRate{} struct or nil" | errors]
 
   @doc """
   Generates a URL-safe invitation token and its SHA-256 hash.

--- a/lib/klass_hero/shared.ex
+++ b/lib/klass_hero/shared.ex
@@ -19,6 +19,7 @@ defmodule KlassHero.Shared do
       Domain.Ports.Driving.ForHandlingEvents,
       Domain.Ports.Driving.ForHandlingIntegrationEvents,
       Domain.Services.ActivityGoalCalculator,
+      Domain.Types.Money,
       Domain.Types.Pagination.PageResult,
       DomainEventBus,
       EventPublishing,

--- a/lib/klass_hero/shared/domain/types/money.ex
+++ b/lib/klass_hero/shared/domain/types/money.ex
@@ -1,0 +1,109 @@
+defmodule KlassHero.Shared.Domain.Types.Money do
+  @moduledoc """
+  Immutable value object representing a monetary amount in a specific currency.
+
+  Used for any domain value that has an amount and currency — e.g. staff pay rates.
+  Existing codebase fields that store bare `Decimal.t()` (program prices, enrollment fees)
+  may migrate to this type over time.
+  """
+
+  @enforce_keys [:amount, :currency]
+  defstruct [:amount, :currency]
+
+  @type t :: %__MODULE__{amount: Decimal.t(), currency: atom()}
+
+  @valid_currencies ~w(EUR)a
+
+  @doc "Supported currency atoms. Extend carefully — expansion may require locale/formatting work."
+  @spec valid_currencies() :: [atom()]
+  def valid_currencies, do: @valid_currencies
+
+  @doc """
+  Builds a Money value with validation.
+
+  Accepts amount as `Decimal.t()`, integer, or parseable string.
+  Returns `{:ok, money}` on success, `{:error, [reasons]}` on failure.
+  """
+  @spec new(Decimal.t() | integer() | String.t() | nil, atom() | String.t()) ::
+          {:ok, t()} | {:error, [String.t()]}
+  def new(amount, currency \\ :EUR) do
+    with {:ok, decimal} <- coerce_amount(amount),
+         :ok <- validate_non_negative(decimal),
+         {:ok, currency_atom} <- coerce_currency(currency) do
+      {:ok, %__MODULE__{amount: decimal, currency: currency_atom}}
+    end
+  end
+
+  @doc """
+  Reconstructs Money from persisted data without revalidating.
+
+  Storage stores currency as a string; this converts it back to the atom.
+  Uses `String.to_existing_atom/1` — safe because all valid currencies are
+  declared at compile time by `@valid_currencies` above.
+  """
+  @spec from_persistence(%{amount: Decimal.t(), currency: String.t() | atom()}) ::
+          {:ok, t()} | {:error, :invalid_persistence_data}
+  def from_persistence(%{amount: %Decimal{} = amount, currency: currency})
+      when is_binary(currency) or is_atom(currency) do
+    {:ok, %__MODULE__{amount: amount, currency: atomize_currency(currency)}}
+  rescue
+    ArgumentError -> {:error, :invalid_persistence_data}
+  end
+
+  def from_persistence(_), do: {:error, :invalid_persistence_data}
+
+  @doc "Structural equality — same amount (via Decimal.equal?/2) and same currency atom."
+  @spec equal?(t(), t()) :: boolean()
+  def equal?(%__MODULE__{amount: a1, currency: c1}, %__MODULE__{amount: a2, currency: c2}) do
+    c1 == c2 and Decimal.equal?(a1, a2)
+  end
+
+  @doc """
+  Formats a Money value for display with the currency symbol, e.g. `"€25.00"`.
+
+  Rounds to 2 decimal places.
+  """
+  @spec format(t()) :: String.t()
+  def format(%__MODULE__{amount: amount, currency: currency}) do
+    "#{symbol(currency)}#{amount |> Decimal.round(2) |> Decimal.to_string()}"
+  end
+
+  defp symbol(:EUR), do: "€"
+
+  defp coerce_amount(nil), do: {:error, ["amount is required"]}
+
+  defp coerce_amount(%Decimal{} = d), do: {:ok, d}
+
+  defp coerce_amount(n) when is_integer(n), do: {:ok, Decimal.new(n)}
+
+  defp coerce_amount(s) when is_binary(s) do
+    case Decimal.parse(s) do
+      {decimal, ""} -> {:ok, decimal}
+      _ -> {:error, ["amount is not a valid number"]}
+    end
+  end
+
+  defp coerce_amount(_), do: {:error, ["amount must be a Decimal, integer, or string"]}
+
+  defp validate_non_negative(%Decimal{} = d) do
+    if Decimal.compare(d, Decimal.new(0)) == :lt,
+      do: {:error, ["amount cannot be negative"]},
+      else: :ok
+  end
+
+  defp coerce_currency(currency) when currency in @valid_currencies, do: {:ok, currency}
+
+  defp coerce_currency(currency) when is_binary(currency) do
+    case Enum.find(@valid_currencies, &(Atom.to_string(&1) == currency)) do
+      nil -> invalid_currency_error()
+      atom -> {:ok, atom}
+    end
+  end
+
+  defp coerce_currency(_), do: invalid_currency_error()
+
+  defp invalid_currency_error, do: {:error, ["currency must be one of #{inspect(@valid_currencies)}"]}
+
+  defp atomize_currency(c) when is_atom(c), do: c
+  defp atomize_currency(c) when is_binary(c), do: String.to_existing_atom(c)
+end

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -445,11 +445,18 @@ defmodule KlassHeroWeb.ProviderComponents do
   @doc """
   Renders a team member card.
 
+  `rate_label` is an explicit attr so the parent-facing caller (program detail page)
+  passes nothing and the admin caller passes `@member.rate_label`. Never sniff the
+  presence of a key on `@member` to decide whether to show the rate — that would
+  re-enable the leak path the presenter split was designed to close.
+
   ## Examples
 
       <.team_member_card member={member} />
+      <.team_member_card member={member} rate_label={member.rate_label} />
   """
   attr :member, :map, required: true
+  attr :rate_label, :string, default: nil
 
   def team_member_card(assigns) do
     ~H"""
@@ -524,6 +531,11 @@ defmodule KlassHeroWeb.ProviderComponents do
             {qual}
           </span>
         </div>
+
+        <%!-- Pay rate (admin-only — caller passes the label explicitly) --%>
+        <p :if={@rate_label} class="text-sm text-hero-charcoal mb-3">
+          <span class="font-semibold">{gettext("Pay rate")}:</span> {@rate_label}
+        </p>
 
         <div class="flex items-center gap-2">
           <button
@@ -687,6 +699,58 @@ defmodule KlassHeroWeb.ProviderComponents do
           {gettext("Separate multiple qualifications with commas")}
         </p>
 
+        <%!-- Pay Rate (visible only to the business account; not rendered in parent-facing views) --%>
+        <div>
+          <label class="block text-sm font-semibold text-hero-charcoal mb-2">
+            {gettext("Pay Rate")}
+          </label>
+          <div class="flex flex-wrap items-center gap-4">
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="staff_member_schema[rate_type]"
+                value=""
+                checked={empty_rate_type?(@form[:rate_type])}
+                class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+              />
+              {gettext("None")}
+            </label>
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="staff_member_schema[rate_type]"
+                value="hourly"
+                checked={rate_type_is?(@form[:rate_type], "hourly")}
+                class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+              />
+              {gettext("Hourly")}
+            </label>
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="staff_member_schema[rate_type]"
+                value="per_session"
+                checked={rate_type_is?(@form[:rate_type], "per_session")}
+                class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+              />
+              {gettext("Per Session")}
+            </label>
+          </div>
+          <div class="mt-2 flex items-center gap-2">
+            <span class="text-hero-charcoal font-medium" aria-hidden="true">€</span>
+            <.input
+              field={@form[:rate_amount]}
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="0.00"
+              label=""
+            />
+            <%!-- Single-currency MVP for Berlin; extend via Money.valid_currencies/0 when we expand regions. --%>
+            <input type="hidden" name="staff_member_schema[rate_currency]" value="EUR" />
+          </div>
+        </div>
+
         <%!-- Headshot upload --%>
         <div>
           <label class="block text-sm font-semibold text-hero-charcoal mb-2">
@@ -773,6 +837,12 @@ defmodule KlassHeroWeb.ProviderComponents do
   defp qualifications_to_string(nil), do: ""
   defp qualifications_to_string(quals) when is_list(quals), do: Enum.join(quals, ", ")
   defp qualifications_to_string(quals) when is_binary(quals), do: quals
+
+  defp empty_rate_type?(nil), do: true
+  defp empty_rate_type?(field), do: field.value in [nil, ""]
+
+  defp rate_type_is?(nil, _value), do: false
+  defp rate_type_is?(field, value), do: to_string(field.value) == value
 
   @doc """
   Renders the program create/edit form.

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -17,6 +17,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   alias KlassHero.Messaging
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.Models.PayRate
   alias KlassHero.Provider.Domain.Models.ProviderProfile
   alias KlassHero.Shared.Entitlements
   alias KlassHero.Shared.Storage
@@ -72,7 +73,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
         staff_members =
           TaskHelpers.safe_await(staff_task, [], label: "Provider.DashboardLive.staff")
 
-        staff_views = StaffMemberPresenter.to_card_view_list(staff_members)
+        staff_views = StaffMemberPresenter.to_admin_view_list(staff_members)
         programs_count = length(programs)
         self_posted_count = ProgramCatalog.count_self_posted_programs(provider_profile.id)
 
@@ -205,7 +206,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     provider = socket.assigns.current_scope.provider
 
     staff_members = fetch_staff_members(provider.id)
-    staff_views = StaffMemberPresenter.to_card_view_list(staff_members)
+    staff_views = StaffMemberPresenter.to_admin_view_list(staff_members)
 
     {:noreply,
      socket
@@ -337,7 +338,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   def handle_event("resend_invitation", %{"id" => staff_member_id}, socket) do
     case Provider.resend_staff_invitation(staff_member_id) do
       {:ok, updated, _raw_token} ->
-        staff_view = StaffMemberPresenter.to_card_view(updated)
+        staff_view = StaffMemberPresenter.to_admin_view(updated)
 
         {:noreply,
          socket
@@ -1083,7 +1084,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   end
 
   defp handle_staff_created(socket, staff, headshot_status) do
-    view = StaffMemberPresenter.to_card_view(staff)
+    view = StaffMemberPresenter.to_admin_view(staff)
 
     flash_msg =
       if headshot_status == :headshot_failed,
@@ -1107,7 +1108,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
     case Provider.update_staff_member(staff_id, attrs) do
       {:ok, staff} ->
-        view = StaffMemberPresenter.to_card_view(staff)
+        view = StaffMemberPresenter.to_admin_view(staff)
 
         flash_msg =
           if headshot_status == :headshot_failed,
@@ -1506,7 +1507,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
           />
         </div>
         <div :for={{id, member} <- @team_members} id={id}>
-          <.team_member_card member={member} />
+          <.team_member_card member={member} rate_label={member.rate_label} />
         </div>
       </div>
     </div>
@@ -1721,7 +1722,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   defp refresh_staff_options(socket) do
     provider_id = socket.assigns.current_scope.provider.id
     staff_members = fetch_staff_members(provider_id)
-    staff_views = StaffMemberPresenter.to_card_view_list(staff_members)
+    staff_views = StaffMemberPresenter.to_admin_view_list(staff_members)
 
     staff_options =
       [%{value: "all", label: gettext("All Staff")}] ++
@@ -1786,8 +1787,29 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
       email: presence(params["email"]),
       bio: presence(params["bio"]),
       tags: (params["tags"] || []) |> Enum.reject(&(&1 == "")),
-      qualifications: parse_qualifications(params["qualifications"])
+      qualifications: parse_qualifications(params["qualifications"]),
+      pay_rate: build_pay_rate_from_params(params)
     }
+  end
+
+  defp build_pay_rate_from_params(%{"rate_type" => "hourly"} = params) do
+    build_pay_rate(&PayRate.hourly/2, params)
+  end
+
+  defp build_pay_rate_from_params(%{"rate_type" => "per_session"} = params) do
+    build_pay_rate(&PayRate.per_session/2, params)
+  end
+
+  defp build_pay_rate_from_params(_params), do: nil
+
+  defp build_pay_rate(constructor, params) do
+    amount = presence(params["rate_amount"])
+    currency = presence(params["rate_currency"]) || "EUR"
+
+    case amount && constructor.(amount, currency) do
+      {:ok, pay_rate} -> pay_rate
+      _ -> nil
+    end
   end
 
   defp presence(""), do: nil

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -1802,13 +1802,19 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
   defp build_pay_rate_from_params(_params), do: nil
 
+  # When rate_type is present but construction fails (bad amount, unknown currency, etc.),
+  # return the `:invalid` sentinel rather than `nil`. Domain validation via
+  # `StaffMember.validate_pay_rate/2` rejects non-PayRate non-nil values, which surfaces
+  # an `{:error, {:validation_error, _}}` tuple from the use case. The LiveView's
+  # existing error branch then re-renders the form via the schema's changeset, which
+  # flags bad `rate_amount` strings (Decimal cast failure) directly on the field.
   defp build_pay_rate(constructor, params) do
     amount = presence(params["rate_amount"])
     currency = presence(params["rate_currency"]) || "EUR"
 
     case amount && constructor.(amount, currency) do
       {:ok, pay_rate} -> pay_rate
-      _ -> nil
+      _ -> :invalid
     end
   end
 

--- a/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
@@ -7,6 +7,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Shared.Entitlements
+  alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -26,6 +27,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
           |> assign(:page_title, gettext("Staff Dashboard"))
           |> assign(:provider, provider)
           |> assign(:staff_member, staff_member)
+          |> assign(:self_view, StaffMemberPresenter.to_self_view(staff_member))
           |> assign(:assigned_program_ids, assigned_ids)
           |> assign(:programs_empty?, programs == [])
           |> assign(:dual_role?, Scope.dual_role?(socket.assigns.current_scope))
@@ -133,6 +135,13 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
         </h1>
         <p class={Theme.typography(:body)}>
           {gettext("Welcome, %{name}", name: @staff_member.first_name)}
+        </p>
+        <p
+          :if={@self_view.rate_label}
+          id="staff-rate-label"
+          class="text-sm text-hero-grey-600 mt-1"
+        >
+          {gettext("Your pay rate")}: {@self_view.rate_label}
         </p>
         <.link
           :if={@dual_role?}

--- a/lib/klass_hero_web/presenters/staff_member_presenter.ex
+++ b/lib/klass_hero_web/presenters/staff_member_presenter.ex
@@ -1,11 +1,19 @@
 defmodule KlassHeroWeb.Presenters.StaffMemberPresenter do
   @moduledoc """
   Transforms StaffMember domain models to view-ready formats.
+
+  Three view variants exist to enforce a visibility boundary around pay rates:
+
+    * `to_card_view/1` — parent/public-facing (program detail pages). MUST NOT include
+      pay_rate. Any addition here leaks confidential compensation data.
+    * `to_admin_view/1` — business-owner-facing (Team tab). Includes pay_rate.
+    * `to_self_view/1` — staff-member-facing (their own dashboard). Includes pay_rate.
   """
 
   use Gettext, backend: KlassHeroWeb.Gettext
 
-  alias KlassHero.Provider.Domain.Models.StaffMember
+  alias KlassHero.Provider.Domain.Models.{PayRate, StaffMember}
+  alias KlassHero.Shared.Domain.Types.Money
 
   @spec to_card_view(StaffMember.t()) :: map()
   def to_card_view(%StaffMember{} = staff) do
@@ -32,6 +40,38 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenter do
   def to_card_view_list(staff_members) when is_list(staff_members) do
     Enum.map(staff_members, &to_card_view/1)
   end
+
+  @doc """
+  Business-owner-facing view. Extends the card view with pay_rate + formatted rate_label.
+  """
+  @spec to_admin_view(StaffMember.t()) :: map()
+  def to_admin_view(%StaffMember{} = staff), do: with_pay_rate(staff)
+
+  @spec to_admin_view_list([StaffMember.t()]) :: [map()]
+  def to_admin_view_list(staff_members) when is_list(staff_members) do
+    Enum.map(staff_members, &to_admin_view/1)
+  end
+
+  @doc """
+  Staff-member's own view of themselves. Includes their own pay_rate + formatted label.
+  """
+  @spec to_self_view(StaffMember.t()) :: map()
+  def to_self_view(%StaffMember{} = staff), do: with_pay_rate(staff)
+
+  defp with_pay_rate(%StaffMember{} = staff) do
+    staff
+    |> to_card_view()
+    |> Map.merge(%{pay_rate: staff.pay_rate, rate_label: rate_label(staff.pay_rate)})
+  end
+
+  defp rate_label(nil), do: nil
+
+  defp rate_label(%PayRate{type: type, money: %Money{} = money}) do
+    "#{Money.format(money)} / #{rate_suffix(type)}"
+  end
+
+  defp rate_suffix(:hourly), do: gettext("hour")
+  defp rate_suffix(:per_session), do: gettext("session")
 
   defp invitation_status_label(nil), do: nil
   defp invitation_status_label(:pending), do: gettext("Invitation Pending")

--- a/priv/repo/migrations/20260422060601_add_pay_rate_to_staff_members.exs
+++ b/priv/repo/migrations/20260422060601_add_pay_rate_to_staff_members.exs
@@ -1,0 +1,19 @@
+defmodule KlassHero.Repo.Migrations.AddPayRateToStaffMembers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:staff_members) do
+      add :rate_type, :string
+      add :rate_amount, :decimal, precision: 10, scale: 2
+      add :rate_currency, :string, size: 3
+    end
+
+    create constraint(:staff_members, :pay_rate_all_or_none,
+             check: """
+             (rate_type IS NULL AND rate_amount IS NULL AND rate_currency IS NULL)
+             OR
+             (rate_type IS NOT NULL AND rate_amount IS NOT NULL AND rate_currency IS NOT NULL)
+             """
+           )
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/persistence/mappers/staff_member_mapper_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/mappers/staff_member_mapper_test.exs
@@ -11,7 +11,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapp
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapper
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSchema
-  alias KlassHero.Provider.Domain.Models.StaffMember
+  alias KlassHero.Provider.Domain.Models.{PayRate, StaffMember}
+  alias KlassHero.Shared.Domain.Types.Money
 
   @id Ecto.UUID.generate()
   @provider_id Ecto.UUID.generate()
@@ -228,6 +229,64 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapp
 
       refute Map.has_key?(attrs, :inserted_at)
       refute Map.has_key?(attrs, :updated_at)
+    end
+  end
+
+  describe "pay_rate round-trip" do
+    test "to_domain builds a %PayRate{} from three rate columns" do
+      schema =
+        valid_schema(%{
+          rate_type: :hourly,
+          rate_amount: Decimal.new("25.00"),
+          rate_currency: :EUR
+        })
+
+      staff = StaffMemberMapper.to_domain(schema)
+
+      assert %PayRate{type: :hourly, money: %Money{currency: :EUR} = money} = staff.pay_rate
+      assert Decimal.equal?(money.amount, Decimal.new("25.00"))
+    end
+
+    test "to_domain yields pay_rate: nil when all rate columns are nil" do
+      schema = valid_schema(%{rate_type: nil, rate_amount: nil, rate_currency: nil})
+
+      staff = StaffMemberMapper.to_domain(schema)
+
+      assert is_nil(staff.pay_rate)
+    end
+
+    test "to_schema flattens a %PayRate{} into three fields" do
+      {:ok, pay_rate} = PayRate.per_session(Decimal.new("80.00"))
+      domain = valid_domain(%{pay_rate: pay_rate})
+
+      attrs = StaffMemberMapper.to_schema(domain)
+
+      assert attrs.rate_type == :per_session
+      assert attrs.rate_currency == :EUR
+      assert Decimal.equal?(attrs.rate_amount, Decimal.new("80.00"))
+    end
+
+    test "to_schema flattens nil pay_rate into three nil fields" do
+      domain = valid_domain(%{pay_rate: nil})
+
+      attrs = StaffMemberMapper.to_schema(domain)
+
+      assert is_nil(attrs.rate_type)
+      assert is_nil(attrs.rate_amount)
+      assert is_nil(attrs.rate_currency)
+    end
+
+    test "round-trip: domain → schema → domain preserves the PayRate" do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("42.50"))
+      domain_before = valid_domain(%{pay_rate: pay_rate})
+
+      attrs = StaffMemberMapper.to_schema(domain_before)
+      schema = struct!(StaffMemberSchema, valid_schema() |> Map.from_struct() |> Map.merge(attrs))
+      domain_after = StaffMemberMapper.to_domain(schema)
+
+      assert domain_after.pay_rate.type == :hourly
+      assert Decimal.equal?(domain_after.pay_rate.money.amount, Decimal.new("42.50"))
+      assert domain_after.pay_rate.money.currency == :EUR
     end
   end
 end

--- a/test/klass_hero/provider/adapters/driven/persistence/schemas/staff_member_schema_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/schemas/staff_member_schema_test.exs
@@ -52,4 +52,149 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSche
       assert changeset.valid?
     end
   end
+
+  describe "create_changeset/2 pay rate fields" do
+    @base_attrs %{first_name: "Mike", last_name: "Johnson", provider_id: Ecto.UUID.generate()}
+
+    test "accepts a valid hourly rate" do
+      attrs =
+        Map.merge(@base_attrs, %{
+          rate_type: "hourly",
+          rate_amount: Decimal.new("25.00"),
+          rate_currency: "EUR"
+        })
+
+      changeset = StaffMemberSchema.create_changeset(%StaffMemberSchema{}, attrs)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :rate_type) == :hourly
+      assert Ecto.Changeset.get_change(changeset, :rate_currency) == :EUR
+    end
+
+    test "accepts a valid per_session rate" do
+      attrs =
+        Map.merge(@base_attrs, %{
+          rate_type: "per_session",
+          rate_amount: Decimal.new("80.00"),
+          rate_currency: "EUR"
+        })
+
+      changeset = StaffMemberSchema.create_changeset(%StaffMemberSchema{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "is valid when no rate fields are set" do
+      changeset = StaffMemberSchema.create_changeset(%StaffMemberSchema{}, @base_attrs)
+      assert changeset.valid?
+    end
+
+    test "rejects partial rate — amount without type or currency" do
+      attrs = Map.put(@base_attrs, :rate_amount, Decimal.new("25.00"))
+      changeset = StaffMemberSchema.create_changeset(%StaffMemberSchema{}, attrs)
+
+      refute changeset.valid?
+      assert %{rate_type: [_ | _]} = errors_on(changeset)
+    end
+
+    test "rejects negative rate amount" do
+      attrs =
+        Map.merge(@base_attrs, %{
+          rate_type: "hourly",
+          rate_amount: Decimal.new("-5.00"),
+          rate_currency: "EUR"
+        })
+
+      changeset = StaffMemberSchema.create_changeset(%StaffMemberSchema{}, attrs)
+
+      refute changeset.valid?
+      assert %{rate_amount: [_ | _]} = errors_on(changeset)
+    end
+
+    test "rejects unknown rate_type" do
+      attrs =
+        Map.merge(@base_attrs, %{
+          rate_type: "weekly",
+          rate_amount: Decimal.new("100.00"),
+          rate_currency: "EUR"
+        })
+
+      changeset = StaffMemberSchema.create_changeset(%StaffMemberSchema{}, attrs)
+
+      refute changeset.valid?
+      assert %{rate_type: [_ | _]} = errors_on(changeset)
+    end
+
+    test "rejects unknown currency" do
+      attrs =
+        Map.merge(@base_attrs, %{
+          rate_type: "hourly",
+          rate_amount: Decimal.new("25.00"),
+          rate_currency: "USD"
+        })
+
+      changeset = StaffMemberSchema.create_changeset(%StaffMemberSchema{}, attrs)
+
+      refute changeset.valid?
+      assert %{rate_currency: [_ | _]} = errors_on(changeset)
+    end
+  end
+
+  describe "edit_changeset/2 pay rate fields" do
+    setup do
+      schema = %StaffMemberSchema{
+        id: Ecto.UUID.generate(),
+        provider_id: Ecto.UUID.generate(),
+        first_name: "Jane",
+        last_name: "Doe",
+        active: true,
+        tags: [],
+        qualifications: []
+      }
+
+      %{schema: schema}
+    end
+
+    test "accepts setting a rate on existing staff", %{schema: schema} do
+      changeset =
+        StaffMemberSchema.edit_changeset(schema, %{
+          "rate_type" => "hourly",
+          "rate_amount" => "30.00",
+          "rate_currency" => "EUR"
+        })
+
+      assert changeset.valid?
+    end
+
+    test "accepts clearing all rate fields back to nil", %{schema: schema} do
+      schema_with_rate = %{
+        schema
+        | rate_type: "hourly",
+          rate_amount: Decimal.new("25.00"),
+          rate_currency: "EUR"
+      }
+
+      changeset =
+        StaffMemberSchema.edit_changeset(schema_with_rate, %{
+          "rate_type" => nil,
+          "rate_amount" => nil,
+          "rate_currency" => nil
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects partial update (clear type only)", %{schema: schema} do
+      schema_with_rate = %{
+        schema
+        | rate_type: "hourly",
+          rate_amount: Decimal.new("25.00"),
+          rate_currency: "EUR"
+      }
+
+      changeset = StaffMemberSchema.edit_changeset(schema_with_rate, %{"rate_type" => nil})
+
+      refute changeset.valid?
+    end
+  end
 end

--- a/test/klass_hero/provider/application/commands/staff_members/create_staff_member_test.exs
+++ b/test/klass_hero/provider/application/commands/staff_members/create_staff_member_test.exs
@@ -2,6 +2,7 @@ defmodule KlassHero.Provider.Application.Commands.StaffMembers.CreateStaffMember
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider.Application.Commands.StaffMembers.CreateStaffMember
+  alias KlassHero.Provider.Domain.Models.PayRate
   alias KlassHero.ProviderFixtures
 
   @repository Application.compile_env!(:klass_hero, [:provider, :for_storing_staff_members])
@@ -96,6 +97,29 @@ defmodule KlassHero.Provider.Application.Commands.StaffMembers.CreateStaffMember
       assert {:ok, fetched} = @repository.get(staff.id)
       assert fetched.id == staff.id
       assert fetched.first_name == "Dave"
+    end
+
+    test "creates a staff member with an hourly pay_rate", %{provider_id: provider_id} do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+
+      attrs = %{
+        provider_id: provider_id,
+        first_name: "Ivy",
+        last_name: "Pay",
+        pay_rate: pay_rate
+      }
+
+      assert {:ok, staff} = CreateStaffMember.execute(attrs)
+      assert staff.pay_rate.type == :hourly
+      assert Decimal.equal?(staff.pay_rate.money.amount, Decimal.new("25.00"))
+      assert staff.pay_rate.money.currency == :EUR
+    end
+
+    test "defaults pay_rate to nil when not provided", %{provider_id: provider_id} do
+      attrs = %{provider_id: provider_id, first_name: "Ken", last_name: "Norate"}
+
+      assert {:ok, staff} = CreateStaffMember.execute(attrs)
+      assert is_nil(staff.pay_rate)
     end
   end
 end

--- a/test/klass_hero/provider/application/commands/staff_members/update_staff_member_test.exs
+++ b/test/klass_hero/provider/application/commands/staff_members/update_staff_member_test.exs
@@ -2,6 +2,7 @@ defmodule KlassHero.Provider.Application.Commands.StaffMembers.UpdateStaffMember
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider.Application.Commands.StaffMembers.UpdateStaffMember
+  alias KlassHero.Provider.Domain.Models.PayRate
   alias KlassHero.ProviderFixtures
 
   @repository Application.compile_env!(:klass_hero, [:provider, :for_storing_staff_members])
@@ -92,6 +93,30 @@ defmodule KlassHero.Provider.Application.Commands.StaffMembers.UpdateStaffMember
       assert {:ok, updated} = UpdateStaffMember.execute(staff.id, attrs)
       assert updated.first_name == "Bob"
       assert updated.provider_id == staff.provider_id
+    end
+
+    test "sets an hourly pay_rate", %{staff: staff} do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("30.00"))
+
+      assert {:ok, updated} = UpdateStaffMember.execute(staff.id, %{pay_rate: pay_rate})
+      assert updated.pay_rate.type == :hourly
+      assert Decimal.equal?(updated.pay_rate.money.amount, Decimal.new("30.00"))
+    end
+
+    test "sets a per_session pay_rate", %{staff: staff} do
+      {:ok, pay_rate} = PayRate.per_session(Decimal.new("80.00"))
+
+      assert {:ok, updated} = UpdateStaffMember.execute(staff.id, %{pay_rate: pay_rate})
+      assert updated.pay_rate.type == :per_session
+    end
+
+    test "clears pay_rate when set to nil", %{staff: staff} do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+      {:ok, staff_with_rate} = UpdateStaffMember.execute(staff.id, %{pay_rate: pay_rate})
+      assert staff_with_rate.pay_rate
+
+      assert {:ok, cleared} = UpdateStaffMember.execute(staff.id, %{pay_rate: nil})
+      assert is_nil(cleared.pay_rate)
     end
   end
 end

--- a/test/klass_hero/provider/domain/models/pay_rate_test.exs
+++ b/test/klass_hero/provider/domain/models/pay_rate_test.exs
@@ -1,0 +1,83 @@
+defmodule KlassHero.Provider.Domain.Models.PayRateTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Domain.Models.PayRate
+  alias KlassHero.Shared.Domain.Types.Money
+
+  describe "hourly/2" do
+    test "builds an hourly PayRate with default EUR currency" do
+      assert {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+      assert pay_rate.type == :hourly
+      assert pay_rate.money.currency == :EUR
+      assert Decimal.equal?(pay_rate.money.amount, Decimal.new("25.00"))
+    end
+
+    test "propagates Money validation errors" do
+      assert {:error, reasons} = PayRate.hourly(Decimal.new("-1"))
+      assert Enum.any?(reasons, &String.contains?(&1, "negative"))
+    end
+  end
+
+  describe "per_session/2" do
+    test "builds a per_session PayRate" do
+      assert {:ok, pay_rate} = PayRate.per_session(Decimal.new("80.00"))
+      assert pay_rate.type == :per_session
+      assert Decimal.equal?(pay_rate.money.amount, Decimal.new("80.00"))
+    end
+  end
+
+  describe "new/1" do
+    test "accepts a valid type + Money struct" do
+      {:ok, money} = Money.new(Decimal.new("10.00"))
+      assert {:ok, pay_rate} = PayRate.new(%{type: :hourly, money: money})
+      assert pay_rate.type == :hourly
+    end
+
+    test "rejects unknown type" do
+      {:ok, money} = Money.new(Decimal.new("10.00"))
+      assert {:error, reasons} = PayRate.new(%{type: :weekly, money: money})
+      assert Enum.any?(reasons, &String.contains?(&1, "type"))
+    end
+
+    test "rejects missing money" do
+      assert {:error, reasons} = PayRate.new(%{type: :hourly, money: nil})
+      assert Enum.any?(reasons, &String.contains?(&1, "money"))
+    end
+  end
+
+  describe "from_persistence/1" do
+    test "reconstructs a PayRate without validation" do
+      {:ok, money} = Money.new(Decimal.new("25.00"))
+
+      assert {:ok, pay_rate} =
+               PayRate.from_persistence(%{type: :hourly, money: money})
+
+      assert pay_rate.type == :hourly
+    end
+
+    test "returns error when required keys missing" do
+      assert {:error, :invalid_persistence_data} = PayRate.from_persistence(%{type: :hourly})
+    end
+
+    test "accepts a string type and atomizes it" do
+      {:ok, money} = Money.new(Decimal.new("25.00"))
+
+      assert {:ok, pay_rate} = PayRate.from_persistence(%{type: "hourly", money: money})
+      assert pay_rate.type == :hourly
+    end
+
+    test "rejects a string type that does not map to a known atom" do
+      {:ok, money} = Money.new(Decimal.new("25.00"))
+
+      assert {:error, :invalid_persistence_data} =
+               PayRate.from_persistence(%{type: "not_a_real_rate_type_xyz", money: money})
+    end
+  end
+
+  describe "valid?/1" do
+    test "returns true for a well-formed PayRate" do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+      assert PayRate.valid?(pay_rate)
+    end
+  end
+end

--- a/test/klass_hero/provider/domain/models/staff_member_test.exs
+++ b/test/klass_hero/provider/domain/models/staff_member_test.exs
@@ -1,7 +1,7 @@
 defmodule KlassHero.Provider.Domain.Models.StaffMemberTest do
   use ExUnit.Case, async: true
 
-  alias KlassHero.Provider.Domain.Models.StaffMember
+  alias KlassHero.Provider.Domain.Models.{PayRate, StaffMember}
 
   @valid_attrs %{
     id: "550e8400-e29b-41d4-a716-446655440000",
@@ -143,6 +143,57 @@ defmodule KlassHero.Provider.Domain.Models.StaffMemberTest do
     test "errors on missing enforce key" do
       assert {:error, :invalid_persistence_data} =
                StaffMember.from_persistence(%{id: "abc", first_name: "X"})
+    end
+  end
+
+  describe "new/1 with pay_rate" do
+    test "defaults pay_rate to nil when omitted" do
+      assert {:ok, staff} = StaffMember.new(@valid_attrs)
+      assert is_nil(staff.pay_rate)
+    end
+
+    test "accepts an hourly pay_rate" do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+
+      assert {:ok, staff} = StaffMember.new(Map.put(@valid_attrs, :pay_rate, pay_rate))
+      assert staff.pay_rate == pay_rate
+    end
+
+    test "accepts a per_session pay_rate" do
+      {:ok, pay_rate} = PayRate.per_session(Decimal.new("80.00"))
+
+      assert {:ok, staff} = StaffMember.new(Map.put(@valid_attrs, :pay_rate, pay_rate))
+      assert staff.pay_rate.type == :per_session
+    end
+
+    test "accepts explicit nil pay_rate" do
+      assert {:ok, staff} = StaffMember.new(Map.put(@valid_attrs, :pay_rate, nil))
+      assert is_nil(staff.pay_rate)
+    end
+
+    test "rejects a non-PayRate value for pay_rate" do
+      assert {:error, errors} =
+               StaffMember.new(Map.put(@valid_attrs, :pay_rate, %{type: :hourly}))
+
+      assert Enum.any?(errors, &String.contains?(&1, "Pay rate"))
+    end
+  end
+
+  describe "from_persistence/1 with pay_rate" do
+    test "reconstructs a StaffMember with a pre-built PayRate" do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("30.00"))
+
+      attrs =
+        @valid_attrs
+        |> Map.merge(%{
+          tags: [],
+          qualifications: [],
+          active: true,
+          pay_rate: pay_rate
+        })
+
+      assert {:ok, staff} = StaffMember.from_persistence(attrs)
+      assert staff.pay_rate == pay_rate
     end
   end
 end

--- a/test/klass_hero/shared/domain/types/money_test.exs
+++ b/test/klass_hero/shared/domain/types/money_test.exs
@@ -1,0 +1,91 @@
+defmodule KlassHero.Shared.Domain.Types.MoneyTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Shared.Domain.Types.Money
+
+  describe "new/2" do
+    test "creates Money with Decimal amount and explicit currency" do
+      assert {:ok, money} = Money.new(Decimal.new("25.00"), :EUR)
+      assert Decimal.equal?(money.amount, Decimal.new("25.00"))
+      assert money.currency == :EUR
+    end
+
+    test "defaults currency to :EUR when omitted" do
+      assert {:ok, money} = Money.new(Decimal.new("10.00"))
+      assert money.currency == :EUR
+    end
+
+    test "accepts integer amount and coerces to Decimal" do
+      assert {:ok, money} = Money.new(15)
+      assert Decimal.equal?(money.amount, Decimal.new("15"))
+    end
+
+    test "accepts string amount that parses to Decimal" do
+      assert {:ok, money} = Money.new("42.50")
+      assert Decimal.equal?(money.amount, Decimal.new("42.50"))
+    end
+
+    test "accepts zero amount (volunteer rate)" do
+      assert {:ok, money} = Money.new(Decimal.new("0"))
+      assert Decimal.equal?(money.amount, Decimal.new("0"))
+    end
+
+    test "rejects negative amount" do
+      assert {:error, reasons} = Money.new(Decimal.new("-5.00"))
+      assert Enum.any?(reasons, &String.contains?(&1, "negative"))
+    end
+
+    test "rejects unknown currency atom" do
+      assert {:error, reasons} = Money.new(Decimal.new("10.00"), :USD)
+      assert Enum.any?(reasons, &String.contains?(&1, "currency"))
+    end
+
+    test "accepts a currency as a string" do
+      assert {:ok, money} = Money.new(Decimal.new("10.00"), "EUR")
+      assert money.currency == :EUR
+    end
+
+    test "rejects an unknown currency string" do
+      assert {:error, reasons} = Money.new(Decimal.new("10.00"), "USD")
+      assert Enum.any?(reasons, &String.contains?(&1, "currency"))
+    end
+
+    test "rejects unparseable string amount" do
+      assert {:error, reasons} = Money.new("not a number")
+      assert Enum.any?(reasons, &String.contains?(&1, "amount"))
+    end
+
+    test "rejects nil amount" do
+      assert {:error, reasons} = Money.new(nil)
+      assert Enum.any?(reasons, &String.contains?(&1, "amount"))
+    end
+  end
+
+  describe "from_persistence/1" do
+    test "reconstructs Money from DB-shaped map without validation" do
+      assert {:ok, money} =
+               Money.from_persistence(%{amount: Decimal.new("99.99"), currency: "EUR"})
+
+      assert Decimal.equal?(money.amount, Decimal.new("99.99"))
+      assert money.currency == :EUR
+    end
+
+    test "returns error when required keys missing" do
+      assert {:error, :invalid_persistence_data} = Money.from_persistence(%{amount: nil})
+    end
+  end
+
+  describe "equal?/2" do
+    test "returns true for same amount and currency" do
+      {:ok, a} = Money.new(Decimal.new("25.00"), :EUR)
+      {:ok, b} = Money.new(Decimal.new("25.00"), :EUR)
+      assert Money.equal?(a, b)
+    end
+
+    test "returns false for different amount" do
+      {:ok, a} = Money.new(Decimal.new("25.00"), :EUR)
+      {:ok, b} = Money.new(Decimal.new("26.00"), :EUR)
+      refute Money.equal?(a, b)
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_team_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_team_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
   import Phoenix.LiveViewTest
 
   alias KlassHero.ProviderFixtures
+  alias Provider.Domain.Models.PayRate
 
   setup :register_and_log_in_provider
 
@@ -350,6 +351,109 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
       # No cast error on qualifications — the comma string was parsed to a list
       refute html =~ "is invalid"
       assert has_element?(view, "#staff-member-form")
+    end
+  end
+
+  describe "pay rate flow" do
+    alias KlassHero.Provider
+    alias KlassHero.Provider.Domain.Models.PayRate
+
+    test "form submission with an hourly rate persists the rate", %{conn: conn, provider: provider} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view |> element("#add-member-btn") |> render_click()
+
+      view
+      |> form("#staff-form", %{
+        "staff_member_schema" => %{
+          "first_name" => "Rena",
+          "last_name" => "Ratepayer",
+          "rate_type" => "hourly",
+          "rate_amount" => "25.00",
+          "rate_currency" => "EUR"
+        }
+      })
+      |> render_submit()
+
+      refute has_element?(view, "#staff-member-form")
+
+      {:ok, [staff]} = Provider.list_staff_members(provider.id)
+      assert staff.pay_rate.type == :hourly
+      assert Decimal.equal?(staff.pay_rate.money.amount, Decimal.new("25.00"))
+      assert staff.pay_rate.money.currency == :EUR
+    end
+
+    test "form submission with per_session rate persists the rate", %{conn: conn, provider: provider} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view |> element("#add-member-btn") |> render_click()
+
+      view
+      |> form("#staff-form", %{
+        "staff_member_schema" => %{
+          "first_name" => "Sonia",
+          "last_name" => "Session",
+          "rate_type" => "per_session",
+          "rate_amount" => "80.00",
+          "rate_currency" => "EUR"
+        }
+      })
+      |> render_submit()
+
+      {:ok, [staff]} = Provider.list_staff_members(provider.id)
+      assert staff.pay_rate.type == :per_session
+    end
+
+    test "form submission without rate_type leaves pay_rate as nil", %{conn: conn, provider: provider} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view |> element("#add-member-btn") |> render_click()
+
+      view
+      |> form("#staff-form", %{
+        "staff_member_schema" => %{
+          "first_name" => "No",
+          "last_name" => "Rate",
+          "rate_type" => "",
+          "rate_amount" => ""
+        }
+      })
+      |> render_submit()
+
+      {:ok, [staff]} = Provider.list_staff_members(provider.id)
+      assert is_nil(staff.pay_rate)
+    end
+
+    test "editing can clear an existing rate back to nil", %{conn: conn, provider: provider} do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+
+      staff =
+        ProviderFixtures.staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Carla",
+          last_name: "Clear",
+          pay_rate: pay_rate
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view
+      |> element(~s(button[phx-click="edit_member"][phx-value-id="#{staff.id}"]))
+      |> render_click()
+
+      view
+      |> form("#staff-form", %{
+        "staff_member_schema" => %{
+          "first_name" => "Carla",
+          "last_name" => "Clear",
+          "rate_type" => "",
+          "rate_amount" => ""
+        }
+      })
+      |> render_submit()
+
+      {:ok, updated} = Provider.get_staff_member(staff.id)
+      assert is_nil(updated.pay_rate)
     end
   end
 end

--- a/test/klass_hero_web/live/provider/dashboard_team_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_team_test.exs
@@ -3,8 +3,8 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
 
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Provider.Domain.Models.PayRate
   alias KlassHero.ProviderFixtures
-  alias Provider.Domain.Models.PayRate
 
   setup :register_and_log_in_provider
 
@@ -356,7 +356,6 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
 
   describe "pay rate flow" do
     alias KlassHero.Provider
-    alias KlassHero.Provider.Domain.Models.PayRate
 
     test "form submission with an hourly rate persists the rate", %{conn: conn, provider: provider} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
@@ -454,6 +453,59 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
 
       {:ok, updated} = Provider.get_staff_member(staff.id)
       assert is_nil(updated.pay_rate)
+    end
+
+    test "invalid rate_amount keeps the form open with a field error", %{conn: conn, provider: provider} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view |> element("#add-member-btn") |> render_click()
+
+      html =
+        view
+        |> form("#staff-form", %{
+          "staff_member_schema" => %{
+            "first_name" => "Bad",
+            "last_name" => "Amount",
+            "rate_type" => "hourly",
+            "rate_amount" => "abc"
+          }
+        })
+        |> render_submit()
+
+      # Form stays open (didn't save)
+      assert has_element?(view, "#staff-member-form")
+      assert html =~ "is invalid"
+      assert Provider.list_staff_members(provider.id) == {:ok, []}
+    end
+
+    test "editing an unrelated field preserves an existing pay rate", %{conn: conn, provider: provider} do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+
+      staff =
+        ProviderFixtures.staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Pia",
+          last_name: "Preserve",
+          role: "Coach",
+          pay_rate: pay_rate
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      view
+      |> element(~s(button[phx-click="edit_member"][phx-value-id="#{staff.id}"]))
+      |> render_click()
+
+      # Form should render pre-populated with the existing rate — submit only a
+      # role change and the pre-populated rate fields flow through unchanged.
+      view
+      |> form("#staff-form", %{"staff_member_schema" => %{"role" => "Head Coach"}})
+      |> render_submit()
+
+      {:ok, updated} = Provider.get_staff_member(staff.id)
+      assert updated.role == "Head Coach"
+      assert updated.pay_rate.type == :hourly
+      assert Decimal.equal?(updated.pay_rate.money.amount, Decimal.new("25.00"))
     end
   end
 end

--- a/test/klass_hero_web/live/staff/staff_dashboard_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_dashboard_live_test.exs
@@ -5,6 +5,8 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLiveTest do
   import KlassHero.Factory, only: [insert: 2]
   import KlassHero.ProviderFixtures
 
+  alias KlassHero.Provider.Domain.Models.PayRate
+
   describe "staff dashboard" do
     setup %{conn: conn} do
       user = user_fixture(intended_roles: [:staff_provider])
@@ -41,6 +43,23 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLiveTest do
       {:ok, view, _html} = live(conn, ~p"/staff/dashboard")
 
       assert render(view) =~ staff.first_name
+    end
+
+    test "shows the staff member's own hourly pay rate when set", %{conn: conn, staff: staff} do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+      {:ok, _updated} = KlassHero.Provider.update_staff_member(staff.id, %{pay_rate: pay_rate})
+
+      {:ok, _view, html} = live(conn, ~p"/staff/dashboard")
+
+      assert html =~ "€25.00 / hour"
+    end
+
+    test "hides pay rate section when no rate is set", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/staff/dashboard")
+
+      refute html =~ "rate-label"
+      refute html =~ "/ hour"
+      refute html =~ "/ session"
     end
 
     test "non-staff user is redirected", %{} do

--- a/test/klass_hero_web/presenters/staff_member_presenter_test.exs
+++ b/test/klass_hero_web/presenters/staff_member_presenter_test.exs
@@ -1,0 +1,121 @@
+defmodule KlassHeroWeb.Presenters.StaffMemberPresenterTest do
+  @moduledoc """
+  Security-critical tests — the base `to_card_view/1` is consumed by the parent-facing
+  program detail page. Pay rates MUST NEVER leak through that function. Admin and
+  self-view variants may include the rate because they are gated to business owners
+  and the staff member themselves.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Domain.Models.{PayRate, StaffMember}
+  alias KlassHeroWeb.Presenters.StaffMemberPresenter
+
+  defp staff_fixture(overrides) do
+    struct!(
+      StaffMember,
+      Map.merge(
+        %{
+          id: Ecto.UUID.generate(),
+          provider_id: Ecto.UUID.generate(),
+          first_name: "Mike",
+          last_name: "Johnson",
+          role: "Head Coach",
+          email: "mike@example.com",
+          bio: "Experienced coach.",
+          tags: [],
+          qualifications: [],
+          active: true,
+          invitation_status: :accepted
+        },
+        overrides
+      )
+    )
+  end
+
+  defp hourly_rate do
+    {:ok, rate} = PayRate.hourly(Decimal.new("25.00"))
+    rate
+  end
+
+  describe "to_card_view/1 — parent/public-facing (no pay_rate)" do
+    test "never includes pay_rate, even when the StaffMember has one set" do
+      staff = staff_fixture(%{pay_rate: hourly_rate()})
+
+      view = StaffMemberPresenter.to_card_view(staff)
+
+      refute Map.has_key?(view, :pay_rate)
+      refute Map.has_key?(view, :rate_label)
+    end
+
+    test "renders a leak-free view when the StaffMember has no pay_rate" do
+      staff = staff_fixture(%{pay_rate: nil})
+
+      view = StaffMemberPresenter.to_card_view(staff)
+
+      refute Map.has_key?(view, :pay_rate)
+      assert view.full_name == "Mike Johnson"
+    end
+  end
+
+  describe "to_card_view_list/1" do
+    test "maps a list without leaking pay_rate" do
+      list = [staff_fixture(%{pay_rate: hourly_rate()}), staff_fixture(%{pay_rate: nil})]
+
+      views = StaffMemberPresenter.to_card_view_list(list)
+
+      for view <- views do
+        refute Map.has_key?(view, :pay_rate)
+      end
+    end
+  end
+
+  describe "to_admin_view/1 — business-owner-facing (includes pay_rate)" do
+    test "includes a formatted rate_label when pay_rate is hourly" do
+      staff = staff_fixture(%{pay_rate: hourly_rate()})
+
+      view = StaffMemberPresenter.to_admin_view(staff)
+
+      assert view.pay_rate.type == :hourly
+      assert view.rate_label == "€25.00 / hour"
+    end
+
+    test "includes a formatted rate_label when pay_rate is per_session" do
+      {:ok, rate} = PayRate.per_session(Decimal.new("80.00"))
+      staff = staff_fixture(%{pay_rate: rate})
+
+      view = StaffMemberPresenter.to_admin_view(staff)
+
+      assert view.rate_label == "€80.00 / session"
+    end
+
+    test "returns nil rate_label when pay_rate is nil" do
+      staff = staff_fixture(%{pay_rate: nil})
+
+      view = StaffMemberPresenter.to_admin_view(staff)
+
+      assert is_nil(view.pay_rate)
+      assert is_nil(view.rate_label)
+    end
+  end
+
+  describe "to_self_view/1 — staff-member-facing (includes own pay_rate)" do
+    test "includes the staff's own pay rate" do
+      staff = staff_fixture(%{pay_rate: hourly_rate()})
+
+      view = StaffMemberPresenter.to_self_view(staff)
+
+      assert view.pay_rate.type == :hourly
+      assert view.rate_label == "€25.00 / hour"
+    end
+
+    test "returns nil rate_label when no pay_rate is set" do
+      staff = staff_fixture(%{pay_rate: nil})
+
+      view = StaffMemberPresenter.to_self_view(staff)
+
+      assert is_nil(view.pay_rate)
+      assert is_nil(view.rate_label)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #374.

Adds per-staff-member pay rates so business owners can track hourly or per-session compensation arrangements directly in the Team tab. Staff members see their own rate on their dashboard; parents and public program pages explicitly do NOT see pay rates — enforced by a dedicated presenter leak test and three independent validation layers.

- **`Shared.Domain.Types.Money`** — new value object (`%Money{amount, currency}`), EUR-only whitelist for the Berlin launch. Extensible later via `@valid_currencies`.
- **`Provider.Domain.Models.PayRate`** — nested aggregate `%PayRate{type: :hourly | :per_session, money}` with smart constructors `PayRate.hourly/2` and `PayRate.per_session/2`.
- **Storage** — three nullable columns on `staff_members` (`rate_type`, `rate_amount`, `rate_currency`) with a DB `CHECK (pay_rate_all_or_none)` constraint as defense-in-depth alongside domain + schema validations.
- **Presenter visibility boundary** — `to_card_view/1` stays leak-free (consumed by parent-facing `program_detail_live`), `to_admin_view/1` adds `rate_label` for the Team tab, `to_self_view/1` adds it for the staff dashboard. A `refute Map.has_key?(:rate_label)` test pins the public variant forever.
- **Form UI** — Pay Rate section on the staff form: radio (None / Hourly / Per Session) + € amount input + hidden EUR currency.
- **Mutual exclusivity** enforced in three layers: domain constructor, schema changeset, DB CHECK.

## Review Focus

- `lib/klass_hero_web/presenters/staff_member_presenter.ex` — the three view variants and their intended audience. Anything that could cause `to_card_view/1` to gain a `pay_rate` key (or map-merge one in) would be a security regression.
- `lib/klass_hero/provider/adapters/driven/persistence/schemas/staff_member_schema.ex` — `validate_pay_rate/1` + `validate_pay_rate_all_or_none/1` handle the all-or-none invariant at the changeset level (mirrored by the DB CHECK).
- `priv/repo/migrations/20260422060601_add_pay_rate_to_staff_members.exs` — new columns + CHECK.

## Test plan

- [x] `mix test test/klass_hero/shared/domain/types/money_test.exs` — 13 tests for Money value object
- [x] `mix test test/klass_hero/provider/domain/models/pay_rate_test.exs` — 9 tests for PayRate value object
- [x] `mix test test/klass_hero/provider/domain/models/staff_member_test.exs` — 24 tests including pay_rate integration
- [x] `mix test test/klass_hero/provider/adapters/driven/persistence/mappers/staff_member_mapper_test.exs` — 22 tests including round-trip
- [x] `mix test test/klass_hero/provider/adapters/driven/persistence/schemas/staff_member_schema_test.exs` — 13 tests including all-or-none validation
- [x] `mix test test/klass_hero/provider/application/commands/staff_members/` — CRUD use cases with pay_rate coverage
- [x] `mix test test/klass_hero_web/presenters/staff_member_presenter_test.exs` — **critical** leak-prevention test
- [x] `mix test test/klass_hero_web/live/provider/dashboard_team_test.exs` — form submission end-to-end
- [x] `mix test test/klass_hero_web/live/staff/staff_dashboard_live_test.exs` — staff self-view of own rate
- [x] `mix precommit` — full suite, 4467 passed
- [x] Manual Playwright end-to-end: logged in as provider, added staff "Rate Tester" with hourly €27.50, verified card shows "Pay rate: €27.50 / hour", verified DB persistence