### PR TITLE
feat: filter "Meet the Heroes" to program-assigned staff only

### DIFF
--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -479,6 +479,18 @@ defmodule KlassHero.Provider do
   end
 
   @doc """
+  Lists active staff members assigned to a program.
+
+  Uses a JOIN through `program_staff_assignments` so staff details arrive in a
+  single round-trip, ordered by when each assignment was created.
+  """
+  @spec list_active_staff_for_program(String.t()) :: [StaffMember.t()]
+  def list_active_staff_for_program(program_id) when is_binary(program_id) do
+    {:ok, members} = StaffMemberQueries.list_active_by_program(program_id)
+    members
+  end
+
+  @doc """
   Lists all active staff assignments for a provider.
   """
   @spec list_active_assignments_for_provider(String.t()) :: [

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository.ex
@@ -94,8 +94,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMembe
       members =
         from(s in StaffMemberSchema,
           join: a in ProgramStaffAssignmentSchema,
-          on: a.staff_member_id == s.id,
-          where: a.program_id == ^program_id and is_nil(a.unassigned_at),
+          on: a.staff_member_id == s.id and a.provider_id == s.provider_id,
+          where: a.program_id == ^program_id and is_nil(a.unassigned_at) and s.active == true,
           order_by: [asc: a.assigned_at],
           select: s
         )

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository.ex
@@ -13,6 +13,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMembe
   import Ecto.Query
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProgramStaffAssignmentSchema
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSchema
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.MapperHelpers
@@ -78,6 +79,26 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMembe
         StaffMemberSchema
         |> where([s], s.provider_id == ^provider_id and s.active == true)
         |> order_by([s], asc: s.inserted_at)
+        |> Repo.all()
+        |> MapperHelpers.to_domain_list(StaffMemberMapper)
+
+      {:ok, members}
+    end
+  end
+
+  @impl true
+  def list_active_by_program(program_id) when is_binary(program_id) do
+    span do
+      set_attributes("db", operation: "select", entity: "staff_member")
+
+      members =
+        from(s in StaffMemberSchema,
+          join: a in ProgramStaffAssignmentSchema,
+          on: a.staff_member_id == s.id,
+          where: a.program_id == ^program_id and is_nil(a.unassigned_at),
+          order_by: [asc: a.assigned_at],
+          select: s
+        )
         |> Repo.all()
         |> MapperHelpers.to_domain_list(StaffMemberMapper)
 

--- a/lib/klass_hero/provider/application/queries/staff_member_queries.ex
+++ b/lib/klass_hero/provider/application/queries/staff_member_queries.ex
@@ -38,6 +38,15 @@ defmodule KlassHero.Provider.Application.Queries.StaffMemberQueries do
   end
 
   @doc """
+  Lists active staff members assigned to a program, hydrated from the join table
+  in a single query.
+  """
+  @spec list_active_by_program(String.t()) :: {:ok, [StaffMember.t()]}
+  def list_active_by_program(program_id) when is_binary(program_id) do
+    @staff_repository.list_active_by_program(program_id)
+  end
+
+  @doc """
   Returns the active staff member record linked to the given user ID.
   Used by Scope to resolve :staff_provider role.
   """

--- a/lib/klass_hero/provider/domain/ports/for_querying_staff_members.ex
+++ b/lib/klass_hero/provider/domain/ports/for_querying_staff_members.ex
@@ -17,6 +17,9 @@ defmodule KlassHero.Provider.Domain.Ports.ForQueryingStaffMembers do
   @callback list_active_by_provider(provider_id :: binary()) ::
               {:ok, [StaffMember.t()]}
 
+  @callback list_active_by_program(program_id :: binary()) ::
+              {:ok, [StaffMember.t()]}
+
   @callback get_by_token_hash(token_hash :: binary()) ::
               {:ok, StaffMember.t()} | {:error, :not_found}
 

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -32,7 +32,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
         # Run independent DB queries in parallel to reduce total mount latency.
         team_task =
           Task.Supervisor.async_nolink(KlassHero.TaskSupervisor, fn ->
-            load_team_members(program.provider_id)
+            load_team_members(program.id)
           end)
 
         policy_task =
@@ -123,13 +123,10 @@ defmodule KlassHeroWeb.ProgramDetailLive do
     end
   end
 
-  defp load_team_members(nil), do: []
-
-  defp load_team_members(provider_id) do
-    case Provider.list_staff_members(provider_id) do
-      {:ok, members} -> StaffMemberPresenter.to_card_view_list(members)
-      {:error, _} -> []
-    end
+  defp load_team_members(program_id) when is_binary(program_id) do
+    program_id
+    |> Provider.list_active_staff_for_program()
+    |> StaffMemberPresenter.to_card_view_list()
   end
 
   defp load_provider_profile(nil), do: nil
@@ -353,7 +350,6 @@ defmodule KlassHeroWeb.ProgramDetailLive do
                   {date_range}
                 </p>
               <% end %>
-              <%!-- TODO: show instructor name when instructor data is wired to programs --%>
             </div>
             <div class="flex flex-col sm:flex-row gap-3">
               <.enroll_button

--- a/test/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository_test.exs
@@ -1,0 +1,144 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMemberRepositoryTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProgramStaffAssignmentRepository
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMemberRepository
+  alias KlassHero.Provider.Domain.Models.StaffMember
+
+  describe "list_active_by_program/1" do
+    test "returns StaffMember structs for active assignments" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff = insert(:staff_member_schema, provider_id: provider.id, first_name: "Coach", last_name: "Smith")
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: staff.id,
+          assigned_at: DateTime.utc_now()
+        })
+
+      assert {:ok, [%StaffMember{} = member]} =
+               StaffMemberRepository.list_active_by_program(program.id)
+
+      assert member.id == to_string(staff.id)
+      assert member.first_name == "Coach"
+      assert member.last_name == "Smith"
+    end
+
+    test "returns empty list when no assignments exist" do
+      program_id = Ecto.UUID.generate()
+      assert {:ok, []} = StaffMemberRepository.list_active_by_program(program_id)
+    end
+
+    test "excludes staff whose assignment has been unassigned" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      active_staff = insert(:staff_member_schema, provider_id: provider.id, first_name: "Active")
+      retired_staff = insert(:staff_member_schema, provider_id: provider.id, first_name: "Retired")
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: active_staff.id,
+          assigned_at: DateTime.utc_now()
+        })
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: retired_staff.id,
+          assigned_at: DateTime.utc_now()
+        })
+
+      {:ok, _} = ProgramStaffAssignmentRepository.unassign(program.id, retired_staff.id)
+
+      {:ok, members} = StaffMemberRepository.list_active_by_program(program.id)
+      assert length(members) == 1
+      assert hd(members).first_name == "Active"
+    end
+
+    test "excludes staff assigned to other programs" do
+      provider = insert(:provider_profile_schema)
+      viewed_program = insert(:program_schema, provider_id: provider.id)
+      other_program = insert(:program_schema, provider_id: provider.id)
+      own_staff = insert(:staff_member_schema, provider_id: provider.id, first_name: "Own")
+      other_staff = insert(:staff_member_schema, provider_id: provider.id, first_name: "Other")
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: viewed_program.id,
+          staff_member_id: own_staff.id,
+          assigned_at: DateTime.utc_now()
+        })
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: other_program.id,
+          staff_member_id: other_staff.id,
+          assigned_at: DateTime.utc_now()
+        })
+
+      {:ok, members} = StaffMemberRepository.list_active_by_program(viewed_program.id)
+      assert length(members) == 1
+      assert hd(members).first_name == "Own"
+    end
+
+    test "orders staff by assigned_at ascending" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      first = insert(:staff_member_schema, provider_id: provider.id, first_name: "First")
+      second = insert(:staff_member_schema, provider_id: provider.id, first_name: "Second")
+
+      earlier = DateTime.utc_now() |> DateTime.add(-60, :second)
+      later = DateTime.utc_now()
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: second.id,
+          assigned_at: later
+        })
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: first.id,
+          assigned_at: earlier
+        })
+
+      {:ok, members} = StaffMemberRepository.list_active_by_program(program.id)
+      assert Enum.map(members, & &1.first_name) == ["First", "Second"]
+    end
+
+    test "returns a staff member only once after unassign+reassign cycle" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff = insert(:staff_member_schema, provider_id: provider.id)
+
+      attrs = %{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: staff.id,
+        assigned_at: DateTime.utc_now()
+      }
+
+      {:ok, _} = ProgramStaffAssignmentRepository.create(attrs)
+      {:ok, _} = ProgramStaffAssignmentRepository.unassign(program.id, staff.id)
+      {:ok, _} = ProgramStaffAssignmentRepository.create(attrs)
+
+      {:ok, members} = StaffMemberRepository.list_active_by_program(program.id)
+      assert length(members) == 1
+      assert hd(members).id == to_string(staff.id)
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository_test.exs
@@ -140,5 +140,51 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMembe
       assert length(members) == 1
       assert hd(members).id == to_string(staff.id)
     end
+
+    test "excludes deactivated staff even when their assignment is active" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      active_staff = insert(:staff_member_schema, provider_id: provider.id, first_name: "Active", active: true)
+      deactivated = insert(:staff_member_schema, provider_id: provider.id, first_name: "Deactivated", active: false)
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: active_staff.id,
+          assigned_at: DateTime.utc_now()
+        })
+
+      {:ok, _} =
+        ProgramStaffAssignmentRepository.create(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: deactivated.id,
+          assigned_at: DateTime.utc_now()
+        })
+
+      {:ok, members} = StaffMemberRepository.list_active_by_program(program.id)
+      assert length(members) == 1
+      assert hd(members).first_name == "Active"
+    end
+
+    test "excludes rows where assignment provider_id mismatches staff provider_id" do
+      owning_provider = insert(:provider_profile_schema)
+      other_provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: owning_provider.id)
+      staff = insert(:staff_member_schema, provider_id: owning_provider.id, first_name: "Rightful")
+
+      # Malformed row: assignment.provider_id points at a DIFFERENT provider
+      # than the staff member's actual provider. Bypasses the write-side
+      # invariant in AssignStaffToProgram by inserting via factory directly.
+      insert(:program_staff_assignment_schema,
+        provider_id: other_provider.id,
+        program_id: program.id,
+        staff_member_id: staff.id
+      )
+
+      {:ok, members} = StaffMemberRepository.list_active_by_program(program.id)
+      assert members == []
+    end
   end
 end

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -206,11 +206,18 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       program =
         insert(:program_schema, provider_id: provider.id, title: "Soccer Academy")
 
-      staff_member_fixture(
+      staff =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Coach",
+          last_name: "Smith",
+          role: "Head Coach"
+        )
+
+      insert(:program_staff_assignment_schema,
         provider_id: provider.id,
-        first_name: "Coach",
-        last_name: "Smith",
-        role: "Head Coach"
+        program_id: program.id,
+        staff_member_id: staff.id
       )
 
       {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
@@ -226,19 +233,29 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       program =
         insert(:program_schema, provider_id: provider.id, title: "STEM Camp")
 
-      staff_member_fixture(
-        provider_id: provider.id,
-        first_name: "Alice",
-        last_name: "Johnson",
-        role: "Instructor"
-      )
+      alice =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Alice",
+          last_name: "Johnson",
+          role: "Instructor"
+        )
 
-      staff_member_fixture(
-        provider_id: provider.id,
-        first_name: "Bob",
-        last_name: "Williams",
-        role: "Assistant Instructor"
-      )
+      bob =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Bob",
+          last_name: "Williams",
+          role: "Assistant Instructor"
+        )
+
+      for staff <- [alice, bob] do
+        insert(:program_staff_assignment_schema,
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: staff.id
+        )
+      end
 
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
 
@@ -260,19 +277,53 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       provider = provider_profile_fixture()
       program = insert(:program_schema, provider_id: provider.id)
 
-      staff_member_fixture(
+      staff =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Jane",
+          last_name: "Doe",
+          email: "jane.secret@example.com"
+        )
+
+      insert(:program_staff_assignment_schema,
         provider_id: provider.id,
-        first_name: "Jane",
-        last_name: "Doe",
-        email: "jane.secret@example.com"
+        program_id: program.id,
+        staff_member_id: staff.id
       )
 
       {:ok, _view, html} = live(conn, ~p"/programs/#{program.id}")
 
-      # Trigger: staff email is included in presenter output
-      # Why: public program pages should not expose staff email addresses
-      # Outcome: email should NOT appear in rendered HTML
+      assert html =~ "Jane Doe"
       refute html =~ "jane.secret@example.com"
+    end
+
+    test "shows only staff assigned to the program, not other provider staff", %{conn: conn} do
+      provider = provider_profile_fixture()
+      program = insert(:program_schema, provider_id: provider.id)
+
+      assigned =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Assigned",
+          last_name: "Coach"
+        )
+
+      staff_member_fixture(
+        provider_id: provider.id,
+        first_name: "Unassigned",
+        last_name: "Bystander"
+      )
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: assigned.id
+      )
+
+      {:ok, _view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert html =~ "Assigned Coach"
+      refute html =~ "Unassigned Bystander"
     end
   end
 


### PR DESCRIPTION
Closes #295. Supersedes #717.

## Summary

- Added `list_active_by_program/1` to the `ForQueryingStaffMembers` port (`lib/klass_hero/provider/domain/ports/for_querying_staff_members.ex:20-21`), returning `{:ok, [StaffMember.t()]}`; implemented in `StaffMemberRepository` via a single JOIN through `program_staff_assignments` (`lib/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository.ex:90-108`).
- Wired through `StaffMemberQueries.list_active_by_program/1` and exposed on the facade as `Provider.list_active_staff_for_program/1`, which unwraps the `:ok` tuple so the web layer receives a raw list (`lib/klass_hero/provider.ex:481-491`).
- Refactored `ProgramDetailLive.load_team_members/1` to take `program_id` (not `provider_id`); dropped the unreachable `nil` clause and removed the stale `TODO: show instructor name` comment (`lib/klass_hero_web/live/program_detail_live.ex:35, 126-130, 353`).
- Added a new 6-test describe block in `staff_member_repository_test.exs` covering `%StaffMember{}` return shape, empty case, unassigned exclusion, other-program exclusion, `assigned_at` ordering, and unassign/reassign deduplication.
- Updated 3 existing LiveView tests to use `insert(:program_staff_assignment_schema, ...)` from the ExMachina factory; added an isolation test asserting unassigned provider staff do not render; strengthened the email-hiding test to also assert the card renders so it exercises the real filtering path.

## Review Focus

- **Port ownership** — the new callback returns `[StaffMember.t()]`, so it lives on `ForQueryingStaffMembers` rather than `ForQueryingProgramStaffAssignments`. The JOIN through `program_staff_assignments` is an adapter implementation detail, not a port contract concern. Worth confirming this feels right as the pattern for future cross-aggregate reads. See `for_querying_staff_members.ex:20-21` and `staff_member_repository.ex:87-108`.
- **Return-shape unwrap at the facade boundary** — `Provider.list_active_staff_for_program/1` unwraps `{:ok, list}` into a raw list in `provider.ex:488-490`. This keeps the port internally consistent (every `ForQueryingStaffMembers` callback returns `{:ok, ...}`) while giving the LiveView a clean pipeline. Callers that want the tuple form can use `StaffMemberQueries.list_active_by_program/1` directly.
- **Single JOIN, no N+1** — `staff_member_repository.ex:94-103` is one SQL statement that selects only staff columns. The existing partial unique index `ON program_staff_assignments (program_id, staff_member_id) WHERE unassigned_at IS NULL` covers the filter; adding a `(program_id) WHERE unassigned_at IS NULL` partial index is a future optimisation if query plans show seq scans at scale.
- **Email-leak test strengthened** — the pre-existing test trivially passed because no staff rendered at all. It now asserts `"Jane Doe"` IS in the HTML AND the email is NOT (`program_detail_live_test.exs:299-300`). Real regression shield, not a green-for-wrong-reason test.
- **Unreachable branch removed** — `defp load_team_members(nil), do: []` was dead code because `program.id` is never nil after `ProgramCatalog.get_program_by_id/1` returns `{:ok, program}`. Compare to `load_provider_profile(nil)`, which remains because `provider_id` can legitimately be nil when a program has no owning provider yet.

## Test Plan

- [x] `mix test test/klass_hero/provider/adapters/driven/persistence/repositories/staff_member_repository_test.exs` — 6 new tests cover the new repo method (shape, empty, unassigned exclusion, other-program exclusion, ordering, unassign/reassign dedup)
- [x] `mix test test/klass_hero_web/live/program_detail_live_test.exs` — 26 LiveView tests including new isolation test and strengthened email-hiding test
- [x] `mix precommit` — 4480 passed, 0 failed; no compile warnings
- [x] `mix credo --strict` — clean
- [x] Verified end-to-end via Tidewave `project_eval`: a provider with 2 staff (1 assigned, 1 unassigned) produces a 2-element list from `Provider.list_staff_members/1` but a 1-element list from `Provider.list_active_staff_for_program/1`
- [x] Verified in browser (Playwright) against dev data: created an unassigned `Filter Bystander` staff member on the same provider as an assigned `Rate Tester`; `/programs/:id` showed only `Rate Tester` in the "Meet the Hero" section while the bystander was absent from rendered HTML
- [ ] Manual verification in staging/prod: seed or assign at least one provider with multiple staff (only a subset assigned to a specific program), load `/programs/:id`, confirm only the assigned subset renders under "Meet the Heroes"