### PR TITLE
fix: seeds.exs uitest-staff missing :name and :password

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -484,12 +484,14 @@ staff_by_provider =
 Logger.info("Seeding UI test staff user...")
 
 uitest_staff_user =
-  User.registration_changeset(%User{}, %{
+  %User{}
+  |> Ecto.Changeset.change(%{
+    name: "UI TestStaff",
     email: "uitest-staff@example.com",
-    password: "password"
+    hashed_password: hashed_pw,
+    confirmed_at: now,
+    intended_roles: [:staff_provider, :provider]
   })
-  |> Ecto.Changeset.put_change(:intended_roles, [:staff_provider])
-  |> Ecto.Changeset.put_change(:confirmed_at, now)
   |> Repo.insert!()
 
 uitest_staff_member =


### PR DESCRIPTION
## Summary

- Fixes `Ecto.InvalidChangesetError` halt at `priv/repo/seeds.exs:486-493` when running against a fresh DB
- Replaces `User.registration_changeset/2` (which requires `:name` and does not cast `:password`) with the established `Ecto.Changeset.change/2` + pre-hashed-password pattern used by every other seed user (lines 134-145, 100-122)
- Also fixes a latent defect: the previous code would have left the user with `hashed_password = nil` even after adding `:name`, since `registration_changeset/2`'s cast list does not include `:password`
- Switches `intended_roles` from `[:staff_provider]` to `[:staff_provider, :provider]` to match `User.staff_registration_changeset/2` semantics — every staff invitee gets a baseline provider account

Closes #710

## Review Focus

- `priv/repo/seeds.exs:486-495` — the only block changed
- Dev-only shortcut; no production code paths touched

## Test Plan

- [x] `mix ecto.reset && mix run priv/repo/seeds.exs` — completes through every seed stage; final summary reports 16 users, 5 conversations, etc.
- [x] `Repo.get_by!(User, email: "uitest-staff@example.com")` returns user with `name: "UI TestStaff"`, `confirmed_at` set, `intended_roles: [:staff_provider, :provider]`
- [x] `Bcrypt.verify_pass("password", u.hashed_password)` returns `true` — login is functional
- [x] `Repo.get_by!(StaffMemberSchema, user_id: u.id)` returns the linked staff member with `invitation_status: "accepted"`
- [x] `mix precommit` — 4752 passed, 5 skipped, 18 excluded