### PR TITLE
ci: add manual feature-branch deploy to dev environment

### DIFF
--- a/.github/workflows/deploy-dev-branch.yml
+++ b/.github/workflows/deploy-dev-branch.yml
@@ -1,0 +1,31 @@
+# Manually deploy any branch to the dev environment (klass-hero-dev) on Fly.io.
+# Trigger from the GitHub Actions UI: select the branch in the "Use workflow
+# from" dropdown and click "Run workflow". No CI gate — intentional, dev is
+# for in-progress QA.
+
+name: Deploy Dev Branch
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy branch to dev
+    runs-on: ubuntu-latest
+    concurrency: deploy-klass-hero-dev
+    environment:
+      name: dev
+      url: https://klass-hero-dev.fly.dev
+    steps:
+      # actions/checkout@v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # superfly/flyctl-actions/setup-flyctl@v1.5
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Added `.github/workflows/deploy-dev-branch.yml` — `workflow_dispatch`-only workflow that deploys the selected branch to `klass-hero-dev` on Fly.io.
- Mirrors the shape of `deploy-production.yml` (manual dispatch, pinned action SHAs, environment annotation) but targets the dev Fly app via the default `fly.toml`.
- Shares the `deploy-klass-hero-dev` concurrency group with `fly-deploy.yml` so manual branch deploys serialise against `main`'s auto-deploy instead of racing.
- No CI gate by design: lets engineers push WIP branches to dev for QA before they would pass CI.

## Review Focus

- **Concurrency group reuse** — `deploy-dev-branch.yml:14` uses `concurrency: deploy-klass-hero-dev`, matching `fly-deploy.yml:17`. Confirms only one deploy hits the dev Fly app at a time across both workflows.
- **Secret + Fly target** — `deploy-dev-branch.yml:30` pulls `FLY_API_TOKEN` (dev token, same as `fly-deploy.yml:33`) and runs `flyctl deploy --remote-only` against the unspecified default `fly.toml` (`app = "klass-hero-dev"`). Cross-check: not the prod token, not the prod config.
- **No CI gate** — intentional, called out in the file's header comment. Dev is non-prod; engineers want to push broken branches there for manual QA. Confirm this matches expectations before merge.
- **Action SHAs pinned** — `deploy-dev-branch.yml:24,28` reuse the exact SHAs already in `fly-deploy.yml` and `deploy-production.yml`. Keeps supply-chain surface identical.
- **First-use caveat** — `workflow_dispatch` workflows only appear in the Actions UI once the file lives on the default branch. After this merges, the \"Deploy Dev Branch\" entry shows up under Actions; the branch dropdown then lets you pick any ref.

## Test Plan

- [x] YAML parses cleanly (Ruby `YAML.safe_load`; structure matches `fly-deploy.yml` / `deploy-production.yml`).
- [ ] After squash-merge, **Actions → Deploy Dev Branch → Run workflow** lists branches in the dropdown.
- [ ] Pick a throwaway branch with a visible diff, run workflow, confirm `flyctl deploy --remote-only` succeeds and the diff is live at https://klass-hero-dev.fly.dev.
- [ ] Trigger a manual deploy while a `main` auto-deploy is running; confirm GitHub queues the second run via the shared `deploy-klass-hero-dev` concurrency group.
- [ ] `mix precommit` (no Elixir touched, but run for completeness).