### PR TITLE
feat: notify business owner by email on incident report

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -56,6 +56,7 @@ alias KlassHero.Participation.Adapters.Driven.Persistence.Repositories.SessionRe
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramListingsRepository
 alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Repositories.ProgramRepository
 alias KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL
+alias KlassHero.Provider.Adapters.Driven.Notifications.IncidentReportedEmailNotifier
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.IncidentReportRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProgramStaffAssignmentRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProviderProfileRepository
@@ -65,6 +66,7 @@ alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.SessionStatsRe
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.StaffMemberRepository
 alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.VerificationDocumentRepository
 alias KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitationStatusHandler
+alias KlassHero.Provider.Adapters.Driving.Events.IncidentReportedHandler
 alias KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler
 alias KlassHero.Shared.Adapters.Driven.Events.PubSubEventPublisher
 alias KlassHero.Shared.Adapters.Driven.Events.PubSubIntegrationEventPublisher
@@ -167,6 +169,9 @@ config :klass_hero, :critical_event_handlers, %{
   ],
   "integration:provider:staff_member_invited" => [
     {StaffInvitationHandler, :handle_event}
+  ],
+  "integration:provider:incident_reported" => [
+    {IncidentReportedHandler, :handle_event}
   ],
   "integration:accounts:staff_invitation_sent" => [
     {StaffInvitationStatusHandler, :handle_event}
@@ -298,6 +303,8 @@ config :klass_hero, :provider,
   for_querying_session_stats: SessionStatsRepository,
   for_resolving_session_stats: ParticipationSessionStatsACL,
   for_storing_incident_reports: IncidentReportRepository,
+  for_querying_incident_reports: IncidentReportRepository,
+  for_sending_incident_emails: IncidentReportedEmailNotifier,
   for_querying_provider_programs: ProviderProgramRepository
 
 config :klass_hero, :resend_req_options, []
@@ -452,7 +459,9 @@ config :logger, :default_formatter,
     :file_url,
     :storage_path,
     :filename,
-    :received
+    :received,
+    :incident_report_id,
+    :provider_profile_id
   ]
 
 config :opentelemetry, :resource,

--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -33,6 +33,7 @@ defmodule KlassHero.Application do
   alias KlassHero.ProgramCatalog.Adapters.Driving.Events.EnrollmentEventHandler
   alias KlassHero.Provider.Adapters.Driving.Events.EventHandlers.CheckProviderVerificationStatus
   alias KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitationStatusHandler
+  alias KlassHero.Provider.Adapters.Driving.Events.IncidentReportedHandler
   alias KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler
   alias KlassHero.Shared.Adapters.Driven.Events.EventSubscriber
   alias KlassHero.Shared.DomainEventBus
@@ -107,7 +108,9 @@ defmodule KlassHero.Application do
            {:staff_assigned_to_program,
             {KlassHero.Provider.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}},
            {:staff_unassigned_from_program,
-            {KlassHero.Provider.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}}
+            {KlassHero.Provider.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}},
+           {:incident_reported,
+            {KlassHero.Provider.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle}, priority: 10}
          ]},
         id: :provider_domain_event_bus
       ),
@@ -354,6 +357,15 @@ defmodule KlassHero.Application do
          message_tag: :integration_event,
          event_label: "Integration event"},
         id: :staff_invitation_status_subscriber
+      ),
+      # Provider self-listener: emails business owner on incident reports
+      Supervisor.child_spec(
+        {EventSubscriber,
+         handler: IncidentReportedHandler,
+         topics: ["integration:provider:incident_reported"],
+         message_tag: :integration_event,
+         event_label: "Integration event"},
+        id: :provider_incident_reported_subscriber
       ),
       # Messaging listens for staff assignment events from Provider
       Supervisor.child_spec(

--- a/lib/klass_hero/enrollment/adapters/driven/notifications/invite_email_notifier.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/notifications/invite_email_notifier.ex
@@ -11,6 +11,7 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Notifications.InviteEmailNotifier
   import Swoosh.Email
 
   alias KlassHero.Mailer
+  alias KlassHero.Shared.EmailHtml
 
   @from Application.compile_env!(:klass_hero, [:mailer_defaults, :from])
 
@@ -55,20 +56,12 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Notifications.InviteEmailNotifier
   end
 
   defp build_html_content(invite, program_name, invite_url) do
-    greeting = esc(invite.guardian_first_name || "there")
-    child_name = "#{esc(invite.child_first_name)} #{esc(invite.child_last_name)}"
-    safe_program_name = esc(program_name)
-    safe_url = esc(invite_url)
+    greeting = EmailHtml.esc(invite.guardian_first_name || "there")
+    child_name = "#{EmailHtml.esc(invite.child_first_name)} #{EmailHtml.esc(invite.child_last_name)}"
+    safe_program_name = EmailHtml.esc(program_name)
+    safe_url = EmailHtml.esc(invite_url)
 
-    """
-    <!DOCTYPE html>
-    <html>
-    <head><meta charset="utf-8"></head>
-    <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
-      <div style="text-align: center; padding: 20px 0; border-bottom: 2px solid #4F46E5;">
-        <h1 style="color: #4F46E5; margin: 0; font-size: 24px;">KlassHero</h1>
-      </div>
-      <div style="padding: 30px 0;">
+    inner = """
         <p>Hi #{greeting},</p>
         <p>You've been invited to enroll <strong>#{child_name}</strong> in <strong>#{safe_program_name}</strong>.</p>
         <p style="color: #666; font-size: 14px;">After clicking the link below, your account will be created automatically. You can set a password in your account settings at any time.</p>
@@ -76,14 +69,8 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Notifications.InviteEmailNotifier
           <a href="#{safe_url}" style="background-color: #4F46E5; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">Complete Registration</a>
         </div>
         <p style="color: #666; font-size: 14px;">Or copy this link: #{safe_url}</p>
-      </div>
-      <div style="border-top: 1px solid #eee; padding-top: 15px; color: #999; font-size: 12px;">
-        <p>If you didn't expect this email, you can safely ignore it.</p>
-      </div>
-    </body>
-    </html>
     """
-  end
 
-  defp esc(text), do: Plug.HTML.html_escape(to_string(text))
+    EmailHtml.wrap(inner)
+  end
 end

--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -6,27 +6,11 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
   and transitions the invite status from `pending` to `invite_sent`.
   """
 
-  use KlassHero.Shared.Tracing.TracedWorker, queue: :email, max_attempts: 3
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
 
   alias KlassHero.Enrollment.Domain.Models.BulkEnrollmentInvite
 
   require Logger
-
-  # Trigger: Resend API enforces 2 req/sec rate limit
-  # Why: default Oban backoff doesn't account for 429 responses — retries
-  #      fire too soon and hit the limit again
-  # Outcome: rate-limited jobs wait 30s+ before retry; other failures use 10s base
-  @impl Oban.Worker
-  def backoff(%Oban.Job{attempt: attempt, unsaved_error: unsaved_error}) do
-    if rate_limit_error?(unsaved_error) do
-      trunc(min(30 * :math.pow(2, attempt - 1), 300))
-    else
-      trunc(min(10 * :math.pow(2, attempt - 1), 120))
-    end
-  end
-
-  defp rate_limit_error?(%{reason: {429, _}}), do: true
-  defp rate_limit_error?(_), do: false
 
   @invite_reader Application.compile_env!(:klass_hero, [
                    :enrollment,

--- a/lib/klass_hero/provider/adapters/driven/notifications/incident_reported_email_notifier.ex
+++ b/lib/klass_hero/provider/adapters/driven/notifications/incident_reported_email_notifier.ex
@@ -1,0 +1,109 @@
+defmodule KlassHero.Provider.Adapters.Driven.Notifications.IncidentReportedEmailNotifier do
+  @moduledoc """
+  Swoosh adapter for sending incident-report notification emails to a
+  provider's business owner.
+
+  Composes HTML + plain-text emails and delivers via `KlassHero.Mailer`.
+  The adapter never calls ports — the use case resolves all display
+  data and passes it as `context`.
+  """
+
+  @behaviour KlassHero.Provider.Domain.Ports.ForSendingIncidentEmails
+
+  import Swoosh.Email
+
+  alias KlassHero.Mailer
+  alias KlassHero.Provider.Domain.Models.IncidentReport
+  alias KlassHero.Shared.EmailHtml
+
+  @from Application.compile_env!(:klass_hero, [:mailer_defaults, :from])
+
+  @impl true
+  def send_incident_report(recipient, %IncidentReport{} = report, context) do
+    recipient_name = recipient.name || recipient.email
+
+    email =
+      new()
+      |> to({recipient_name, recipient.email})
+      |> from(@from)
+      |> subject(build_subject(report, context))
+      |> text_body(build_text_content(report, context))
+      |> html_body(build_html_content(report, context))
+
+    with {:ok, _metadata} <- Mailer.deliver(email) do
+      {:ok, email}
+    end
+  end
+
+  defp build_subject(%IncidentReport{} = report, %{program_name: program_name}) do
+    "Incident reported: #{IncidentReport.category_label(report.category)} (#{IncidentReport.severity_label(report.severity)}) — #{program_name}"
+  end
+
+  defp build_text_content(%IncidentReport{} = report, context) do
+    photo_line =
+      case context.signed_photo_url do
+        nil -> ""
+        url -> "Photo: #{url} (link valid for 1 hour)\n\n"
+      end
+
+    """
+    A new incident has been reported for #{context.program_name}.
+
+    Category: #{IncidentReport.category_label(report.category)}
+    Severity: #{IncidentReport.severity_label(report.severity)}
+    Occurred at: #{format_datetime(report.occurred_at)}
+    Report ID: #{report.id}
+
+    Description:
+    #{report.description}
+
+    #{photo_line}- The KlassHero Team
+    """
+  end
+
+  defp build_html_content(%IncidentReport{} = report, context) do
+    safe_program = EmailHtml.esc(context.program_name)
+    safe_category = EmailHtml.esc(IncidentReport.category_label(report.category))
+    safe_severity = EmailHtml.esc(IncidentReport.severity_label(report.severity))
+    safe_occurred = EmailHtml.esc(format_datetime(report.occurred_at))
+    safe_description = EmailHtml.esc(report.description)
+    safe_id = EmailHtml.esc(report.id)
+
+    photo_section =
+      case context.signed_photo_url do
+        nil ->
+          ""
+
+        url ->
+          safe_url = EmailHtml.esc(url)
+
+          """
+          <p style="margin: 16px 0;">
+            <a href="#{safe_url}" style="color: #4F46E5; font-weight: 600;">View photo</a>
+            <span style="color: #999; font-size: 12px;"> (link valid for 1 hour)</span>
+          </p>
+          """
+      end
+
+    inner = """
+        <p>A new incident has been reported for <strong>#{safe_program}</strong>.</p>
+        <table style="border-collapse: collapse; margin: 16px 0;">
+          <tr><td style="padding: 4px 12px 4px 0; color: #666;">Category</td><td style="padding: 4px 0;"><strong>#{safe_category}</strong></td></tr>
+          <tr><td style="padding: 4px 12px 4px 0; color: #666;">Severity</td><td style="padding: 4px 0;"><strong>#{safe_severity}</strong></td></tr>
+          <tr><td style="padding: 4px 12px 4px 0; color: #666;">Occurred at</td><td style="padding: 4px 0;">#{safe_occurred}</td></tr>
+          <tr><td style="padding: 4px 12px 4px 0; color: #666;">Report ID</td><td style="padding: 4px 0;">#{safe_id}</td></tr>
+        </table>
+        <p style="margin-top: 16px;"><strong>Description</strong></p>
+        <p style="white-space: pre-wrap;">#{safe_description}</p>
+        #{photo_section}
+    """
+
+    EmailHtml.wrap(inner,
+      footer_message: "You're receiving this because an incident was reported for your program on KlassHero."
+    )
+  end
+
+  defp format_datetime(%DateTime{} = dt) do
+    Calendar.strftime(dt, "%Y-%m-%d %H:%M UTC")
+  end
+end

--- a/lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_profile_mapper.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/mappers/provider_profile_mapper.ex
@@ -1,21 +1,6 @@
 defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderProfileMapper do
   @moduledoc """
-  Maps between domain ProviderProfile entities and ProviderProfileSchema Ecto structs.
-
-  This adapter provides bidirectional conversion:
-  - to_domain/1: ProviderProfileSchema -> ProviderProfile (for reading from database)
-  - to_schema/1: ProviderProfile -> ProviderProfileSchema attributes (for creating/updating in database)
-  The mapper is bidirectional to support both reading and writing provider profiles.
-
-  ## Design Note: to_schema Excludes Database-Managed Fields
-
-  The `to_schema/1` function intentionally excludes:
-  - `id` - Managed by Ecto on insert (conditionally included via maybe_add_id/2)
-  - `inserted_at`, `updated_at` - Managed by Ecto timestamps
-
-  This follows standard Ecto patterns where the database/framework manages
-  these fields automatically. The repository handles id explicitly when needed
-  (e.g., for updates or when domain entity already has an id).
+  Bidirectional mapping between `ProviderProfile` domain entities and `ProviderProfileSchema` Ecto structs.
   """
 
   import KlassHero.Shared.Adapters.Driven.Persistence.MapperHelpers,
@@ -38,6 +23,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderProfile
       id: to_string(schema.id),
       identity_id: to_string(schema.identity_id),
       business_name: schema.business_name,
+      business_owner_email: schema.business_owner_email,
       description: schema.description,
       phone: schema.phone,
       website: schema.website,
@@ -66,6 +52,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderProfile
     %{
       identity_id: provider_profile.identity_id,
       business_name: provider_profile.business_name,
+      business_owner_email: provider_profile.business_owner_email,
       description: provider_profile.description,
       phone: provider_profile.phone,
       website: provider_profile.website,

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/incident_report_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/incident_report_repository.ex
@@ -2,23 +2,24 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.IncidentRe
   @moduledoc """
   Ecto-based repository for incident reports.
 
-  Implements the ForStoringIncidentReports port with:
-  - Domain entity mapping via IncidentReportMapper
-  - Idiomatic "let it crash" error handling
-
-  Infrastructure errors (connection, query) are not caught — they crash and
-  are handled by the supervision tree.
+  Implements both `ForStoringIncidentReports` (writes) and
+  `ForQueryingIncidentReports` (reads). Domain mapping via
+  `IncidentReportMapper`. Infrastructure errors crash and are handled
+  by the supervision tree.
   """
 
+  @behaviour KlassHero.Provider.Domain.Ports.ForQueryingIncidentReports
   @behaviour KlassHero.Provider.Domain.Ports.ForStoringIncidentReports
 
   use KlassHero.Shared.Tracing
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportMapper
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.IncidentReportSchema
+  alias KlassHero.Provider.Domain.Ports.ForQueryingIncidentReports
+  alias KlassHero.Provider.Domain.Ports.ForStoringIncidentReports
   alias KlassHero.Repo
 
-  @impl true
+  @impl ForStoringIncidentReports
   @doc """
   Creates a new incident report in the database.
 
@@ -35,6 +36,25 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.IncidentRe
 
       with {:ok, saved} <- Repo.insert(changeset) do
         {:ok, IncidentReportMapper.to_domain(saved)}
+      end
+    end
+  end
+
+  @impl ForQueryingIncidentReports
+  @doc """
+  Retrieves an incident report by its ID.
+
+  Returns:
+  - `{:ok, IncidentReport.t()}` when found
+  - `{:error, :not_found}` when no report exists with the given ID
+  """
+  def get(id) when is_binary(id) do
+    span do
+      set_attributes("db", operation: "select", entity: "incident_report")
+
+      case Repo.get(IncidentReportSchema, id) do
+        nil -> {:error, :not_found}
+        schema -> {:ok, IncidentReportMapper.to_domain(schema)}
       end
     end
   end

--- a/lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_profile_schema.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/schemas/provider_profile_schema.ex
@@ -24,6 +24,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProfile
   schema "providers" do
     field :identity_id, :binary_id
     field :business_name, :string
+    field :business_owner_email, :string
     field :description, :string
     field :phone, :string
     field :website, :string
@@ -64,6 +65,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProfile
     |> cast(attrs, [
       :identity_id,
       :business_name,
+      :business_owner_email,
       :description,
       :phone,
       :website,

--- a/lib/klass_hero/provider/adapters/driving/events/incident_reported_handler.ex
+++ b/lib/klass_hero/provider/adapters/driving/events/incident_reported_handler.ex
@@ -1,0 +1,49 @@
+defmodule KlassHero.Provider.Adapters.Driving.Events.IncidentReportedHandler do
+  @moduledoc """
+  Integration event handler for `:incident_reported`.
+
+  Thin dispatcher that enqueues `NotifyIncidentReportedWorker` for each
+  reported incident. Domain orchestration (self-report check, owner email
+  resolution, photo signing) lives in the `NotifyIncidentReported` use case.
+  """
+
+  @behaviour KlassHero.Shared.Domain.Ports.Driving.ForHandlingIntegrationEvents
+
+  alias KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWorker
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+  alias KlassHero.Shared.Tracing.Context
+
+  require Logger
+
+  @impl true
+  def subscribed_events, do: [:incident_reported]
+
+  @impl true
+  def handle_event(%IntegrationEvent{event_type: :incident_reported, entity_id: incident_id}) do
+    args =
+      %{incident_report_id: incident_id}
+      |> Context.inject_into_args()
+
+    args
+    |> NotifyIncidentReportedWorker.new()
+    |> Oban.insert()
+    |> case do
+      {:ok, _job} ->
+        Logger.info("[IncidentReportedHandler] Enqueued incident notification",
+          incident_report_id: incident_id
+        )
+
+        :ok
+
+      {:error, reason} ->
+        Logger.error("[IncidentReportedHandler] Failed to enqueue notification",
+          incident_report_id: incident_id,
+          reason: inspect(reason)
+        )
+
+        {:error, reason}
+    end
+  end
+
+  def handle_event(_event), do: :ignore
+end

--- a/lib/klass_hero/provider/adapters/driving/events/provider_event_handler.ex
+++ b/lib/klass_hero/provider/adapters/driving/events/provider_event_handler.ex
@@ -30,45 +30,20 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler do
   def subscribed_events, do: [:user_registered, :user_confirmed, :user_anonymized]
 
   @impl true
-  def handle_event(%{event_type: :user_anonymized, entity_id: _user_id}) do
-    # Trigger: user_anonymized event received
-    # Why: provider profiles retain business_name for audit — no PII to anonymize
-    # Outcome: no-op, return :ok
-    :ok
-  end
+  def handle_event(%{event_type: :user_anonymized, entity_id: _user_id}), do: :ok
 
   @impl true
-  def handle_event(%{event_type: :user_registered, entity_id: user_id, payload: payload}) do
-    intended_roles = Map.get(payload, :intended_roles, [])
-    business_name = Map.get(payload, :name, "")
-    provider_tier = Map.get(payload, :provider_subscription_tier)
-
-    # Trigger: user_registered event with role list
+  def handle_event(%{event_type: event_type, entity_id: user_id, payload: payload})
+      when event_type in [:user_registered, :user_confirmed] do
     # Why: only create provider profile if "provider" role requested AND
     #   the user didn't register via staff invitation (staff flow handles its own
     #   profile creation with originated_from: :staff_invite)
-    # Outcome: provider profile created with selected tier or default starter
-    if "provider" in intended_roles and "staff_provider" not in intended_roles do
-      create_provider_profile_with_retry(user_id, business_name, provider_tier)
-    else
-      :ignore
-    end
-  end
-
-  @impl true
-  def handle_event(%{event_type: :user_confirmed, entity_id: user_id, payload: payload}) do
     intended_roles = Map.get(payload, :intended_roles, [])
-    business_name = Map.get(payload, :name, "")
-    provider_tier = Map.get(payload, :provider_subscription_tier)
 
-    # Trigger: user_confirmed event — compensation path for profile creation
-    # Why: if user_registered delivery was delayed, this ensures the profile
-    #      exists before the user's first authenticated session.
-    #      Staff registrations are excluded — their flow creates the profile
-    #      with originated_from: :staff_invite via StaffInvitationStatusHandler.
-    # Outcome: creates profile or returns :ok if already exists (idempotent)
     if "provider" in intended_roles and "staff_provider" not in intended_roles do
-      create_provider_profile_with_retry(user_id, business_name, provider_tier)
+      user_id
+      |> build_attrs_from_payload(payload)
+      |> create_provider_profile_with_retry(user_id)
     else
       :ignore
     end
@@ -76,17 +51,17 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler do
 
   def handle_event(_event), do: :ignore
 
-  defp create_provider_profile_with_retry(user_id, business_name, provider_tier) do
-    attrs =
-      %{
-        identity_id: user_id,
-        business_name: business_name
-      }
-      |> maybe_put_tier(provider_tier)
+  defp build_attrs_from_payload(user_id, payload) do
+    %{
+      identity_id: user_id,
+      business_name: Map.get(payload, :name, ""),
+      business_owner_email: Map.get(payload, :email)
+    }
+    |> maybe_put_tier(Map.get(payload, :provider_subscription_tier))
+  end
 
-    operation = fn ->
-      Provider.create_provider_profile(attrs)
-    end
+  defp create_provider_profile_with_retry(attrs, user_id) do
+    operation = fn -> Provider.create_provider_profile(attrs) end
 
     context = %{
       operation_name: "create provider profile",
@@ -97,9 +72,6 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler do
     RetryHelpers.retry_and_normalize(operation, context)
   end
 
-  # Trigger: provider_subscription_tier may be nil or a string like "professional"
-  # Why: nil means use default (starter); string needs safe cast to atom for domain model
-  # Outcome: attrs includes subscription_tier only when explicitly selected and valid
   defp maybe_put_tier(attrs, nil), do: attrs
   defp maybe_put_tier(attrs, ""), do: attrs
 

--- a/lib/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker.ex
+++ b/lib/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker.ex
@@ -1,0 +1,18 @@
+defmodule KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWorker do
+  @moduledoc """
+  Oban worker that delivers the incident-report email for a single report.
+
+  Runs on the `:email` queue (concurrency 1) so Resend rate limits are
+  respected globally. Delegates the actual orchestration to the
+  `NotifyIncidentReported` use case.
+  """
+
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
+
+  alias KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReported
+
+  @impl true
+  def execute(%Oban.Job{args: %{"incident_report_id" => id}}) when is_binary(id) do
+    NotifyIncidentReported.execute(%{incident_report_id: id})
+  end
+end

--- a/lib/klass_hero/provider/application/commands/incident/notify_incident_reported.ex
+++ b/lib/klass_hero/provider/application/commands/incident/notify_incident_reported.ex
@@ -1,0 +1,127 @@
+defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReported do
+  @moduledoc """
+  Emails a provider's business owner when an incident report is submitted.
+  Self-reports (reporter == owner) short-circuit early.
+  """
+
+  alias KlassHero.Provider.Domain.Models.IncidentReport
+  alias KlassHero.Provider.Domain.Models.ProviderProfile
+  alias KlassHero.Shared.Storage
+
+  require Logger
+
+  @incident_query Application.compile_env!(:klass_hero, [:provider, :for_querying_incident_reports])
+  @profile_query Application.compile_env!(:klass_hero, [:provider, :for_querying_provider_profiles])
+  @program_query Application.compile_env!(:klass_hero, [:provider, :for_querying_provider_programs])
+  @notifier Application.compile_env!(:klass_hero, [:provider, :for_sending_incident_emails])
+
+  @signed_url_ttl_seconds 3600
+  @program_fallback_label "a program"
+  @session_fallback_label "a session"
+
+  @doc """
+  Sends the incident-report email for the given report id.
+
+  Returns `:ok` on success or self-report skip; `{:error, reason}` on
+  recoverable failure (Oban retries) or permanent failure.
+  """
+  @spec execute(%{required(:incident_report_id) => binary()}) :: :ok | {:error, atom()}
+  def execute(%{incident_report_id: id}) when is_binary(id) do
+    with {:ok, report} <- fetch_report(id),
+         {:ok, profile} <- fetch_profile(report.provider_profile_id),
+         :continue <- check_self_report(report, profile, id),
+         {:ok, email} <- require_owner_email(profile, id) do
+      program_label = resolve_program_label(report)
+      signed_url = maybe_sign_photo(report, id)
+      send_email(profile, email, report, program_label, signed_url)
+    end
+  end
+
+  defp fetch_report(id) do
+    case @incident_query.get(id) do
+      {:ok, %IncidentReport{} = report} -> {:ok, report}
+      {:error, :not_found} -> {:error, :incident_report_not_found}
+    end
+  end
+
+  defp fetch_profile(provider_profile_id) do
+    case @profile_query.get(provider_profile_id) do
+      {:ok, %ProviderProfile{} = profile} -> {:ok, profile}
+      {:error, :not_found} -> {:error, :provider_profile_not_found}
+    end
+  end
+
+  defp check_self_report(%IncidentReport{reporter_user_id: rid}, %ProviderProfile{identity_id: iid}, id)
+       when rid == iid do
+    Logger.info("[NotifyIncidentReported] Skipping self-report",
+      incident_report_id: id,
+      identity_id: iid
+    )
+
+    :ok
+  end
+
+  defp check_self_report(_report, _profile, _id), do: :continue
+
+  defp require_owner_email(%ProviderProfile{business_owner_email: email}, _id)
+       when is_binary(email) and byte_size(email) > 0 do
+    {:ok, email}
+  end
+
+  defp require_owner_email(%ProviderProfile{id: profile_id}, id) do
+    Logger.warning("[NotifyIncidentReported] Missing business_owner_email",
+      incident_report_id: id,
+      provider_profile_id: profile_id
+    )
+
+    {:error, :missing_business_owner_email}
+  end
+
+  defp resolve_program_label(%IncidentReport{program_id: pid}) when is_binary(pid) do
+    case @program_query.get_by_id(pid) do
+      {:ok, %{name: name}} when is_binary(name) and byte_size(name) > 0 ->
+        name
+
+      {:error, :not_found} ->
+        Logger.warning("[NotifyIncidentReported] Program not found, using fallback label",
+          program_id: pid
+        )
+
+        @program_fallback_label
+    end
+  end
+
+  defp resolve_program_label(%IncidentReport{}), do: @session_fallback_label
+
+  defp maybe_sign_photo(%IncidentReport{photo_url: nil}, _id), do: nil
+
+  defp maybe_sign_photo(%IncidentReport{photo_url: key}, id) when is_binary(key) do
+    case Storage.signed_url(:private, key, @signed_url_ttl_seconds) do
+      {:ok, url} ->
+        url
+
+      {:error, reason} ->
+        Logger.warning("[NotifyIncidentReported] Photo signing failed, sending without photo",
+          incident_report_id: id,
+          reason: inspect(reason)
+        )
+
+        nil
+    end
+  end
+
+  defp send_email(profile, email, report, program_label, signed_url) do
+    recipient = %{email: email, name: profile.business_name}
+
+    context = %{
+      program_name: program_label,
+      signed_photo_url: signed_url,
+      business_name: profile.business_name
+    }
+
+    case @notifier.send_incident_report(recipient, report, context) do
+      {:ok, _email} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/klass_hero/provider/domain/models/incident_report.ex
+++ b/lib/klass_hero/provider/domain/models/incident_report.ex
@@ -97,6 +97,22 @@ defmodule KlassHero.Provider.Domain.Models.IncidentReport do
   @doc "Returns the list of valid incident severities."
   def valid_severities, do: @valid_severities
 
+  @doc "Plain English label for a category atom."
+  @spec category_label(category()) :: String.t()
+  def category_label(:safety_concern), do: "Safety concern"
+  def category_label(:behavioral_issue), do: "Behavioral issue"
+  def category_label(:injury), do: "Injury"
+  def category_label(:property_damage), do: "Property damage"
+  def category_label(:policy_violation), do: "Policy violation"
+  def category_label(:other), do: "Other"
+
+  @doc "Plain English label for a severity atom."
+  @spec severity_label(severity()) :: String.t()
+  def severity_label(:low), do: "Low"
+  def severity_label(:medium), do: "Medium"
+  def severity_label(:high), do: "High"
+  def severity_label(:critical), do: "Critical"
+
   @doc """
   Creates a new IncidentReport with validation.
 

--- a/lib/klass_hero/provider/domain/models/provider_profile.ex
+++ b/lib/klass_hero/provider/domain/models/provider_profile.ex
@@ -17,6 +17,7 @@ defmodule KlassHero.Provider.Domain.Models.ProviderProfile do
     :id,
     :identity_id,
     :business_name,
+    :business_owner_email,
     :description,
     :phone,
     :website,
@@ -37,6 +38,7 @@ defmodule KlassHero.Provider.Domain.Models.ProviderProfile do
           id: String.t(),
           identity_id: String.t(),
           business_name: String.t(),
+          business_owner_email: String.t() | nil,
           description: String.t() | nil,
           phone: String.t() | nil,
           website: String.t() | nil,
@@ -170,7 +172,20 @@ defmodule KlassHero.Provider.Domain.Models.ProviderProfile do
     |> validate_subscription_tier(provider_profile.subscription_tier)
     |> validate_originated_from(provider_profile.originated_from)
     |> validate_profile_status(provider_profile.profile_status)
+    |> validate_business_owner_email(provider_profile.business_owner_email)
   end
+
+  defp validate_business_owner_email(errors, nil), do: errors
+
+  defp validate_business_owner_email(errors, email) when is_binary(email) do
+    if String.length(email) > 254 do
+      ["Business owner email must be 254 characters or less" | errors]
+    else
+      errors
+    end
+  end
+
+  defp validate_business_owner_email(errors, _), do: ["Business owner email must be a string" | errors]
 
   defp validate_identity_id(errors, identity_id) when is_binary(identity_id) do
     trimmed = String.trim(identity_id)

--- a/lib/klass_hero/provider/domain/ports/for_querying_incident_reports.ex
+++ b/lib/klass_hero/provider/domain/ports/for_querying_incident_reports.ex
@@ -1,0 +1,16 @@
+defmodule KlassHero.Provider.Domain.Ports.ForQueryingIncidentReports do
+  @moduledoc """
+  Read-only port for querying incident reports in the Provider bounded context.
+  """
+
+  alias KlassHero.Provider.Domain.Models.IncidentReport
+
+  @doc """
+  Retrieves an incident report by its ID.
+
+  Returns:
+  - `{:ok, IncidentReport.t()}` when the report is found
+  - `{:error, :not_found}` when no report exists with the given ID
+  """
+  @callback get(id :: binary()) :: {:ok, IncidentReport.t()} | {:error, :not_found}
+end

--- a/lib/klass_hero/provider/domain/ports/for_sending_incident_emails.ex
+++ b/lib/klass_hero/provider/domain/ports/for_sending_incident_emails.ex
@@ -1,0 +1,39 @@
+defmodule KlassHero.Provider.Domain.Ports.ForSendingIncidentEmails do
+  @moduledoc """
+  Port for sending incident-report notification emails to a provider's
+  business owner.
+
+  Adapters deliver an email summarising the incident — category,
+  severity, program, occurrence time, description, and (when available)
+  a temporary signed link to the attached photo.
+  """
+
+  alias KlassHero.Provider.Domain.Models.IncidentReport
+
+  @typedoc """
+  Recipient details. `name` may be nil for legacy rows whose owner has
+  no display name on record; the adapter falls back to the email
+  address in that case.
+  """
+  @type recipient :: %{required(:email) => String.t(), required(:name) => String.t() | nil}
+
+  @typedoc """
+  Display context resolved by the use case before calling the notifier.
+  Keeps the adapter free of port lookups and translation concerns.
+  """
+  @type context :: %{
+          required(:program_name) => String.t(),
+          required(:business_name) => String.t() | nil,
+          required(:signed_photo_url) => String.t() | nil
+        }
+
+  @doc """
+  Sends an incident-report email to the given recipient.
+
+  Returns `{:ok, email}` on successful delivery, or `{:error, reason}`
+  on transient/permanent mailer failure (callers — typically an Oban
+  worker — decide whether to retry).
+  """
+  @callback send_incident_report(recipient(), IncidentReport.t(), context()) ::
+              {:ok, term()} | {:error, term()}
+end

--- a/lib/klass_hero/shared.ex
+++ b/lib/klass_hero/shared.ex
@@ -31,6 +31,8 @@ defmodule KlassHero.Shared do
       Adapters.Driven.Persistence.EctoErrorHelpers,
       Adapters.Driven.Persistence.MapperHelpers,
       Adapters.Driven.Persistence.RepositoryHelpers,
+      EmailHtml,
+      RateLimitedEmailWorker,
       Storage,
       Tracing,
       Tracing.Context,

--- a/lib/klass_hero/shared/adapters/driven/events/critical_event_serializer.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/critical_event_serializer.ex
@@ -92,6 +92,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
 
   # -- Key conversion helpers --
 
+  defp stringify_keys(%_{} = struct), do: struct
+
   defp stringify_keys(map) when is_map(map) do
     Map.new(map, fn
       {k, v} when is_atom(k) -> {Atom.to_string(k), stringify_keys(v)}
@@ -99,7 +101,11 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
     end)
   end
 
+  defp stringify_keys(list) when is_list(list), do: Enum.map(list, &stringify_keys/1)
+
   defp stringify_keys(value), do: value
+
+  defp atomize_keys(%_{} = struct), do: struct
 
   defp atomize_keys(map) when is_map(map) do
     Map.new(map, fn
@@ -107,6 +113,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
       {k, v} -> {k, atomize_keys(v)}
     end)
   end
+
+  defp atomize_keys(list) when is_list(list), do: Enum.map(list, &atomize_keys/1)
 
   defp atomize_keys(value), do: value
 

--- a/lib/klass_hero/shared/email_html.ex
+++ b/lib/klass_hero/shared/email_html.ex
@@ -26,14 +26,16 @@ defmodule KlassHero.Shared.EmailHtml do
   defp escape_chars(<<c::utf8, rest::binary>>, acc), do: escape_chars(rest, acc <> <<c::utf8>>)
 
   @doc """
-  Wraps inner HTML in the standard KlassHero email shell.
+  Wraps a pre-rendered HTML string in the standard KlassHero email shell.
+
+  `inner_html` must be a binary — callers build it via `~s|...|` or heredoc strings.
 
   ## Options
 
     * `:footer_message` — overrides the default footer paragraph.
   """
-  @spec wrap(iodata(), keyword()) :: String.t()
-  def wrap(inner_html, opts \\ []) do
+  @spec wrap(String.t(), keyword()) :: String.t()
+  def wrap(inner_html, opts \\ []) when is_binary(inner_html) do
     footer = Keyword.get(opts, :footer_message, @default_footer) |> esc()
 
     """

--- a/lib/klass_hero/shared/email_html.ex
+++ b/lib/klass_hero/shared/email_html.ex
@@ -1,0 +1,57 @@
+defmodule KlassHero.Shared.EmailHtml do
+  @moduledoc """
+  Shared scaffolding for transactional email HTML bodies.
+
+  Centralises the KlassHero brand bar, typography defaults, and footer so
+  all notifiers render with one consistent shell. Each notifier supplies
+  the inner content; this module wraps it.
+  """
+
+  @default_footer "If you didn't expect this email, you can safely ignore it."
+
+  @doc "HTML-escapes any term, coercing to string first."
+  @spec esc(term()) :: String.t()
+  def esc(text) do
+    text
+    |> to_string()
+    |> escape_chars(<<>>)
+  end
+
+  defp escape_chars(<<>>, acc), do: acc
+  defp escape_chars(<<"<", rest::binary>>, acc), do: escape_chars(rest, acc <> "&lt;")
+  defp escape_chars(<<">", rest::binary>>, acc), do: escape_chars(rest, acc <> "&gt;")
+  defp escape_chars(<<"&", rest::binary>>, acc), do: escape_chars(rest, acc <> "&amp;")
+  defp escape_chars(<<"\"", rest::binary>>, acc), do: escape_chars(rest, acc <> "&quot;")
+  defp escape_chars(<<"'", rest::binary>>, acc), do: escape_chars(rest, acc <> "&#39;")
+  defp escape_chars(<<c::utf8, rest::binary>>, acc), do: escape_chars(rest, acc <> <<c::utf8>>)
+
+  @doc """
+  Wraps inner HTML in the standard KlassHero email shell.
+
+  ## Options
+
+    * `:footer_message` — overrides the default footer paragraph.
+  """
+  @spec wrap(iodata(), keyword()) :: String.t()
+  def wrap(inner_html, opts \\ []) do
+    footer = Keyword.get(opts, :footer_message, @default_footer) |> esc()
+
+    """
+    <!DOCTYPE html>
+    <html>
+    <head><meta charset="utf-8"></head>
+    <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
+      <div style="text-align: center; padding: 20px 0; border-bottom: 2px solid #4F46E5;">
+        <h1 style="color: #4F46E5; margin: 0; font-size: 24px;">KlassHero</h1>
+      </div>
+      <div style="padding: 30px 0;">
+    #{inner_html}
+      </div>
+      <div style="border-top: 1px solid #eee; padding-top: 15px; color: #999; font-size: 12px;">
+        <p>#{footer}</p>
+      </div>
+    </body>
+    </html>
+    """
+  end
+end

--- a/lib/klass_hero/shared/rate_limited_email_worker.ex
+++ b/lib/klass_hero/shared/rate_limited_email_worker.ex
@@ -1,0 +1,45 @@
+defmodule KlassHero.Shared.RateLimitedEmailWorker do
+  @moduledoc """
+  Macro for Oban workers that send email through Resend (or any 429-returning
+  upstream). Wraps `KlassHero.Shared.Tracing.TracedWorker` and adds a `backoff/1`
+  override that backs off harder on rate-limit errors.
+
+  ## Usage
+
+      defmodule MyApp.Workers.SomeEmailWorker do
+        use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
+
+        @impl KlassHero.Shared.Tracing.TracedWorker
+        def execute(%Oban.Job{} = job), do: ...
+      end
+
+  Backoff schedule:
+  - Rate-limit error (`%{reason: {429, _}}`): 30s → 60s → 120s → … capped at 300s
+  - Other errors: 10s → 20s → 40s → … capped at 120s
+  """
+
+  @doc "Returns true when the captured Oban error reason is a 429 rate limit."
+  @spec rate_limit_error?(term()) :: boolean()
+  def rate_limit_error?(%{reason: {429, _}}), do: true
+  def rate_limit_error?(_), do: false
+
+  @doc false
+  defmacro __using__(opts) do
+    quote do
+      use KlassHero.Shared.Tracing.TracedWorker, unquote(opts)
+
+      alias KlassHero.Shared.RateLimitedEmailWorker
+
+      @impl Oban.Worker
+      def backoff(%Oban.Job{attempt: attempt, unsaved_error: unsaved_error}) do
+        if RateLimitedEmailWorker.rate_limit_error?(unsaved_error) do
+          trunc(min(30 * :math.pow(2, attempt - 1), 300))
+        else
+          trunc(min(10 * :math.pow(2, attempt - 1), 120))
+        end
+      end
+
+      defoverridable backoff: 1
+    end
+  end
+end

--- a/priv/repo/migrations/20260425062731_add_business_owner_email_to_providers.exs
+++ b/priv/repo/migrations/20260425062731_add_business_owner_email_to_providers.exs
@@ -1,0 +1,21 @@
+defmodule KlassHero.Repo.Migrations.AddBusinessOwnerEmailToProviders do
+  use Ecto.Migration
+
+  def up do
+    alter table(:providers) do
+      add :business_owner_email, :string
+    end
+
+    flush()
+
+    execute(
+      "UPDATE providers SET business_owner_email = users.email FROM users WHERE providers.identity_id = users.id"
+    )
+  end
+
+  def down do
+    alter table(:providers) do
+      remove :business_owner_email
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/notifications/incident_reported_email_notifier_test.exs
+++ b/test/klass_hero/provider/adapters/driven/notifications/incident_reported_email_notifier_test.exs
@@ -1,0 +1,131 @@
+defmodule KlassHero.Provider.Adapters.Driven.Notifications.IncidentReportedEmailNotifierTest do
+  @moduledoc """
+  Tests for the IncidentReportedEmailNotifier adapter.
+
+  Uses Swoosh.Adapters.Test (configured in test env) which returns
+  `{:ok, %{}}` from `Mailer.deliver/1`, so `send_incident_report/3`
+  returns `{:ok, email}`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Notifications.IncidentReportedEmailNotifier
+  alias KlassHero.Provider.Domain.Models.IncidentReport
+
+  @recipient %{email: "owner@example.com", name: "Hannah Owner"}
+
+  defp build_report(overrides \\ %{}) do
+    {:ok, report} =
+      IncidentReport.new(
+        Map.merge(
+          %{
+            id: "01HZ-incident-id",
+            provider_profile_id: "prov-1",
+            reporter_user_id: "user-1",
+            program_id: "prog-1",
+            category: :safety_concern,
+            severity: :high,
+            description: "A child slipped near the edge of the play area.",
+            occurred_at: ~U[2026-04-20 14:30:00Z]
+          },
+          overrides
+        )
+      )
+
+    report
+  end
+
+  defp build_context(overrides \\ %{}) do
+    Map.merge(
+      %{
+        program_name: "Friday Climbing Club",
+        business_name: "Acme Adventures",
+        signed_photo_url: nil
+      },
+      overrides
+    )
+  end
+
+  describe "send_incident_report/3" do
+    test "delivers email with the prescribed subject format" do
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(@recipient, build_report(), build_context())
+
+      assert email.subject ==
+               "Incident reported: Safety concern (High) — Friday Climbing Club"
+    end
+
+    test "renders text body containing report metadata and description" do
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(@recipient, build_report(), build_context())
+
+      assert email.text_body =~ "Safety concern"
+      assert email.text_body =~ "High"
+      assert email.text_body =~ "Friday Climbing Club"
+      assert email.text_body =~ "A child slipped near the edge of the play area."
+      assert email.text_body =~ "01HZ-incident-id"
+      assert email.text_body =~ "2026-04-20"
+    end
+
+    test "renders HTML body containing report metadata and description" do
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(@recipient, build_report(), build_context())
+
+      assert email.html_body =~ "Safety concern"
+      assert email.html_body =~ "High"
+      assert email.html_body =~ "Friday Climbing Club"
+      assert email.html_body =~ "A child slipped near the edge of the play area."
+      assert email.html_body =~ "01HZ-incident-id"
+    end
+
+    test "includes the signed photo URL in both bodies when present" do
+      context = build_context(%{signed_photo_url: "https://signed.example.com/photo.jpg?sig=abc"})
+
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(
+          @recipient,
+          build_report(%{photo_url: "incidents/photo.jpg", original_filename: "photo.jpg"}),
+          context
+        )
+
+      assert email.text_body =~ "https://signed.example.com/photo.jpg?sig=abc"
+      assert email.html_body =~ "https://signed.example.com/photo.jpg?sig=abc"
+    end
+
+    test "omits photo section when signed_photo_url is nil" do
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(@recipient, build_report(), build_context())
+
+      refute email.text_body =~ "View photo"
+      refute email.html_body =~ "View photo"
+    end
+
+    test "escapes HTML in user-provided description" do
+      report =
+        build_report(%{description: "<script>alert('xss')</script> happened in the room."})
+
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(@recipient, report, build_context())
+
+      refute email.html_body =~ "<script>alert('xss')</script>"
+      assert email.html_body =~ "&lt;script&gt;"
+    end
+
+    test "uses the recipient name and email and the configured sender" do
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(@recipient, build_report(), build_context())
+
+      assert email.to == [{"Hannah Owner", "owner@example.com"}]
+      assert email.from == {"KlassHero", "noreply@mail.klasshero.com"}
+    end
+
+    test "falls back to the email address when recipient name is nil" do
+      recipient = %{email: "owner@example.com", name: nil}
+
+      {:ok, email} =
+        IncidentReportedEmailNotifier.send_incident_report(recipient, build_report(), build_context())
+
+      assert email.to == [{"owner@example.com", "owner@example.com"}]
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/persistence/repositories/incident_report_repository_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/repositories/incident_report_repository_test.exs
@@ -62,6 +62,35 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.IncidentRe
     end
   end
 
+  describe "get/1" do
+    test "returns the report mapped to the domain entity" do
+      provider = provider_profile_fixture()
+      reporter = unconfirmed_user_fixture(intended_roles: [:provider])
+      program = insert(:program_schema, provider_id: provider.id)
+
+      report =
+        build_report(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: reporter.id,
+          program_id: program.id
+        })
+
+      {:ok, %IncidentReport{} = saved} = IncidentReportRepository.create(report)
+
+      assert {:ok, %IncidentReport{} = fetched} = IncidentReportRepository.get(saved.id)
+      assert fetched.id == saved.id
+      assert fetched.provider_profile_id == provider.id
+      assert fetched.reporter_user_id == reporter.id
+      assert fetched.program_id == program.id
+      assert fetched.category == :safety_concern
+      assert fetched.severity == :low
+    end
+
+    test "returns {:error, :not_found} when the report does not exist" do
+      assert {:error, :not_found} = IncidentReportRepository.get(Ecto.UUID.generate())
+    end
+  end
+
   defp build_report(attrs) do
     defaults = %{
       id: Ecto.UUID.generate(),

--- a/test/klass_hero/provider/adapters/driving/events/incident_reported_handler_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/incident_reported_handler_test.exs
@@ -1,0 +1,47 @@
+defmodule KlassHero.Provider.Adapters.Driving.Events.IncidentReportedHandlerTest do
+  @moduledoc """
+  Tests for IncidentReportedHandler — a thin dispatcher that enqueues an
+  Oban job for each `:incident_reported` integration event. Asserts on the
+  enqueued job using `Oban.Testing.assert_enqueued/1` under manual mode.
+  """
+
+  use KlassHero.DataCase, async: true
+  use Oban.Testing, repo: KlassHero.Repo
+
+  alias KlassHero.Provider.Adapters.Driving.Events.IncidentReportedHandler
+  alias KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWorker
+  alias KlassHero.Provider.Domain.Events.ProviderIntegrationEvents
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  describe "subscribed_events/0" do
+    test "subscribes only to :incident_reported" do
+      assert IncidentReportedHandler.subscribed_events() == [:incident_reported]
+    end
+  end
+
+  describe "handle_event/1 — :incident_reported" do
+    test "enqueues NotifyIncidentReportedWorker with the report id" do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        incident_id = Ecto.UUID.generate()
+        event = ProviderIntegrationEvents.incident_reported(incident_id)
+
+        assert :ok = IncidentReportedHandler.handle_event(event)
+
+        assert_enqueued(
+          worker: NotifyIncidentReportedWorker,
+          args: %{incident_report_id: incident_id},
+          queue: :email
+        )
+      end)
+    end
+  end
+
+  describe "handle_event/1 — unrelated events" do
+    test "ignores events of other types" do
+      event =
+        IntegrationEvent.new(:something_else, :provider, :incident_report, "id-1", %{})
+
+      assert :ignore = IncidentReportedHandler.handle_event(event)
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driving/events/provider_event_handler_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/provider_event_handler_test.exs
@@ -70,6 +70,27 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
       event = build_user_registered_event(user, intended_roles: ["parent"])
       assert :ignore = ProviderEventHandler.handle_event(event)
     end
+
+    test "captures business_owner_email from payload" do
+      user = AccountsFixtures.unconfirmed_user_fixture(intended_roles: [:provider])
+
+      event = build_user_registered_event(user, email: "owner@example.com")
+      assert :ok = ProviderEventHandler.handle_event(event)
+
+      assert {:ok, profile} = Provider.get_provider_by_identity(user.id)
+      assert profile.business_owner_email == "owner@example.com"
+    end
+
+    test "leaves business_owner_email nil when payload omits :email" do
+      user = AccountsFixtures.unconfirmed_user_fixture(intended_roles: [:provider])
+
+      event = build_user_registered_event(user)
+      payload = Map.delete(event.payload, :email)
+      assert :ok = ProviderEventHandler.handle_event(%{event | payload: payload})
+
+      assert {:ok, profile} = Provider.get_provider_by_identity(user.id)
+      assert profile.business_owner_email == nil
+    end
   end
 
   describe "handle_event/1 for :user_anonymized" do
@@ -166,6 +187,16 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
       event = build_user_confirmed_event(user, intended_roles: ["parent"])
       assert :ignore = ProviderEventHandler.handle_event(event)
     end
+
+    test "captures business_owner_email from payload" do
+      user = AccountsFixtures.unconfirmed_user_fixture(intended_roles: [:provider])
+
+      event = build_user_confirmed_event(user, email: "confirmed@example.com")
+      assert :ok = ProviderEventHandler.handle_event(event)
+
+      assert {:ok, profile} = Provider.get_provider_by_identity(user.id)
+      assert profile.business_owner_email == "confirmed@example.com"
+    end
   end
 
   describe "subscribed_events/0" do
@@ -179,6 +210,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
   defp build_user_registered_event(user, opts \\ []) do
     intended_roles = Keyword.get(opts, :intended_roles, ["provider"])
     provider_tier = Keyword.get(opts, :provider_subscription_tier)
+    email = Keyword.get(opts, :email, user.email)
 
     %{
       event_type: :user_registered,
@@ -186,6 +218,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
       payload: %{
         intended_roles: intended_roles,
         name: user.name || "Test Provider",
+        email: email,
         provider_subscription_tier: provider_tier
       }
     }
@@ -194,6 +227,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
   defp build_user_confirmed_event(user, opts \\ []) do
     intended_roles = Keyword.get(opts, :intended_roles, ["provider"])
     provider_tier = Keyword.get(opts, :provider_subscription_tier)
+    email = Keyword.get(opts, :email, user.email)
 
     %{
       event_type: :user_confirmed,
@@ -201,6 +235,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
       payload: %{
         intended_roles: intended_roles,
         name: user.name || "Test Provider",
+        email: email,
         provider_subscription_tier: provider_tier
       }
     }

--- a/test/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker_test.exs
+++ b/test/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker_test.exs
@@ -1,0 +1,82 @@
+defmodule KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWorkerTest do
+  @moduledoc """
+  Tests for the NotifyIncidentReportedWorker Oban worker.
+
+  The worker is a thin shell over the NotifyIncidentReported use case —
+  it deserialises `incident_report_id` from JSON args and propagates the
+  use case's return value so Oban can decide whether to retry.
+  """
+
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.AccountsFixtures, only: [unconfirmed_user_fixture: 1]
+  import KlassHero.EmailTestHelper
+  import KlassHero.Factory
+  import KlassHero.ProviderFixtures
+  import Swoosh.TestAssertions
+
+  alias KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWorker
+
+  setup do
+    flush_emails()
+    :ok
+  end
+
+  describe "perform/1" do
+    test "sends an email when given a valid incident_report_id" do
+      owner = unconfirmed_user_fixture(intended_roles: [:provider])
+      reporter = unconfirmed_user_fixture(intended_roles: [:provider])
+
+      provider =
+        provider_profile_fixture(
+          identity_id: owner.id,
+          business_name: "Worker Acme",
+          business_owner_email: "worker-owner@example.com"
+        )
+
+      program = insert(:program_schema, provider_id: provider.id)
+
+      provider_program_projection_fixture(
+        provider_id: provider.id,
+        program_id: program.id,
+        name: "Worker Program"
+      )
+
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: reporter.id,
+          program_id: program.id,
+          description: "Worker test incident description."
+        })
+
+      job = %Oban.Job{
+        args: %{"incident_report_id" => report.id},
+        queue: "email",
+        attempt: 1,
+        max_attempts: 3
+      }
+
+      assert :ok = NotifyIncidentReportedWorker.perform(job)
+
+      assert_email_sent(fn email ->
+        email.to == [{"Worker Acme", "worker-owner@example.com"}] and
+          email.subject =~ "Worker Program"
+      end)
+    end
+
+    test "propagates :incident_report_not_found error for unknown ids" do
+      job = %Oban.Job{
+        args: %{"incident_report_id" => Ecto.UUID.generate()},
+        queue: "email",
+        attempt: 1,
+        max_attempts: 3
+      }
+
+      assert {:error, :incident_report_not_found} =
+               NotifyIncidentReportedWorker.perform(job)
+
+      assert_no_email_sent()
+    end
+  end
+end

--- a/test/klass_hero/provider/application/commands/incident/notify_incident_reported_test.exs
+++ b/test/klass_hero/provider/application/commands/incident/notify_incident_reported_test.exs
@@ -1,0 +1,246 @@
+defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReportedTest do
+  @moduledoc """
+  Tests for the NotifyIncidentReported use case.
+
+  Uses real adapters with the test DB and the Swoosh test mailer adapter,
+  matching the convention of other Provider use case tests. Email assertions
+  use `Swoosh.TestAssertions`.
+
+  Note: the `:provider_profile_not_found` branch is not covered here because
+  `incident_reports.provider_id` has an `on_delete: :delete_all` FK on
+  `providers` — there is no way to leave a report orphaned for that branch
+  to fire. End-to-end coverage relies on inspection of the `with` chain.
+  """
+
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.AccountsFixtures, only: [unconfirmed_user_fixture: 1]
+  import KlassHero.EmailTestHelper
+  import KlassHero.Factory
+  import KlassHero.ProviderFixtures
+  import Swoosh.TestAssertions
+
+  alias KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReported
+  alias KlassHero.Shared.Adapters.Driven.Storage.StubStorageAdapter
+
+  setup do
+    flush_emails()
+
+    owner = unconfirmed_user_fixture(intended_roles: [:provider])
+    reporter = unconfirmed_user_fixture(intended_roles: [:provider])
+
+    provider =
+      provider_profile_fixture(
+        identity_id: owner.id,
+        business_name: "Acme Adventures",
+        business_owner_email: "owner@example.com"
+      )
+
+    program = insert(:program_schema, provider_id: provider.id)
+
+    provider_program_projection_fixture(
+      provider_id: provider.id,
+      program_id: program.id,
+      name: "Climbing Club"
+    )
+
+    %{owner: owner, reporter: reporter, provider: provider, program: program}
+  end
+
+  describe "execute/1 — happy path" do
+    test "sends an incident report email to the business owner", %{
+      provider: provider,
+      program: program,
+      reporter: reporter
+    } do
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: reporter.id,
+          program_id: program.id
+        })
+
+      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+
+      assert_email_sent(fn email ->
+        assert email.to == [{"Acme Adventures", "owner@example.com"}]
+        assert email.subject =~ "Climbing Club"
+        assert email.subject =~ "Safety concern"
+        assert email.text_body =~ report.description
+        assert email.text_body =~ report.id
+      end)
+    end
+  end
+
+  describe "execute/1 — self-report short-circuit" do
+    test "skips email when reporter is the provider's own owner", %{
+      provider: provider,
+      owner: owner,
+      program: program
+    } do
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: owner.id,
+          program_id: program.id
+        })
+
+      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "execute/1 — incident report missing" do
+    test "returns :incident_report_not_found when the id does not exist" do
+      assert {:error, :incident_report_not_found} =
+               NotifyIncidentReported.execute(%{incident_report_id: Ecto.UUID.generate()})
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "execute/1 — missing business_owner_email" do
+    test "returns :missing_business_owner_email and sends nothing", %{
+      reporter: reporter
+    } do
+      provider_no_email =
+        provider_profile_fixture(
+          business_name: "No Email Co",
+          business_owner_email: nil
+        )
+
+      program = insert(:program_schema, provider_id: provider_no_email.id)
+
+      provider_program_projection_fixture(
+        provider_id: provider_no_email.id,
+        program_id: program.id,
+        name: "Some Program"
+      )
+
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider_no_email.id,
+          reporter_user_id: reporter.id,
+          program_id: program.id
+        })
+
+      assert {:error, :missing_business_owner_email} =
+               NotifyIncidentReported.execute(%{incident_report_id: report.id})
+
+      assert_no_email_sent()
+    end
+  end
+
+  describe "execute/1 — program lookup fallback" do
+    test "still sends email with fallback label when the program projection is missing", %{
+      provider: provider,
+      reporter: reporter
+    } do
+      # Trigger: program exists in :programs table (FK satisfied) but the
+      #         provider-local projection row was never inserted
+      # Why: ProviderProgramRepository.get_by_id returns {:error, :not_found}
+      #      whenever the provider_programs projection row is missing
+      # Outcome: use case must not fail — falls back to "a program" label
+      unprojected_program = insert(:program_schema, provider_id: provider.id)
+
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: reporter.id,
+          program_id: unprojected_program.id
+        })
+
+      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+
+      assert_email_sent(fn email ->
+        email.subject =~ "a program" and email.text_body =~ "a program"
+      end)
+    end
+  end
+
+  describe "execute/1 — session-scoped report" do
+    test "uses 'a session' label when the report is session-scoped", %{
+      provider: provider,
+      program: program,
+      reporter: reporter
+    } do
+      session = insert(:program_session_schema, program_id: program.id)
+
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: reporter.id,
+          session_id: session.id
+        })
+
+      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+
+      assert_email_sent(fn email ->
+        assert email.subject =~ "a session"
+        assert email.text_body =~ "a session"
+      end)
+    end
+  end
+
+  describe "execute/1 — photo signing" do
+    setup do
+      # Trigger: photo signing tests need a default-named StubStorageAdapter agent
+      # Why: Storage.signed_url passes no opts to the adapter, so the adapter falls
+      #      back to its default registered name (StubStorageAdapter) for the agent
+      # Outcome: starting an agent under that name lets us drive signed_url's
+      #          {:ok, url} / {:error, :file_not_found} branches deterministically
+      {:ok, _pid} = StubStorageAdapter.start_link(name: StubStorageAdapter)
+      :ok = StubStorageAdapter.clear()
+      :ok
+    end
+
+    test "sends a no-photo email when signed_url fails", %{
+      provider: provider,
+      program: program,
+      reporter: reporter
+    } do
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: reporter.id,
+          program_id: program.id,
+          photo_url: "incident-reports/providers/#{provider.id}/missing.jpg",
+          original_filename: "missing.jpg"
+        })
+
+      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+
+      assert_email_sent(fn email ->
+        not (email.text_body =~ "View photo") and not (email.html_body =~ "View photo")
+      end)
+    end
+
+    test "includes the signed URL when signing succeeds", %{
+      provider: provider,
+      program: program,
+      reporter: reporter
+    } do
+      photo_key = "incident-reports/providers/#{provider.id}/incident.jpg"
+
+      # Pre-upload the file so signed_url returns {:ok, url}
+      {:ok, ^photo_key} = StubStorageAdapter.upload(:private, photo_key, "fake-bytes", [])
+
+      report =
+        incident_report_fixture(%{
+          provider_profile_id: provider.id,
+          reporter_user_id: reporter.id,
+          program_id: program.id,
+          photo_url: photo_key,
+          original_filename: "incident.jpg"
+        })
+
+      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ "stub://signed/"
+        assert email.html_body =~ "View photo"
+      end)
+    end
+  end
+end

--- a/test/klass_hero/provider/application/commands/incident/submit_incident_report_test.exs
+++ b/test/klass_hero/provider/application/commands/incident/submit_incident_report_test.exs
@@ -3,13 +3,19 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
 
   import Ecto.Query
   import KlassHero.AccountsFixtures, only: [unconfirmed_user_fixture: 1]
+  import KlassHero.EmailTestHelper
   import KlassHero.Factory
+  import KlassHero.ProviderFixtures, only: [provider_program_projection_fixture: 1]
+  import Swoosh.TestAssertions
 
+  alias Ecto.Adapters.SQL.Sandbox
+  alias KlassHero.Accounts.User
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.IncidentReportSchema
-  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProgramProjectionSchema
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
+  alias KlassHero.Provider.Adapters.Driving.Events.IncidentReportedHandler
   alias KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReport
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Events.PubSubIntegrationEventPublisher
   alias KlassHero.Shared.Adapters.Driven.Storage.StubStorageAdapter
   alias KlassHero.Shared.DomainEventBus
 
@@ -17,16 +23,12 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
     provider = insert(:provider_profile_schema)
     program = insert(:program_schema, provider_id: provider.id)
     user = unconfirmed_user_fixture(%{})
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    Repo.insert!(%ProviderProgramProjectionSchema{
-      program_id: program.id,
+    provider_program_projection_fixture(
       provider_id: provider.id,
-      name: "Art Club",
-      status: "active",
-      inserted_at: now,
-      updated_at: now
-    })
+      program_id: program.id,
+      name: "Art Club"
+    )
 
     test_pid = self()
 
@@ -186,6 +188,83 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
 
       # Storage stub agent should hold no entries — proves we never called upload/4
       assert Agent.get(storage, & &1) == %{}
+    end
+  end
+
+  describe "execute/1 — incident email pipeline (end-to-end)" do
+    # Trigger: tests need PubSub-driven CriticalEventDispatcher → handler → Oban inline
+    # Why: the default test publisher only collects events; it does not broadcast,
+    #      so the IncidentReportedHandler subscriber would never wake up
+    # Outcome: swap to real PubSub, grant the subscriber sandbox access, route Swoosh
+    #          mail back to the test pid even when Mailer.deliver runs in another process
+    setup do
+      flush_emails()
+
+      original_publisher = Application.get_env(:klass_hero, :integration_event_publisher)
+
+      Application.put_env(:klass_hero, :integration_event_publisher,
+        module: PubSubIntegrationEventPublisher,
+        pubsub: KlassHero.PubSub
+      )
+
+      original_swoosh_pid = Application.get_env(:swoosh, :shared_test_process)
+      Application.put_env(:swoosh, :shared_test_process, self())
+
+      case Process.whereis(IncidentReportedHandler) do
+        nil -> :ok
+        pid -> Sandbox.allow(KlassHero.Repo, self(), pid)
+      end
+
+      on_exit(fn ->
+        Application.put_env(:klass_hero, :integration_event_publisher, original_publisher)
+
+        if original_swoosh_pid do
+          Application.put_env(:swoosh, :shared_test_process, original_swoosh_pid)
+        else
+          Application.delete_env(:swoosh, :shared_test_process)
+        end
+      end)
+
+      :ok
+    end
+
+    test "delivers an email to the business owner when reporter is not the owner", %{
+      provider: provider,
+      program_id: program_id,
+      user: reporter
+    } do
+      # Backfill the email column on the existing provider row so the use case can
+      # resolve a recipient — production rows are populated by ProviderEventHandler
+      # off the :user_registered integration event payload.
+      provider
+      |> Ecto.Changeset.change(%{business_owner_email: "owner@example.com"})
+      |> Repo.update!()
+
+      params = base_params(provider, program_id, reporter)
+
+      assert {:ok, _report} = SubmitIncidentReport.execute(params)
+
+      assert_email_sent(fn email ->
+        email.to == [{provider.business_name, "owner@example.com"}] and
+          email.subject =~ "Art Club"
+      end)
+    end
+
+    test "skips the email when the reporter is the provider owner (self-report)", %{
+      provider: provider,
+      program_id: program_id
+    } do
+      owner = Repo.get!(User, provider.identity_id)
+
+      provider
+      |> Ecto.Changeset.change(%{business_owner_email: "owner@example.com"})
+      |> Repo.update!()
+
+      params = base_params(provider, program_id, owner)
+
+      assert {:ok, _report} = SubmitIncidentReport.execute(params)
+
+      assert_no_email_sent()
     end
   end
 end

--- a/test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs
@@ -96,6 +96,15 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
 
       assert deserialized.payload == %{address: %{city: "Berlin", zip: "10115"}}
     end
+
+    test "atomizes keys inside maps nested in lists" do
+      event = DomainEvent.new(:test, "id", :test, %{items: [%{name: "Alice"}, %{name: "Bob"}]})
+      serialized = CriticalEventSerializer.serialize(event)
+      json_cycled = Jason.decode!(Jason.encode!(serialized))
+      deserialized = CriticalEventSerializer.deserialize(json_cycled)
+
+      assert deserialized.payload == %{items: [%{name: "Alice"}, %{name: "Bob"}]}
+    end
   end
 
   describe "metadata round-trip" do

--- a/test/support/fixtures/provider_fixtures.ex
+++ b/test/support/fixtures/provider_fixtures.ex
@@ -7,9 +7,12 @@ defmodule KlassHero.ProviderFixtures do
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.ProviderProfileMapper
   alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.StaffMemberMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.IncidentReportRepository
   alias KlassHero.Provider.Adapters.Driven.Persistence.Repositories.VerificationDocumentRepository
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProfileSchema
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProgramProjectionSchema
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.StaffMemberSchema
+  alias KlassHero.Provider.Domain.Models.IncidentReport
   alias KlassHero.Provider.Domain.Models.VerificationDocument
   alias KlassHero.Repo
 
@@ -146,6 +149,51 @@ defmodule KlassHero.ProviderFixtures do
     doc = verification_document_fixture(attrs)
     {:ok, rejected} = VerificationDocument.reject(doc, reviewer_id, reason)
     {:ok, persisted} = VerificationDocumentRepository.update(rejected)
+    persisted
+  end
+
+  @doc """
+  Inserts a `provider_programs` projection row for testing.
+
+  Accepts `program_id`, `provider_id`, `name`, `status`. Defaults provided.
+  Returns the inserted schema struct.
+  """
+  def provider_program_projection_fixture(attrs \\ %{}) do
+    attrs_map = Map.new(attrs)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.insert!(%ProviderProgramProjectionSchema{
+      program_id: attrs_map[:program_id] || Ecto.UUID.generate(),
+      provider_id: attrs_map[:provider_id] || raise("provider_id is required"),
+      name: attrs_map[:name] || "Test Program #{System.unique_integer([:positive])}",
+      status: attrs_map[:status] || "active",
+      inserted_at: now,
+      updated_at: now
+    })
+  end
+
+  @doc """
+  Creates an incident report for testing.
+
+  Accepts overrides via `attrs`. Defaults provide a safety_concern/high
+  report dated 2026-04-20. Caller must supply `provider_profile_id`,
+  `reporter_user_id`, and either `program_id` or `session_id`.
+
+  Returns the persisted domain model.
+  """
+  def incident_report_fixture(attrs \\ %{}) do
+    attrs_map = Map.new(attrs)
+
+    defaults = %{
+      id: Ecto.UUID.generate(),
+      category: :safety_concern,
+      severity: :high,
+      description: "A child slipped near the play area but is unharmed.",
+      occurred_at: ~U[2026-04-20 14:30:00Z]
+    }
+
+    {:ok, report} = IncidentReport.new(Map.merge(defaults, attrs_map))
+    {:ok, persisted} = IncidentReportRepository.create(report)
     persisted
   end
 


### PR DESCRIPTION
Closes #371.

## Summary

- Added Provider context email notification pipeline: `:incident_reported` integration event → `IncidentReportedHandler` → `NotifyIncidentReportedWorker` (Oban `:email` queue) → `NotifyIncidentReported` use case → `IncidentReportedEmailNotifier` (Swoosh) → `Mailer`.
- Skipped self-reports (reporter == business owner) with an early-return in the use case; logged at `:info`.
- Photo support via `KlassHero.Shared.Storage.signed_url/4` (1h TTL); degrades to no-photo email if signing fails — never blocks delivery.
- Sourced business owner email via projection (no new ACL): denormalised onto a new `providers.business_owner_email` column, populated by the existing `ProviderEventHandler` from the `:user_registered` payload it already consumes. Backfill in the same migration.
- Extracted two cross-context email utilities to `KlassHero.Shared`: `EmailHtml` (HTML scaffold + escape, no `Plug` dep) and `RateLimitedEmailWorker` macro (Resend 429-aware backoff). Both consumed by Provider AND Enrollment notifiers/workers.
- Fixed two latent bugs surfaced by end-to-end testing: missing `:incident_reported` → `PromoteIntegrationEvents` subscription on the Provider DomainEventBus; `CriticalEventSerializer` list-recursion gap (would have crashed on any future critical event with a struct nested in a payload list).

## Review Focus

- **No new ACL — projection-via-existing-event** — `lib/klass_hero/provider/adapters/driving/events/provider_event_handler.ex` collapses `:user_registered` and `:user_confirmed` clauses into a single `attrs`-map dispatcher and now also captures `payload.email` into the denormalised column. Verify this honours the `prefer-projections-over-acls` rule. Stale-email-after-change is an accepted trade-off; tracked in #753 / `:user_email_changed` follow-up.
- **Self-report skip + missing-email guard** — `lib/klass_hero/provider/application/commands/incident/notify_incident_reported.ex:33-42`. Six branches: success, self-report, profile-not-found, missing email, program-not-found (fallback label), signed-url failure (no-photo email still sent). All covered by unit tests at `test/klass_hero/provider/application/commands/incident/notify_incident_reported_test.exs`.
- **Critical event handler wiring** — `config/config.exs` adds `for_querying_incident_reports`, `for_sending_incident_emails` under `:provider`, plus `"integration:provider:incident_reported"` entry under `:critical_event_handlers`. `lib/klass_hero/application.ex:362-369` registers the `EventSubscriber` child spec. Verify both layers match.
- **Shared kernel additions and Boundary exports** — `lib/klass_hero/shared.ex` exports `EmailHtml` and `RateLimitedEmailWorker`. The macro re-exposes `Tracing.TracedWorker` (already exported) so cross-context `use` from Enrollment + Provider compiles clean.
- **CriticalEventSerializer list-recursion fix** — `lib/klass_hero/shared/adapters/driven/events/critical_event_serializer.ex` adds list clauses to both `stringify_keys/1` and `atomize_keys/1`. Without these, structs nested in a payload list (`%{photos: [%X{taken_at: ~U[...]}]}`) survive serialization and break round-trip. Test added at `test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs`.

## Test Plan

- [x] `mix precommit` (compile warnings-as-errors, deps unlock unused, format, lint typography, full test suite — 4574 passed)
- [x] `mix test test/klass_hero/provider/` — 515 passed
- [x] `mix test test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs` — new list-recursion case asserts round-trip
- [x] `mix test test/klass_hero/provider/adapters/driven/notifications/incident_reported_email_notifier_test.exs` — subject/body shape, photo branch, no-photo branch, HTML-escape on description
- [x] `mix test test/klass_hero/provider/application/commands/incident/submit_incident_report_test.exs` — end-to-end happy path + self-report skip
- [x] Architecture review: 18/18 checks pass, 0 violations, 0 warnings
- [x] Manual: restart `mix phx.server` (dev server has stale code from review session), submit a real incident via the UI, confirm email at `http://localhost:4000/dev/mailbox`
- [x] Manual: re-submit with `reporter_user_id == provider.identity_id` → no email + skip log line
- [x] Manual: confirm migration backfill on dev DB: `SELECT COUNT(*) FROM providers WHERE business_owner_email IS NULL AND identity_id IN (SELECT id FROM users)` returns 0

## Follow-ups filed

- #753 — Carry `business_owner_email` + `business_name` on `:incident_reported` payload to skip the profile DB fetch on the happy path
- #754 — Move incident-email enqueue into `SubmitIncidentReport` `Multi` for transactional guarantee