### PR TITLE
feat: carry owner email + name on incident_reported payload

### DIFF
--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -13,13 +13,16 @@ The project follows Domain-Driven Design with Ports & Adapters architecture (Hex
 
 ## Architecture Documentation
 
-**Start here for architectural guidance:**
+Authoritative reference is the code itself — read existing context implementations under `lib/klass_hero/<context>/` and mirror established patterns. Recommended reads when learning the conventions:
 
-- Existing context implementations under `lib/klass_hero/` - Follow established patterns
+- `lib/klass_hero/enrollment/` — full DDD shape (commands, queries, ports, driven + driving adapters)
+- `lib/klass_hero/messaging/` — projections + read-model pattern
+- `lib/klass_hero/shared/` — event infrastructure (publishers, registry, retry helpers)
+- `config/config.exs` — DI wiring per context and `critical_event_handlers` registry
 
 ## Authentication Note
 
-The authentication system uses Phoenix's standard `phx.gen.auth` for simplicity and maintainability. For future bounded contexts (Program Catalog, Enrollment, Family, Provider, etc.), the DDD/Ports & Adapters architecture documented in the above files will be followed.
+The authentication system uses Phoenix's standard `phx.gen.auth` for simplicity and maintainability. New bounded contexts follow the DDD/Ports & Adapters patterns described below.
 
 ## Port & Adapter Directionality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,12 +71,16 @@ context/
 - **Provider** (`provider/`) - Provider profiles, staff members, verification documents
 - **Program Catalog** (`program_catalog/`) - Program discovery, filtering, pricing, categories
 - **Enrollment** (`enrollment/`) - Bookings, fee calculations, subscription tiers
-- **Entitlements** (`entitlements.ex`) - Pure domain service for subscription tier authorization (cross-context, no DB)
+- **Entitlements** (`shared/entitlements.ex`) - Pure domain service for subscription tier authorization (cross-context, no DB)
 - **Messaging** (`messaging/`) - Conversations, messages, participants, retention policies
 - **Participation** (`participation/`) - Session tracking, check-in/out, attendance rosters
 - **Shared** (`shared/`) - Event publishing, Ecto helpers, pagination, domain events
 
 See `.claude/rules/domain-architecture.md` for patterns. For context-specific details, read the code under `lib/klass_hero/<context>/` directly — Claude Code explores on-demand.
+
+**Boundary enforcement:** Each context's root module (`lib/klass_hero/<context>.ex`) declares `use Boundary, deps: [...], exports: [...]`. Compile-time violations surface via `mix compile --warnings-as-errors`. There is no separate `boundary.ex`.
+
+**CQRS direction:** New use cases go under `application/commands/` or `application/queries/`. New ports separate read contracts (`ForQuerying*`, `ForListing*`, `ForResolving*`) from write contracts (`ForStoring*`, `ForCreating*`, `ForUpdating*`). Existing `ForManaging*` ports will be split incrementally.
 
 ### Dependency Injection (Port Wiring)
 
@@ -97,7 +101,24 @@ When adding a new port: define the behaviour in `domain/ports/`, implement the a
 ### Event System (Two-Tier)
 
 - **Domain events** (non-critical): Published via PubSub (`PubSubEventPublisher`). Used for real-time UI updates and non-essential side effects.
-- **Integration events** (critical): Routed through `critical_event_handlers` registry in `config/config.exs` to Oban-backed handlers for durable, at-least-once delivery. Used for cross-context workflows (e.g., `invite_claimed`, `user_registered`).
+- **Integration events** (critical): Routed through `critical_event_handlers` registry in `config/config.exs` to Oban-backed handlers for durable, at-least-once delivery. Used for cross-context workflows.
+
+Registry shape — topic strings keyed `integration:<context>:<event>` map to a list of `{Handler, :function}` tuples (fan-out supported):
+
+```elixir
+# config/config.exs
+config :klass_hero, :critical_event_handlers, %{
+  "integration:accounts:user_registered" => [
+    {FamilyEventHandler, :handle_event},
+    {ProviderEventHandler, :handle_event}
+  ],
+  "integration:enrollment:invite_claimed" => [
+    {InviteClaimedHandler, :handle_event}
+  ]
+}
+```
+
+When adding a new integration event: define the event struct, publish it from the use case, then register the handler(s) here. Handlers live under their own context's `adapters/driving/events/`.
 
 ### Feature Flags
 
@@ -184,7 +205,7 @@ When addressing PR review comments, follow this workflow:
 
 ## Detailed Rules
 
-Comprehensive guidelines live in `.claude/rules/` (auto-loaded into context). These cover LiveView, Elixir style, HEEx templates, authentication, testing, database/Ecto, MCP integration, DDD architecture, frontend, workflow, available skills, and behavioral guidelines. **Do not duplicate those rules here.**
+Topic-specific guidelines live in `.claude/rules/` and are auto-loaded into context. **Do not duplicate those rules here.**
 
 <!-- usage-rules-start -->
 <!-- igniter-start -->
@@ -231,27 +252,16 @@ _A config-driven dev tool for Elixir projects to manage AGENTS.md files and agen
 
 ## Landing the Plane (Session Completion)
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+Work is NOT complete until `git push` succeeds. Session-end work lands via PR from a feature branch; direct pushes to `main` are blocked by the ruleset.
 
-**MANDATORY WORKFLOW:**
+```bash
+git fetch origin
+git rebase origin/main
+git push --force-with-lease   # only on your own feature branch
+git status                     # MUST show "up to date with origin"
+```
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY. Session-end work lands via PR from a feature branch; direct pushes to `main` are blocked by the ruleset. Rebase onto `origin/main` before the final push so the PR is fresh against current main:
-   ```bash
-   git fetch origin
-   git rebase origin/main
-   git push --force-with-lease
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
-- Force-push ONLY with `--force-with-lease` — and ONLY on your own feature branch after a rebase, never on `main` (the ruleset blocks it anyway)
+- File issues for follow-up work before closing the session
+- Run `mix precommit` if code changed; do not push with failing checks
+- Force-push only with `--force-with-lease`, only on your own feature branch, never on `main`
+- If push fails, resolve and retry — do not leave work stranded locally

--- a/lib/klass_hero/provider/adapters/driven/notifications/incident_notification_scheduler.ex
+++ b/lib/klass_hero/provider/adapters/driven/notifications/incident_notification_scheduler.ex
@@ -14,10 +14,15 @@ defmodule KlassHero.Provider.Adapters.Driven.Notifications.IncidentNotificationS
 
   alias KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWorker
   alias KlassHero.Provider.Domain.Models.IncidentReport
+  alias KlassHero.Provider.Domain.Models.ProviderProfile
   alias KlassHero.Shared.Tracing.ObanEnqueue
 
   @impl true
-  def schedule(%IncidentReport{id: id}) when is_binary(id) do
-    ObanEnqueue.with_context(NotifyIncidentReportedWorker, %{incident_report_id: id})
+  def schedule(%IncidentReport{id: id}, %ProviderProfile{} = profile) when is_binary(id) do
+    ObanEnqueue.with_context(NotifyIncidentReportedWorker, %{
+      incident_report_id: id,
+      business_owner_email: profile.business_owner_email,
+      business_name: profile.business_name
+    })
   end
 end

--- a/lib/klass_hero/provider/adapters/driven/notifications/stub_incident_notification_scheduler.ex
+++ b/lib/klass_hero/provider/adapters/driven/notifications/stub_incident_notification_scheduler.ex
@@ -21,11 +21,11 @@ defmodule KlassHero.Provider.Adapters.Driven.Notifications.StubIncidentNotificat
   @calls_key :__incident_notification_scheduler_calls__
 
   @impl true
-  def schedule(report) do
-    record_call(report)
+  def schedule(report, profile) do
+    record_call({report, profile})
 
     case Process.get(@mode_key, :passthrough) do
-      :passthrough -> IncidentNotificationScheduler.schedule(report)
+      :passthrough -> IncidentNotificationScheduler.schedule(report, profile)
       {:fail, reason} -> {:error, reason}
     end
   end
@@ -50,12 +50,12 @@ defmodule KlassHero.Provider.Adapters.Driven.Notifications.StubIncidentNotificat
   end
 
   @doc """
-  Returns the list of incident reports `schedule/1` was called with, in order.
+  Returns the list of `{report, profile}` tuples `schedule/2` was called with, in order.
   """
-  @spec calls() :: [struct()]
+  @spec calls() :: [{struct(), struct()}]
   def calls, do: Process.get(@calls_key, []) |> Enum.reverse()
 
-  defp record_call(report) do
-    Process.put(@calls_key, [report | Process.get(@calls_key, [])])
+  defp record_call(call) do
+    Process.put(@calls_key, [call | Process.get(@calls_key, [])])
   end
 end

--- a/lib/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker.ex
+++ b/lib/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker.ex
@@ -11,8 +11,17 @@ defmodule KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWork
 
   alias KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReported
 
+  defguardp is_present(s) when is_binary(s) and byte_size(s) > 0
+
   @impl true
-  def execute(%Oban.Job{args: %{"incident_report_id" => id}}) when is_binary(id) do
-    NotifyIncidentReported.execute(%{incident_report_id: id})
+  def execute(%Oban.Job{
+        args: %{"incident_report_id" => id, "business_owner_email" => owner_email, "business_name" => business_name}
+      })
+      when is_present(id) and is_present(owner_email) and is_present(business_name) do
+    NotifyIncidentReported.execute(%{
+      incident_report_id: id,
+      business_owner_email: owner_email,
+      business_name: business_name
+    })
   end
 end

--- a/lib/klass_hero/provider/application/commands/incident/notify_incident_reported.ex
+++ b/lib/klass_hero/provider/application/commands/incident/notify_incident_reported.ex
@@ -37,7 +37,7 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
   Returns `:ok` on success or `{:error, reason}` when the report row cannot
   be loaded or the notifier rejects the email.
   """
-  @spec execute(args()) :: :ok | {:error, atom()}
+  @spec execute(args()) :: :ok | {:error, term()}
   def execute(%{incident_report_id: id, business_owner_email: owner_email, business_name: business_name})
       when is_present(id) and is_present(owner_email) and is_present(business_name) do
     with {:ok, report} <- fetch_report(id) do

--- a/lib/klass_hero/provider/application/commands/incident/notify_incident_reported.ex
+++ b/lib/klass_hero/provider/application/commands/incident/notify_incident_reported.ex
@@ -1,17 +1,20 @@
 defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReported do
   @moduledoc """
   Emails a provider's business owner when an incident report is submitted.
-  Self-reports (reporter == owner) short-circuit early.
+
+  Payload-driven: `business_owner_email` and `business_name` arrive in the
+  args map (forwarded by `NotifyIncidentReportedWorker` from the enqueued
+  Oban job). No `ProviderProfile` lookup happens here — that responsibility
+  is upstream in `SubmitIncidentReport`, which loads the profile once and
+  threads the two fields through the scheduler.
   """
 
   alias KlassHero.Provider.Domain.Models.IncidentReport
-  alias KlassHero.Provider.Domain.Models.ProviderProfile
   alias KlassHero.Shared.Storage
 
   require Logger
 
   @incident_query Application.compile_env!(:klass_hero, [:provider, :for_querying_incident_reports])
-  @profile_query Application.compile_env!(:klass_hero, [:provider, :for_querying_provider_profiles])
   @program_query Application.compile_env!(:klass_hero, [:provider, :for_querying_provider_programs])
   @notifier Application.compile_env!(:klass_hero, [:provider, :for_sending_incident_emails])
 
@@ -19,21 +22,34 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
   @program_fallback_label "a program"
   @session_fallback_label "a session"
 
-  @doc """
-  Sends the incident-report email for the given report id.
+  defguardp is_present(s) when is_binary(s) and byte_size(s) > 0
 
-  Returns `:ok` on success or self-report skip; `{:error, reason}` on
-  recoverable failure (Oban retries) or permanent failure.
+  @typedoc "Worker-shaped args. All three keys required, all non-empty binaries."
+  @type args :: %{
+          required(:incident_report_id) => binary(),
+          required(:business_owner_email) => String.t(),
+          required(:business_name) => String.t()
+        }
+
+  @doc """
+  Sends the incident-report email for the given args map.
+
+  Returns `:ok` on success or `{:error, reason}` when the report row cannot
+  be loaded or the notifier rejects the email.
   """
-  @spec execute(%{required(:incident_report_id) => binary()}) :: :ok | {:error, atom()}
-  def execute(%{incident_report_id: id}) when is_binary(id) do
-    with {:ok, report} <- fetch_report(id),
-         {:ok, profile} <- fetch_profile(report.provider_profile_id),
-         :continue <- check_self_report(report, profile, id),
-         {:ok, email} <- require_owner_email(profile, id) do
+  @spec execute(args()) :: :ok | {:error, atom()}
+  def execute(%{incident_report_id: id, business_owner_email: owner_email, business_name: business_name})
+      when is_present(id) and is_present(owner_email) and is_present(business_name) do
+    with {:ok, report} <- fetch_report(id) do
       program_label = resolve_program_label(report)
       signed_url = maybe_sign_photo(report, id)
-      send_email(profile, email, report, program_label, signed_url)
+
+      send_email(
+        %{owner_email: owner_email, business_name: business_name},
+        report,
+        program_label,
+        signed_url
+      )
     end
   end
 
@@ -42,39 +58,6 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
       {:ok, %IncidentReport{} = report} -> {:ok, report}
       {:error, :not_found} -> {:error, :incident_report_not_found}
     end
-  end
-
-  defp fetch_profile(provider_profile_id) do
-    case @profile_query.get(provider_profile_id) do
-      {:ok, %ProviderProfile{} = profile} -> {:ok, profile}
-      {:error, :not_found} -> {:error, :provider_profile_not_found}
-    end
-  end
-
-  defp check_self_report(%IncidentReport{reporter_user_id: rid}, %ProviderProfile{identity_id: iid}, id)
-       when rid == iid do
-    Logger.info("[NotifyIncidentReported] Skipping self-report",
-      incident_report_id: id,
-      identity_id: iid
-    )
-
-    :ok
-  end
-
-  defp check_self_report(_report, _profile, _id), do: :continue
-
-  defp require_owner_email(%ProviderProfile{business_owner_email: email}, _id)
-       when is_binary(email) and byte_size(email) > 0 do
-    {:ok, email}
-  end
-
-  defp require_owner_email(%ProviderProfile{id: profile_id}, id) do
-    Logger.warning("[NotifyIncidentReported] Missing business_owner_email",
-      incident_report_id: id,
-      provider_profile_id: profile_id
-    )
-
-    {:error, :missing_business_owner_email}
   end
 
   defp resolve_program_label(%IncidentReport{program_id: pid}) when is_binary(pid) do
@@ -110,13 +93,13 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
     end
   end
 
-  defp send_email(profile, email, report, program_label, signed_url) do
-    recipient = %{email: email, name: profile.business_name}
+  defp send_email(%{owner_email: owner_email, business_name: business_name}, report, program_label, signed_url) do
+    recipient = %{email: owner_email, name: business_name}
 
     context = %{
       program_name: program_label,
       signed_photo_url: signed_url,
-      business_name: profile.business_name
+      business_name: business_name
     }
 
     case @notifier.send_incident_report(recipient, report, context) do

--- a/lib/klass_hero/provider/application/commands/incident/submit_incident_report.ex
+++ b/lib/klass_hero/provider/application/commands/incident/submit_incident_report.ex
@@ -18,6 +18,7 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReport 
   alias KlassHero.Provider.Application.Queries.ProviderProgramQueries
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.Domain.Models.IncidentReport
+  alias KlassHero.Provider.Domain.Models.ProviderProfile
   alias KlassHero.Repo
   alias KlassHero.Shared.DomainEventBus
   alias KlassHero.Shared.Storage
@@ -28,7 +29,10 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReport 
 
   @repository Application.compile_env!(:klass_hero, [:provider, :for_storing_incident_reports])
   @sessions_query Application.compile_env!(:klass_hero, [:provider, :for_querying_session_details])
+  @profile_query Application.compile_env!(:klass_hero, [:provider, :for_querying_provider_profiles])
   @scheduler Application.compile_env!(:klass_hero, [:provider, :for_scheduling_incident_notifications])
+
+  defguardp is_present(s) when is_binary(s) and byte_size(s) > 0
 
   @doc """
   Submits an incident report.
@@ -61,11 +65,24 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReport 
     storage_opts = params[:storage_opts] || []
 
     with :ok <- validate_ownership(params),
+         {:ok, profile} <- fetch_profile(params),
          {:ok, photo_ref} <- maybe_upload_photo(params),
          {:ok, report} <- build_report(params, photo_ref),
-         {:ok, persisted} <- persist_and_enqueue(report, photo_ref, storage_opts) do
-      publish_event(persisted)
+         {:ok, persisted} <- persist_and_enqueue(report, profile, photo_ref, storage_opts) do
+      publish_event(persisted, profile)
       {:ok, persisted}
+    end
+  end
+
+  # Read happens *outside* `Repo.transaction/1` deliberately: the two profile
+  # fields we forward (`business_owner_email`, `business_name`) are stable
+  # provider attributes, not data the transaction will mutate, so the
+  # "no read-outside-tx" rule (CLAUDE.md) does not apply. Loading once here
+  # replaces a per-email DB round-trip the worker used to make.
+  defp fetch_profile(%{provider_profile_id: id}) do
+    case @profile_query.get(id) do
+      {:ok, %ProviderProfile{} = profile} -> {:ok, profile}
+      {:error, :not_found} -> {:error, [provider_profile_id: "does not exist"]}
     end
   end
 
@@ -149,10 +166,10 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReport 
   #      there still governs other critical events.
   # Outcome: {:ok, persisted} when both rows commit; {:error, reason} when either
   #          step fails, after which any uploaded photo is best-effort deleted
-  defp persist_and_enqueue(report, photo_ref, storage_opts) do
+  defp persist_and_enqueue(report, profile, photo_ref, storage_opts) do
     fn ->
       with {:ok, persisted} <- @repository.create(report),
-           {:ok, _job} <- @scheduler.schedule(persisted) do
+           :ok <- maybe_schedule_notification(persisted, profile) do
         persisted
       else
         {:error, reason} -> Repo.rollback(reason)
@@ -160,6 +177,23 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReport 
     end
     |> Repo.transaction()
     |> finalise_transaction(photo_ref, storage_opts)
+  end
+
+  # Skip clauses fall through to :ok so the report row still commits but no
+  # email job is enqueued. Two scenarios:
+  #   - Self-report: the owner is the reporter; notifying them is noise.
+  #   - Missing email: there is nobody to notify; enqueueing would just burn
+  #     the worker's retry budget against its own boundary guards.
+  defp maybe_schedule_notification(%IncidentReport{reporter_user_id: rid}, %ProviderProfile{identity_id: rid}), do: :ok
+
+  defp maybe_schedule_notification(_report, %ProviderProfile{business_owner_email: email}) when not is_present(email),
+    do: :ok
+
+  defp maybe_schedule_notification(report, %ProviderProfile{} = profile) do
+    case @scheduler.schedule(report, profile) do
+      {:ok, _job} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp finalise_transaction({:ok, _persisted} = ok, _photo_ref, _storage_opts), do: ok
@@ -191,8 +225,8 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReport 
     end
   end
 
-  defp publish_event(report) do
-    event = ProviderEvents.incident_reported(report)
+  defp publish_event(report, profile) do
+    event = ProviderEvents.incident_reported(report, profile)
     DomainEventBus.dispatch(@context, event)
   end
 end

--- a/lib/klass_hero/provider/domain/events/provider_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_events.ex
@@ -68,9 +68,15 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
     )
   end
 
-  @doc "Creates an incident_reported event."
-  @spec incident_reported(IncidentReport.t(), keyword()) :: DomainEvent.t()
-  def incident_reported(%IncidentReport{} = report, opts \\ []) do
+  @doc """
+  Creates an incident_reported event.
+
+  Carries `business_owner_email` and `business_name` from the provider profile
+  so downstream consumers (notifications, audit projections) can render
+  incident summaries without a Provider-context lookup.
+  """
+  @spec incident_reported(IncidentReport.t(), ProviderProfile.t(), keyword()) :: DomainEvent.t()
+  def incident_reported(%IncidentReport{} = report, %ProviderProfile{} = profile, opts \\ []) do
     payload = %{
       incident_report_id: report.id,
       provider_id: report.provider_profile_id,
@@ -80,7 +86,9 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
       category: report.category,
       severity: report.severity,
       occurred_at: report.occurred_at,
-      has_photo: not is_nil(report.photo_url)
+      has_photo: not is_nil(report.photo_url),
+      business_owner_email: profile.business_owner_email,
+      business_name: profile.business_name
     }
 
     DomainEvent.new(:incident_reported, report.id, @aggregate_type, payload, opts)

--- a/lib/klass_hero/provider/domain/ports/for_scheduling_incident_notifications.ex
+++ b/lib/klass_hero/provider/domain/ports/for_scheduling_incident_notifications.ex
@@ -24,13 +24,18 @@ defmodule KlassHero.Provider.Domain.Ports.ForSchedulingIncidentNotifications do
   """
 
   alias KlassHero.Provider.Domain.Models.IncidentReport
+  alias KlassHero.Provider.Domain.Models.ProviderProfile
 
   @doc """
   Schedules the notification job for a freshly persisted incident report.
 
+  The provider profile is passed in alongside the report so its
+  `business_owner_email` and `business_name` can travel on the Oban job
+  args — the email worker uses them directly without a profile DB lookup.
+
   Implementations must NOT raise on failure — return `{:error, _}` so the
   caller's transaction can roll back the report row.
   """
-  @callback schedule(IncidentReport.t()) ::
+  @callback schedule(IncidentReport.t(), ProviderProfile.t()) ::
               {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t() | term()}
 end

--- a/lib/klass_hero/provider/domain/ports/for_scheduling_incident_notifications.ex
+++ b/lib/klass_hero/provider/domain/ports/for_scheduling_incident_notifications.ex
@@ -13,7 +13,7 @@ defmodule KlassHero.Provider.Domain.Ports.ForSchedulingIncidentNotifications do
 
   ## Expected Return Values
 
-  - `schedule/1` — Returns `{:ok, Oban.Job.t()}` on success.
+  - `schedule/2` — Returns `{:ok, Oban.Job.t()}` on success.
   - On failure, returns `{:error, reason}` where `reason` is typically:
     - `Ecto.Changeset.t()` — Oban rejected the job args via its own changeset
       (invalid worker, malformed args, unique-constraint violation when

--- a/lib/klass_hero_web/components/composite_components.ex
+++ b/lib/klass_hero_web/components/composite_components.ex
@@ -586,8 +586,8 @@ defmodule KlassHeroWeb.CompositeComponents do
   """
   def app_footer(assigns) do
     ~H"""
-    <footer class="footer footer-center p-10 bg-hero-black text-hero-grey-300">
-      <div class="grid grid-cols-1 md:grid-cols-4 gap-8 w-full max-w-6xl">
+    <footer class="bg-hero-black text-hero-grey-300 px-6 py-10 sm:p-10">
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-8 w-full max-w-6xl mx-auto">
         <div class="text-left">
           <h3 class="font-bold text-lg text-white mb-4">{gettext("Klass Hero")}</h3>
           <p class="text-sm">
@@ -668,7 +668,7 @@ defmodule KlassHeroWeb.CompositeComponents do
         </div>
       </div>
 
-      <div class="border-t border-base-300 pt-6 mt-6 w-full">
+      <div class="border-t border-base-300 pt-6 mt-6 w-full max-w-6xl mx-auto text-center">
         <p class="text-sm">
           &copy; {Date.utc_today().year} Klass Hero. {gettext("All rights reserved.")}
         </p>

--- a/lib/klass_hero_web/components/layouts/app.html.heex
+++ b/lib/klass_hero_web/components/layouts/app.html.heex
@@ -2,7 +2,11 @@
   <input id="main-drawer" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col">
     <!-- Navbar -->
-    <div class="navbar bg-white shadow-sm border-b border-hero-grey-200 relative z-10">
+    <div class={[
+      "navbar bg-white shadow-sm border-b border-hero-grey-200 relative z-10",
+      "[&>.navbar-start]:w-auto [&>.navbar-end]:flex-1 [&>.navbar-end]:w-auto",
+      "lg:[&>.navbar-start]:w-1/2 lg:[&>.navbar-end]:w-1/2"
+    ]}>
       <div class="navbar-start">
         <div class="dropdown lg:hidden">
           <label for="main-drawer" class="btn btn-square btn-ghost">
@@ -65,7 +69,9 @@
 
       <div class="navbar-end">
         <div class="flex items-center gap-2">
-          <.language_switcher locale={assigns[:locale] || "en"} />
+          <div class="hidden sm:block">
+            <.language_switcher locale={assigns[:locale] || "en"} />
+          </div>
 
           <%= if assigns[:current_scope] && @current_scope.user do %>
             <!-- Messages Indicator -->
@@ -281,6 +287,10 @@
             </li>
           <% end %>
         </ul>
+
+        <div class="mt-8 flex justify-center">
+          <.language_switcher locale={assigns[:locale] || "en"} />
+        </div>
       </div>
     </aside>
   </div>

--- a/test/klass_hero/provider/adapters/driven/notifications/incident_notification_scheduler_test.exs
+++ b/test/klass_hero/provider/adapters/driven/notifications/incident_notification_scheduler_test.exs
@@ -12,21 +12,34 @@ defmodule KlassHero.Provider.Adapters.Driven.Notifications.IncidentNotificationS
   alias KlassHero.Provider.Adapters.Driven.Notifications.IncidentNotificationScheduler
   alias KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWorker
   alias KlassHero.Provider.Domain.Models.IncidentReport
+  alias KlassHero.Provider.Domain.Models.ProviderProfile
 
-  describe "schedule/1" do
-    test "schedules NotifyIncidentReportedWorker on the :email queue with the report id" do
+  describe "schedule/2" do
+    test "enqueues NotifyIncidentReportedWorker with report id + owner email + business name" do
       Oban.Testing.with_testing_mode(:manual, fn ->
-        # Bypassing IncidentReport.new/1 + the persisting `incident_report_fixture/1`
-        # on purpose: this is a contract test for the adapter, which only reads
-        # `id`. A real fixture would add a DB write and a provider/program setup
-        # for foreign keys — neither contributes to what this test asserts.
+        # Bypassing IncidentReport.new/1 + the persisting fixtures on purpose:
+        # this is a contract test for the adapter, which only reads a few
+        # fields off each struct. A real fixture would add DB writes and FK
+        # setup that don't contribute to what this test asserts.
         report = struct(IncidentReport, id: Ecto.UUID.generate())
 
-        assert {:ok, _job} = IncidentNotificationScheduler.schedule(report)
+        profile =
+          struct(ProviderProfile,
+            id: Ecto.UUID.generate(),
+            identity_id: Ecto.UUID.generate(),
+            business_name: "Acme Adventures",
+            business_owner_email: "owner@example.com"
+          )
+
+        assert {:ok, _job} = IncidentNotificationScheduler.schedule(report, profile)
 
         assert_enqueued(
           worker: NotifyIncidentReportedWorker,
-          args: %{incident_report_id: report.id},
+          args: %{
+            incident_report_id: report.id,
+            business_owner_email: "owner@example.com",
+            business_name: "Acme Adventures"
+          },
           queue: :email
         )
       end)

--- a/test/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker_test.exs
+++ b/test/klass_hero/provider/adapters/driving/workers/notify_incident_reported_worker_test.exs
@@ -3,8 +3,9 @@ defmodule KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWork
   Tests for the NotifyIncidentReportedWorker Oban worker.
 
   The worker is a thin shell over the NotifyIncidentReported use case —
-  it deserialises `incident_report_id` from JSON args and propagates the
-  use case's return value so Oban can decide whether to retry.
+  it deserialises `incident_report_id`, `business_owner_email` and
+  `business_name` from JSON args and propagates the use case's return
+  value so Oban can decide whether to retry.
   """
 
   use KlassHero.DataCase, async: false
@@ -23,15 +24,15 @@ defmodule KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWork
   end
 
   describe "perform/1" do
-    test "sends an email when given a valid incident_report_id" do
+    test "forwards business_owner_email + business_name from args to the use case" do
       owner = unconfirmed_user_fixture(intended_roles: [:provider])
       reporter = unconfirmed_user_fixture(intended_roles: [:provider])
 
       provider =
         provider_profile_fixture(
           identity_id: owner.id,
-          business_name: "Worker Acme",
-          business_owner_email: "worker-owner@example.com"
+          business_name: "Profile Name (should be ignored)",
+          business_owner_email: "profile-owner@example.com"
         )
 
       program = insert(:program_schema, provider_id: provider.id)
@@ -50,8 +51,14 @@ defmodule KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWork
           description: "Worker test incident description."
         })
 
+      # Mismatched values prove the worker forwards args (not falling back to
+      # the profile DB row, which has different values).
       job = %Oban.Job{
-        args: %{"incident_report_id" => report.id},
+        args: %{
+          "incident_report_id" => report.id,
+          "business_owner_email" => "args-owner@example.com",
+          "business_name" => "Args Business"
+        },
         queue: "email",
         attempt: 1,
         max_attempts: 3
@@ -60,14 +67,18 @@ defmodule KlassHero.Provider.Adapters.Driving.Workers.NotifyIncidentReportedWork
       assert :ok = NotifyIncidentReportedWorker.perform(job)
 
       assert_email_sent(fn email ->
-        email.to == [{"Worker Acme", "worker-owner@example.com"}] and
-          email.subject =~ "Worker Program"
+        assert email.to == [{"Args Business", "args-owner@example.com"}]
+        assert email.subject =~ "Worker Program"
       end)
     end
 
     test "propagates :incident_report_not_found error for unknown ids" do
       job = %Oban.Job{
-        args: %{"incident_report_id" => Ecto.UUID.generate()},
+        args: %{
+          "incident_report_id" => Ecto.UUID.generate(),
+          "business_owner_email" => "owner@example.com",
+          "business_name" => "Acme"
+        },
         queue: "email",
         attempt: 1,
         max_attempts: 3

--- a/test/klass_hero/provider/application/commands/incident/notify_incident_reported_test.exs
+++ b/test/klass_hero/provider/application/commands/incident/notify_incident_reported_test.exs
@@ -6,10 +6,10 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
   matching the convention of other Provider use case tests. Email assertions
   use `Swoosh.TestAssertions`.
 
-  Note: the `:provider_profile_not_found` branch is not covered here because
-  `incident_reports.provider_id` has an `on_delete: :delete_all` FK on
-  `providers` — there is no way to leave a report orphaned for that branch
-  to fire. End-to-end coverage relies on inspection of the `with` chain.
+  The use case is payload-driven: `business_owner_email` and `business_name`
+  arrive in the args (forwarded by the Oban worker from the enqueued job).
+  No profile DB lookup happens here; that responsibility lives in
+  `SubmitIncidentReport`.
   """
 
   use KlassHero.DataCase, async: false
@@ -48,11 +48,8 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
   end
 
   describe "execute/1 — happy path" do
-    test "sends an incident report email to the business owner", %{
-      provider: provider,
-      program: program,
-      reporter: reporter
-    } do
+    test "uses business_owner_email + business_name from args, not the profile DB row",
+         %{provider: provider, program: program, reporter: reporter} do
       report =
         incident_report_fixture(%{
           provider_profile_id: provider.id,
@@ -60,10 +57,17 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
           program_id: program.id
         })
 
-      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+      # Mismatched values prove the use case reads the args, not the profile DB row.
+      args =
+        notify_args(report, provider,
+          business_owner_email: "args-owner@example.com",
+          business_name: "Args Business Name"
+        )
+
+      assert :ok = NotifyIncidentReported.execute(args)
 
       assert_email_sent(fn email ->
-        assert email.to == [{"Acme Adventures", "owner@example.com"}]
+        assert email.to == [{"Args Business Name", "args-owner@example.com"}]
         assert email.subject =~ "Climbing Club"
         assert email.subject =~ "Safety concern"
         assert email.text_body =~ report.description
@@ -72,61 +76,14 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
     end
   end
 
-  describe "execute/1 — self-report short-circuit" do
-    test "skips email when reporter is the provider's own owner", %{
-      provider: provider,
-      owner: owner,
-      program: program
-    } do
-      report =
-        incident_report_fixture(%{
-          provider_profile_id: provider.id,
-          reporter_user_id: owner.id,
-          program_id: program.id
-        })
-
-      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
-
-      assert_no_email_sent()
-    end
-  end
-
   describe "execute/1 — incident report missing" do
     test "returns :incident_report_not_found when the id does not exist" do
       assert {:error, :incident_report_not_found} =
-               NotifyIncidentReported.execute(%{incident_report_id: Ecto.UUID.generate()})
-
-      assert_no_email_sent()
-    end
-  end
-
-  describe "execute/1 — missing business_owner_email" do
-    test "returns :missing_business_owner_email and sends nothing", %{
-      reporter: reporter
-    } do
-      provider_no_email =
-        provider_profile_fixture(
-          business_name: "No Email Co",
-          business_owner_email: nil
-        )
-
-      program = insert(:program_schema, provider_id: provider_no_email.id)
-
-      provider_program_projection_fixture(
-        provider_id: provider_no_email.id,
-        program_id: program.id,
-        name: "Some Program"
-      )
-
-      report =
-        incident_report_fixture(%{
-          provider_profile_id: provider_no_email.id,
-          reporter_user_id: reporter.id,
-          program_id: program.id
-        })
-
-      assert {:error, :missing_business_owner_email} =
-               NotifyIncidentReported.execute(%{incident_report_id: report.id})
+               NotifyIncidentReported.execute(%{
+                 incident_report_id: Ecto.UUID.generate(),
+                 business_owner_email: "owner@example.com",
+                 business_name: "Acme Adventures"
+               })
 
       assert_no_email_sent()
     end
@@ -151,7 +108,7 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
           program_id: unprojected_program.id
         })
 
-      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+      assert :ok = NotifyIncidentReported.execute(notify_args(report, provider))
 
       assert_email_sent(fn email ->
         email.subject =~ "a program" and email.text_body =~ "a program"
@@ -174,7 +131,7 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
           session_id: session.id
         })
 
-      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+      assert :ok = NotifyIncidentReported.execute(notify_args(report, provider))
 
       assert_email_sent(fn email ->
         assert email.subject =~ "a session"
@@ -209,7 +166,7 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
           original_filename: "missing.jpg"
         })
 
-      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+      assert :ok = NotifyIncidentReported.execute(notify_args(report, provider))
 
       assert_email_sent(fn email ->
         not (email.text_body =~ "View photo") and not (email.html_body =~ "View photo")
@@ -235,12 +192,23 @@ defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReporte
           original_filename: "incident.jpg"
         })
 
-      assert :ok = NotifyIncidentReported.execute(%{incident_report_id: report.id})
+      assert :ok = NotifyIncidentReported.execute(notify_args(report, provider))
 
       assert_email_sent(fn email ->
         assert email.text_body =~ "stub://signed/"
         assert email.html_body =~ "View photo"
       end)
     end
+  end
+
+  # Builds the worker-shaped args map. Defaults pull straight from the
+  # provider record so tests stay in sync with whatever `setup` actually
+  # created. Tests that exercise mismatched values pass overrides via opts.
+  defp notify_args(report, provider, opts \\ []) do
+    %{
+      incident_report_id: report.id,
+      business_owner_email: Keyword.get(opts, :business_owner_email, provider.business_owner_email),
+      business_name: Keyword.get(opts, :business_name, provider.business_name)
+    }
   end
 end

--- a/test/klass_hero/provider/application/commands/incident/submit_incident_report_test.exs
+++ b/test/klass_hero/provider/application/commands/incident/submit_incident_report_test.exs
@@ -55,12 +55,23 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
     }
   end
 
+  # Production rows get `business_owner_email` populated by `ProviderEventHandler`
+  # off the `:user_registered` integration event. The schema factory leaves it nil
+  # to keep fixtures FK-minimal, so tests that exercise the notification path
+  # backfill explicitly here.
+  defp with_owner_email(provider, email \\ "owner@example.com") do
+    provider
+    |> Ecto.Changeset.change(%{business_owner_email: email})
+    |> Repo.update!()
+  end
+
   describe "execute/1 — program scope" do
     test "persists the report and emits an incident_reported domain event", %{
       provider: p,
       program_id: pg,
       user: u
     } do
+      p = with_owner_email(p)
       params = base_params(p, pg, u)
 
       assert {:ok, report} = SubmitIncidentReport.execute(params)
@@ -71,6 +82,8 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
       assert event.aggregate_id == report.id
       assert event.payload.program_id == pg
       assert event.payload.has_photo == false
+      assert event.payload.business_owner_email == "owner@example.com"
+      assert event.payload.business_name == p.business_name
     end
 
     test "fails when program_id does not belong to the provider", %{provider: p, user: u} do
@@ -242,21 +255,37 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
       end)
     end
 
-    test "skips the email when the reporter is the provider owner (self-report)", %{
+    test "skips the scheduler call when the reporter is the provider owner (self-report)", %{
       provider: provider,
       program_id: program_id
     } do
       owner = Repo.get!(User, provider.identity_id)
-
-      provider
-      |> Ecto.Changeset.change(%{business_owner_email: "owner@example.com"})
-      |> Repo.update!()
+      provider = with_owner_email(provider)
 
       params = base_params(provider, program_id, owner)
 
       assert {:ok, _report} = SubmitIncidentReport.execute(params)
 
       assert_no_email_sent()
+      assert StubIncidentNotificationScheduler.calls() == []
+      # Domain event is still dispatched — preserves the eventing contract;
+      # only the email work is skipped.
+      assert_receive {:domain_event, _event}, 500
+    end
+
+    test "skips the scheduler call when the provider has no business_owner_email on file", %{
+      provider: provider,
+      program_id: program_id,
+      user: reporter
+    } do
+      # provider has business_owner_email: nil from the factory
+      params = base_params(provider, program_id, reporter)
+
+      assert {:ok, _report} = SubmitIncidentReport.execute(params)
+
+      assert_no_email_sent()
+      assert StubIncidentNotificationScheduler.calls() == []
+      assert_receive {:domain_event, _event}, 500
     end
   end
 
@@ -271,6 +300,7 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
       program_id: pg,
       user: u
     } do
+      p = with_owner_email(p)
       StubIncidentNotificationScheduler.set_failure_mode(:enqueue_failed)
 
       params = base_params(p, pg, u)
@@ -281,17 +311,18 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
       refute_receive {:domain_event, _}, 100
     end
 
-    test "still records the enqueue attempt on the success path", %{
-      provider: p,
-      program_id: pg,
-      user: u
-    } do
+    test "calls the scheduler with both the persisted report and the loaded profile",
+         %{provider: p, program_id: pg, user: u} do
+      p = with_owner_email(p)
       params = base_params(p, pg, u)
 
       assert {:ok, report} = SubmitIncidentReport.execute(params)
 
-      assert [%{id: enqueued_id}] = StubIncidentNotificationScheduler.calls()
-      assert enqueued_id == report.id
+      assert [{enqueued_report, enqueued_profile}] = StubIncidentNotificationScheduler.calls()
+      assert enqueued_report.id == report.id
+      assert enqueued_profile.id == p.id
+      assert enqueued_profile.business_owner_email == "owner@example.com"
+      assert enqueued_profile.business_name == p.business_name
     end
 
     test "deletes the uploaded photo when the transaction rolls back", %{
@@ -299,6 +330,8 @@ defmodule KlassHero.Provider.Application.Commands.Incident.SubmitIncidentReportT
       program_id: pg,
       user: u
     } do
+      p = with_owner_email(p)
+
       {:ok, storage} =
         StubStorageAdapter.start_link(name: :"storage_#{System.unique_integer([:positive])}")
 

--- a/test/klass_hero/provider/domain/events/provider_events_test.exs
+++ b/test/klass_hero/provider/domain/events/provider_events_test.exs
@@ -55,7 +55,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEventsTest do
     end
   end
 
-  describe "incident_reported/2" do
+  describe "incident_reported/3" do
     test "returns a DomainEvent with the documented payload shape" do
       report = %IncidentReport{
         id: "r1",
@@ -72,7 +72,14 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEventsTest do
         original_filename: "photo.jpg"
       }
 
-      event = ProviderEvents.incident_reported(report)
+      profile = %ProviderProfile{
+        id: "prov-1",
+        identity_id: "owner-uuid",
+        business_name: "Acme Adventures",
+        business_owner_email: "owner@example.com"
+      }
+
+      event = ProviderEvents.incident_reported(report, profile)
 
       assert %DomainEvent{
                event_type: :incident_reported,
@@ -90,7 +97,9 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEventsTest do
                category: :injury,
                severity: :high,
                occurred_at: ~U[2026-04-20 10:00:00Z],
-               has_photo: true
+               has_photo: true,
+               business_owner_email: "owner@example.com",
+               business_name: "Acme Adventures"
              }
 
       refute Map.has_key?(payload, :description)
@@ -113,7 +122,15 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEventsTest do
         original_filename: nil
       }
 
-      assert %DomainEvent{payload: %{has_photo: false}} = ProviderEvents.incident_reported(report)
+      profile = %ProviderProfile{
+        id: "prov-1",
+        identity_id: "owner-uuid",
+        business_name: "Acme Adventures",
+        business_owner_email: "owner@example.com"
+      }
+
+      assert %DomainEvent{payload: %{has_photo: false}} =
+               ProviderEvents.incident_reported(report, profile)
     end
 
     test "forwards opts to DomainEvent.new/5 (e.g., correlation_id)" do
@@ -132,9 +149,17 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEventsTest do
         original_filename: nil
       }
 
+      profile = %ProviderProfile{
+        id: "prov-1",
+        identity_id: "owner-uuid",
+        business_name: "Acme Adventures",
+        business_owner_email: "owner@example.com"
+      }
+
       correlation_id = Ecto.UUID.generate()
 
-      event = ProviderEvents.incident_reported(report, correlation_id: correlation_id)
+      event =
+        ProviderEvents.incident_reported(report, profile, correlation_id: correlation_id)
 
       assert event.metadata.correlation_id == correlation_id
     end


### PR DESCRIPTION
Closes #753

## Summary

- Extended `ProviderEvents.incident_reported/3` to take `ProviderProfile` and emit `business_owner_email` + `business_name` on the payload (`provider_events.ex:78-94`).
- Changed the `ForSchedulingIncidentNotifications.schedule/2` port + `IncidentNotificationScheduler` adapter to take the profile and enqueue the two extra Oban args (`incident_notification_scheduler.ex:18-24`); stub matches the new signature.
- Stripped the entire profile-fetching path from `NotifyIncidentReported` — no `@profile_query`, no `fetch_profile/1`, no `:provider_profile_not_found`, no `:missing_business_owner_email`. Worker forwards the new args through binary guards via a local `defguardp is_present/1` (`notify_incident_reported.ex:25,42`; `worker.ex:14,20`).
- `SubmitIncidentReport` now loads the profile once before the transaction (`submit_incident_report.ex:68,82`) and routes self-reports + missing-email providers around the scheduler so no email job is ever enqueued without recipient data (`submit_incident_report.ex:182-198`).
- 12 files changed, +266/-172. `mix precommit` clean: 4615 passed, 0 warnings; credo strict on touched files: 0 issues.

## Review Focus

- **Read-outside-transaction at `submit_incident_report.ex:75-86`** — `fetch_profile/1` runs outside `Repo.transaction/1`. The profile fields we forward are stable (not mutated by this flow), so the CLAUDE.md "no read-outside-tx" rule doesn't apply. The justification is inlined as a comment at the function — please sanity-check the reasoning.
- **Self-report short-circuit moved one layer up (`submit_incident_report.ex:182-198`)** — previously `NotifyIncidentReported` checked `reporter_user_id == identity_id` after fetching the profile. Now `maybe_schedule_notification/2` short-circuits in `SubmitIncidentReport` *inside the transaction* before the scheduler is called. Behaviour change worth confirming: the `:incident_reported` domain event is **still dispatched** for self-reports (preserves the eventing contract); only the scheduler call is skipped.
- **No backward-compat path for in-flight Oban jobs** — per direction during planning: jobs queued under the old args shape (`%{"incident_report_id" => id}` only) will fail the worker's pattern match and exhaust their retry budget after deploy. Acceptable trade-off for keeping the worker clean (`worker.ex:16-20`); flag if you want a deploy note about draining the queue first.
- **Stub `calls/0` shape changed (`stub_incident_notification_scheduler.ex:54-58`)** — now returns `[{report, profile}]` tuples instead of `[report]`. Only consumer is `submit_incident_report_test.exs`.
- **Empty `:critical_event_handlers` for this event** — `integration:provider:incident_reported` has no consumer registered today. Fattening the integration event payload is forward-looking; the actual perf benefit lands in the Oban path. Confirm we're OK shipping the payload without an immediate cross-context consumer.

## Test Plan

- [x] `mix precommit` — 4615 passed, 12 skipped, 18 excluded; zero warnings
- [x] `mix credo --strict` on 7 touched lib files — 0 issues
- [x] All 37 incident-related tests pass (event factory, scheduler adapter, worker, both use cases)
- [x] Tidewave smoke test — factory payload carries both new fields; scheduler enqueues args with all three keys
- [x] Manually submit an incident in dev (`/provider/incidents/new`) and confirm the Oban job's `args` JSON contains `business_owner_email` + `business_name` (`SELECT args FROM oban_jobs ORDER BY inserted_at DESC LIMIT 1`)
- [ ] Confirm self-report by the provider's own owner persists the report row, dispatches the event, but does NOT insert an Oban job
- [x] Confirm a provider with `business_owner_email IS NULL` can submit a report without enqueueing a doomed job