### PR TITLE
fix: replace primeyouth.com emails with KlassHero contact address

### DIFF
--- a/.claude/skills/test-drive/references/auth-flows.md
+++ b/.claude/skills/test-drive/references/auth-flows.md
@@ -33,7 +33,7 @@ All seed users share password: `password`
 
 | Name | Email |
 |------|-------|
-| Klass Hero Admin | app@primeyouth.de |
+| Klass Hero Admin | app@klasshero.com |
 
 ## Login Procedure
 
@@ -50,6 +50,6 @@ All seed users share password: `password`
 | Provider dashboard, sessions, programs | Provider | claudia.wolf (professional) |
 | Entitlement-gated features | Provider | lena.hartmann (starter, should be denied) |
 | Parent dashboard, enrollment, booking | Parent | anna.mueller |
-| Admin panel, Backpex | Admin | app@primeyouth.de |
+| Admin panel, Backpex | Admin | app@klasshero.com |
 | Staff dashboard, sessions, check-in/out | Staff | uitest-staff |
 | Cross-role messaging | Both provider + parent in separate steps |

--- a/lib/klass_hero_web/live/privacy_policy_live.ex
+++ b/lib/klass_hero_web/live/privacy_policy_live.ex
@@ -17,7 +17,7 @@ defmodule KlassHeroWeb.PrivacyPolicyLive do
   defp last_updated, do: "February 1, 2026"
 
   defp privacy_sections do
-    email = Contact.email()
+    email = Contact.email() |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
 
     [
       %{

--- a/lib/klass_hero_web/live/privacy_policy_live.ex
+++ b/lib/klass_hero_web/live/privacy_policy_live.ex
@@ -1,6 +1,7 @@
 defmodule KlassHeroWeb.PrivacyPolicyLive do
   use KlassHeroWeb, :live_view
 
+  alias KlassHero.Contact
   alias KlassHeroWeb.Theme
 
   @impl true
@@ -16,6 +17,8 @@ defmodule KlassHeroWeb.PrivacyPolicyLive do
   defp last_updated, do: "February 1, 2026"
 
   defp privacy_sections do
+    email = Contact.email()
+
     [
       %{
         id: "introduction",
@@ -120,9 +123,9 @@ defmodule KlassHeroWeb.PrivacyPolicyLive do
         <h4 class="font-semibold text-gray-900 mb-2">Right to Data Portability:</h4>
         <p class="mb-4">Your exported data is provided in a standard JSON format that can be used with other services.</p>
         <h4 class="font-semibold text-gray-900 mb-2">Right to Object:</h4>
-        <p class="mb-4">You can object to certain types of data processing. Contact us at privacy@primeyouth.com to discuss your concerns.</p>
+        <p class="mb-4">You can object to certain types of data processing. Contact us at #{email} to discuss your concerns.</p>
         <p class="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-          <strong class="text-blue-900">To exercise any of these rights:</strong> Visit your Settings page or contact us at <a href="mailto:privacy@primeyouth.com" class="text-blue-600 hover:underline">privacy@primeyouth.com</a>
+          <strong class="text-blue-900">To exercise any of these rights:</strong> Visit your Settings page or contact us at <a href="mailto:#{email}" class="text-blue-600 hover:underline">#{email}</a>
         </p>
         """
       },
@@ -219,8 +222,8 @@ defmodule KlassHeroWeb.PrivacyPolicyLive do
         content: """
         <p class="mb-4">If you have any questions about this Privacy Policy or how we handle your data, please contact us:</p>
         <div class="space-y-2">
-          <p><strong>Email:</strong> <a href="mailto:privacy@primeyouth.com" class="text-blue-600 hover:underline">privacy@primeyouth.com</a></p>
-          <p><strong>General Inquiries:</strong> <a href="mailto:hello@primeyouth.com" class="text-blue-600 hover:underline">hello@primeyouth.com</a></p>
+          <p><strong>Email:</strong> <a href="mailto:#{email}" class="text-blue-600 hover:underline">#{email}</a></p>
+          <p><strong>General Inquiries:</strong> <a href="mailto:#{email}" class="text-blue-600 hover:underline">#{email}</a></p>
         </div>
         <p class="mt-4">You can also reach us through our <a href="/contact" class="text-blue-600 hover:underline">Contact Page</a>.</p>
         """

--- a/lib/klass_hero_web/live/terms_of_service_live.ex
+++ b/lib/klass_hero_web/live/terms_of_service_live.ex
@@ -17,7 +17,7 @@ defmodule KlassHeroWeb.TermsOfServiceLive do
   defp last_updated, do: "December 12, 2025"
 
   defp terms_sections do
-    email = Contact.email()
+    email = Contact.email() |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
 
     [
       %{

--- a/lib/klass_hero_web/live/terms_of_service_live.ex
+++ b/lib/klass_hero_web/live/terms_of_service_live.ex
@@ -1,6 +1,7 @@
 defmodule KlassHeroWeb.TermsOfServiceLive do
   use KlassHeroWeb, :live_view
 
+  alias KlassHero.Contact
   alias KlassHeroWeb.Theme
 
   @impl true
@@ -16,6 +17,8 @@ defmodule KlassHeroWeb.TermsOfServiceLive do
   defp last_updated, do: "December 12, 2025"
 
   defp terms_sections do
+    email = Contact.email()
+
     [
       %{
         id: "agreement",
@@ -219,7 +222,7 @@ defmodule KlassHeroWeb.TermsOfServiceLive do
         title: gettext("Dispute Resolution"),
         content: """
         <h4 class="font-semibold text-gray-900 mb-2">Contact Us First:</h4>
-        <p class="mb-4">If you have a dispute or concern, please contact us first at hello@primeyouth.com. We are committed to resolving issues amicably and will work with you in good faith.</p>
+        <p class="mb-4">If you have a dispute or concern, please contact us first at #{email}. We are committed to resolving issues amicably and will work with you in good faith.</p>
         <h4 class="font-semibold text-gray-900 mb-2">Informal Resolution:</h4>
         <p class="mb-4">Most concerns can be resolved through direct communication. We will respond to disputes within 5 business days and work toward a fair resolution.</p>
         <h4 class="font-semibold text-gray-900 mb-2">Governing Law:</h4>
@@ -237,8 +240,8 @@ defmodule KlassHeroWeb.TermsOfServiceLive do
         content: """
         <p class="mb-4">If you have questions about these Terms of Service, please contact us:</p>
         <div class="space-y-2">
-          <p><strong>Email:</strong> <a href="mailto:hello@primeyouth.com" class="text-blue-600 hover:underline">hello@primeyouth.com</a></p>
-          <p><strong>Privacy Questions:</strong> <a href="mailto:privacy@primeyouth.com" class="text-blue-600 hover:underline">privacy@primeyouth.com</a></p>
+          <p><strong>Email:</strong> <a href="mailto:#{email}" class="text-blue-600 hover:underline">#{email}</a></p>
+          <p><strong>Privacy Questions:</strong> <a href="mailto:#{email}" class="text-blue-600 hover:underline">#{email}</a></p>
         </div>
         <p class="mt-4">You can also reach us through our <a href="/contact" class="text-blue-600 hover:underline">Contact Page</a>.</p>
         <p class="mt-6 p-4 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-700">

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -114,7 +114,7 @@ admin =
   %User{}
   |> Ecto.Changeset.change(%{
     name: "Klass Hero Admin",
-    email: "app@primeyouth.de",
+    email: "app@klasshero.com",
     hashed_password: hashed_pw,
     confirmed_at: now,
     is_admin: true

--- a/test/klass_hero_web/live/privacy_policy_live_test.exs
+++ b/test/klass_hero_web/live/privacy_policy_live_test.exs
@@ -83,7 +83,7 @@ defmodule KlassHeroWeb.PrivacyPolicyLiveTest do
     test "includes contact information", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/privacy")
 
-      assert html =~ "privacy@primeyouth.com"
+      assert html =~ "info@mail.klasshero.com"
       assert html =~ "Contact Us"
     end
 

--- a/test/klass_hero_web/live/privacy_policy_live_test.exs
+++ b/test/klass_hero_web/live/privacy_policy_live_test.exs
@@ -81,10 +81,11 @@ defmodule KlassHeroWeb.PrivacyPolicyLiveTest do
     end
 
     test "includes contact information", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/privacy")
+      {:ok, view, html} = live(conn, ~p"/privacy")
 
       assert html =~ "info@mail.klasshero.com"
       assert html =~ "Contact Us"
+      assert has_element?(view, ~s|a[href="mailto:info@mail.klasshero.com"]|)
     end
 
     test "accessible without authentication", %{conn: conn} do

--- a/test/klass_hero_web/live/terms_of_service_live_test.exs
+++ b/test/klass_hero_web/live/terms_of_service_live_test.exs
@@ -89,7 +89,7 @@ defmodule KlassHeroWeb.TermsOfServiceLiveTest do
     test "includes contact information", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/terms")
 
-      assert html =~ "hello@primeyouth.com"
+      assert html =~ "info@mail.klasshero.com"
       assert html =~ "Contact Information"
     end
 

--- a/test/klass_hero_web/live/terms_of_service_live_test.exs
+++ b/test/klass_hero_web/live/terms_of_service_live_test.exs
@@ -87,10 +87,11 @@ defmodule KlassHeroWeb.TermsOfServiceLiveTest do
     end
 
     test "includes contact information", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/terms")
+      {:ok, view, html} = live(conn, ~p"/terms")
 
       assert html =~ "info@mail.klasshero.com"
       assert html =~ "Contact Information"
+      assert has_element?(view, ~s|a[href="mailto:info@mail.klasshero.com"]|)
     end
 
     test "accessible without authentication", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Routes Privacy Policy + Terms of Service contact addresses through `KlassHero.Contact.email/0` (existing single source of truth in `config/config.exs:159` → `info@mail.klasshero.com`, already used by `ContactLive` and the marketing footer) so a future address change is a one-line config edit instead of grepping legal pages.
- Replaces 7 hardcoded `*@primeyouth.com` references on the two legal LiveViews and updates the matching test assertions.
- Bundles two adjacent `app@primeyouth.de` refs (admin seed user + `auth-flows.md` skill doc) onto the `klasshero.com` domain to satisfy the issue's "verify no other files reference primeyouth.com" criterion in one sweep.

## Review Focus
- `lib/klass_hero_web/live/privacy_policy_live.ex` and `lib/klass_hero_web/live/terms_of_service_live.ex` — `email` is bound at the top of `*_sections/0` and interpolated into the heredoc strings (plain HTML, not HEEx, so attribute syntax stays `"..."`).
- Test assertions pin the literal `info@mail.klasshero.com` rather than reading config dynamically — intentional, so a future config change forces a deliberate test update.

## Test plan
- [x] `rg -i 'primeyouth' --hidden -g '!.git' -g '!_build' -g '!deps'` → zero hits
- [x] `mix test test/klass_hero_web/live/privacy_policy_live_test.exs test/klass_hero_web/live/terms_of_service_live_test.exs` → 30/30 pass
- [x] `mix precommit` → 4752 pass, 5 skipped, 18 excluded; format + warnings-as-errors + typography lint clean
- [x] Manual smoke: `/privacy` and `/terms` render `info@mail.klasshero.com` in body text and `mailto:` hrefs

Closes #664.