### PR TITLE
fix: include assigned staff as participants in private broadcast replies

### DIFF
--- a/lib/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository.ex
@@ -51,6 +51,39 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Participa
   end
 
   @impl true
+  def add_or_get(attrs) do
+    span do
+      set_attributes("db", operation: "upsert", entity: "messaging_participant")
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      entry =
+        attrs
+        |> ParticipantMapper.to_create_attrs()
+        |> Map.put(:id, Ecto.UUID.generate())
+        |> Map.put(:joined_at, now)
+        |> Map.put(:inserted_at, now)
+        |> Map.put(:updated_at, now)
+
+      case Repo.insert_all(ParticipantSchema, [entry],
+             returning: true,
+             on_conflict: :nothing,
+             conflict_target: [:conversation_id, :user_id]
+           ) do
+        {1, [schema]} ->
+          {:ok, ParticipantMapper.to_domain(schema)}
+
+        # Trigger: row already existed; on_conflict: :nothing skipped the insert
+        # Why: callers (BroadcastToProgram follow-up) need to keep going inside Repo.transaction
+        #      without poisoning it via a unique-constraint failure
+        # Outcome: fetch the existing row so the caller gets a Participant.t() either way
+        {0, _} ->
+          get(attrs.conversation_id, attrs.user_id)
+      end
+    end
+  end
+
+  @impl true
   def get(conversation_id, user_id) do
     span do
       set_attributes("db", operation: "select", entity: "messaging_participant")

--- a/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
+++ b/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
@@ -121,7 +121,7 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
       with {:ok, _participants} <-
              @participant_repo.add_batch(conversation.id, parent_user_ids),
            {:ok, _} <-
-             @participant_repo.add(%{
+             @participant_repo.add_or_get(%{
                conversation_id: conversation.id,
                user_id: scope.user.id
              }),

--- a/lib/klass_hero/messaging/application/commands/reply_privately_to_broadcast.ex
+++ b/lib/klass_hero/messaging/application/commands/reply_privately_to_broadcast.ex
@@ -64,7 +64,8 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast do
            find_or_create_direct_conversation(
              scope,
              broadcast.provider_id,
-             provider_user_id
+             provider_user_id,
+             broadcast.program_id
            ),
          :ok <-
            maybe_insert_system_note(
@@ -98,20 +99,23 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast do
   #      is the initiator (it would match any provider conversation).
   #      We handle find and create separately to get the correct lookup semantics.
   # Outcome: returns the unique direct conversation between this parent and provider
-  defp find_or_create_direct_conversation(scope, provider_id, provider_user_id) do
+  defp find_or_create_direct_conversation(scope, provider_id, provider_user_id, program_id) do
     case @conversation_reader.find_direct_conversation(provider_id, scope.user.id) do
       {:ok, existing} ->
         {:ok, existing}
 
       {:error, :not_found} ->
-        create_direct_conversation(scope, provider_id, provider_user_id)
+        create_direct_conversation(scope, provider_id, provider_user_id, program_id)
     end
   end
 
-  defp create_direct_conversation(scope, provider_id, provider_user_id) do
+  defp create_direct_conversation(scope, provider_id, provider_user_id, program_id) do
     Repo.transaction(fn ->
-      with {:ok, conversation} <-
-             @conversation_repo.create(%{type: :direct, provider_id: provider_id}),
+      attrs =
+        %{type: :direct, provider_id: provider_id}
+        |> maybe_put_program_id(program_id)
+
+      with {:ok, conversation} <- @conversation_repo.create(attrs),
            {:ok, _} <-
              @participant_repo.add(%{
                conversation_id: conversation.id,
@@ -121,7 +125,8 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast do
              @participant_repo.add(%{
                conversation_id: conversation.id,
                user_id: provider_user_id
-             }) do
+             }),
+           :ok <- Shared.add_assigned_staff(conversation.id, program_id, provider_user_id) do
         publish_conversation_created(conversation, scope.user.id, provider_user_id, provider_id)
         conversation
       else
@@ -129,6 +134,9 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast do
       end
     end)
   end
+
+  defp maybe_put_program_id(attrs, nil), do: attrs
+  defp maybe_put_program_id(attrs, program_id), do: Map.put(attrs, :program_id, program_id)
 
   defp publish_conversation_created(conversation, parent_user_id, provider_user_id, provider_id) do
     event =

--- a/lib/klass_hero/messaging/application/commands/reply_privately_to_broadcast.ex
+++ b/lib/klass_hero/messaging/application/commands/reply_privately_to_broadcast.ex
@@ -144,7 +144,8 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast do
         conversation.id,
         conversation.type,
         provider_id,
-        [parent_user_id, provider_user_id]
+        [parent_user_id, provider_user_id],
+        conversation.program_id
       )
 
     DomainEventBus.dispatch(@context, event)

--- a/lib/klass_hero/messaging/domain/ports/for_managing_participants.ex
+++ b/lib/klass_hero/messaging/domain/ports/for_managing_participants.ex
@@ -21,6 +21,21 @@ defmodule KlassHero.Messaging.Domain.Ports.ForManagingParticipants do
               {:ok, Participant.t()} | {:error, :already_participant | term()}
 
   @doc """
+  Adds a participant if not already present, or returns the existing one.
+
+  Idempotent variant of `add/1`. Safe to call inside a `Repo.transaction` for
+  a `(conversation_id, user_id)` pair that may already exist — the underlying
+  insert uses `on_conflict: :nothing` so the unique-constraint violation never
+  fires and the surrounding transaction is not poisoned.
+
+  Returns:
+  - `{:ok, Participant.t()}` - Either the newly inserted or the pre-existing participant
+  - `{:error, :not_found}` - Insert was skipped on conflict but the row could not be re-fetched
+  """
+  @callback add_or_get(attrs :: map()) ::
+              {:ok, Participant.t()} | {:error, term()}
+
+  @doc """
   Updates the last_read_at timestamp for a participant.
 
   Returns:

--- a/test/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository_test.exs
@@ -51,6 +51,76 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Participa
     end
   end
 
+  describe "add_or_get/1" do
+    test "inserts when no participant exists" do
+      conversation = insert(:conversation_schema)
+      user = AccountsFixtures.user_fixture()
+
+      attrs = %{conversation_id: conversation.id, user_id: user.id}
+
+      assert {:ok, %Participant{} = participant} = ParticipantRepository.add_or_get(attrs)
+      assert participant.conversation_id == conversation.id
+      assert participant.user_id == user.id
+      assert participant.joined_at != nil
+
+      assert KlassHero.Repo.get_by(ParticipantSchema,
+               conversation_id: conversation.id,
+               user_id: user.id
+             )
+    end
+
+    test "returns existing participant when already present, no error" do
+      conversation = insert(:conversation_schema)
+      user = AccountsFixtures.user_fixture()
+
+      attrs = %{conversation_id: conversation.id, user_id: user.id}
+
+      assert {:ok, first} = ParticipantRepository.add_or_get(attrs)
+      assert {:ok, second} = ParticipantRepository.add_or_get(attrs)
+
+      assert second.id == first.id
+      assert second.joined_at == first.joined_at
+    end
+
+    test "remains idempotent across many calls" do
+      conversation = insert(:conversation_schema)
+      user = AccountsFixtures.user_fixture()
+
+      attrs = %{conversation_id: conversation.id, user_id: user.id}
+
+      ids =
+        for _ <- 1..5 do
+          {:ok, p} = ParticipantRepository.add_or_get(attrs)
+          p.id
+        end
+
+      assert Enum.uniq(ids) |> length() == 1
+    end
+
+    # Trigger: caller runs add_or_get inside a Repo.transaction for a user that may already be a participant
+    # Why: a unique-constraint failure under Repo.insert would mark the Postgres transaction
+    #      as aborted (25P02) and poison every subsequent query — exactly the BroadcastToProgram
+    #      follow-up bug we are fixing. add_or_get must use insert_all with on_conflict: :nothing
+    #      so the constraint never fires.
+    # Outcome: transaction commits cleanly even after multiple adds for the same (conversation, user)
+    test "does not poison the surrounding Repo.transaction" do
+      conversation = insert(:conversation_schema)
+      user = AccountsFixtures.user_fixture()
+      attrs = %{conversation_id: conversation.id, user_id: user.id}
+
+      result =
+        KlassHero.Repo.transaction(fn ->
+          {:ok, _} = ParticipantRepository.add_or_get(attrs)
+          {:ok, _} = ParticipantRepository.add_or_get(attrs)
+          {:ok, _} = ParticipantRepository.add_or_get(attrs)
+          KlassHero.Repo.query!("SELECT 1")
+          :committed
+        end)
+
+      assert {:ok, :committed} = result
+    end
+  end
+
   describe "get/2" do
     test "returns participant when found" do
       conversation = insert(:conversation_schema)

--- a/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
+++ b/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
@@ -227,6 +227,49 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgramTest do
     end
   end
 
+  describe "execute/4 — follow-up broadcasts" do
+    # Trigger: provider sends a second broadcast on a program they have already broadcast to
+    # Why: get_or_create_broadcast_conversation reuses the existing conversation, so the
+    #      sender is already a participant when execute_broadcast_transaction runs the
+    #      participant adds. Pre-fix, the sender's add hit a unique constraint and rolled
+    #      back the entire transaction, surfacing as a generic "Failed to send broadcast".
+    # Outcome: both calls succeed, the same broadcast conversation is reused, both messages
+    #          are persisted, no duplicate participant rows.
+    test "second broadcast on the same program reuses the conversation and persists both messages" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, first_conv, first_msg, 1} =
+               BroadcastToProgram.execute(scope, program.id, "First announcement")
+
+      assert {:ok, second_conv, second_msg, 1} =
+               BroadcastToProgram.execute(scope, program.id, "Second announcement")
+
+      assert second_conv.id == first_conv.id
+      refute second_msg.id == first_msg.id
+
+      # Sender stays a single participant — no duplicate insert
+      assert ParticipantRepository.is_participant?(first_conv.id, scope.user.id)
+
+      sender_rows =
+        first_conv.id
+        |> ParticipantRepository.list_for_conversation()
+        |> Enum.filter(&(&1.user_id == scope.user.id))
+
+      assert length(sender_rows) == 1
+    end
+  end
+
   defp build_scope_with_provider(provider_schema, tier) do
     user = AccountsFixtures.user_fixture()
 

--- a/test/klass_hero/messaging/application/commands/reply_privately_to_broadcast_test.exs
+++ b/test/klass_hero/messaging/application/commands/reply_privately_to_broadcast_test.exs
@@ -6,7 +6,10 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcastTest
   alias KlassHero.Accounts.Scope
   alias KlassHero.AccountsFixtures
   alias KlassHero.Family.Domain.Models.ParentProfile
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ConversationRepository
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.MessageRepository
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ParticipantRepository
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ProgramStaffParticipantRepository
   alias KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast
 
   describe "execute/2" do
@@ -163,6 +166,108 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcastTest
 
       assert {:error, :not_participant} =
                ReplyPrivatelyToBroadcast.execute(non_participant_scope, ctx.broadcast.id)
+    end
+  end
+
+  describe "execute/2 — staff auto-inclusion" do
+    setup do
+      provider_user = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: provider_user.id)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      broadcast =
+        insert(:conversation_schema,
+          type: "program_broadcast",
+          provider_id: provider.id,
+          program_id: program.id,
+          subject: "Schedule Change"
+        )
+
+      parent_user = AccountsFixtures.user_fixture()
+
+      insert(:participant_schema,
+        conversation_id: broadcast.id,
+        user_id: parent_user.id
+      )
+
+      parent_profile = %ParentProfile{
+        id: Ecto.UUID.generate(),
+        identity_id: parent_user.id,
+        subscription_tier: :explorer
+      }
+
+      scope = %Scope{
+        user: parent_user,
+        roles: [:parent],
+        parent: parent_profile,
+        provider: nil
+      }
+
+      %{
+        scope: scope,
+        broadcast: broadcast,
+        provider: provider,
+        provider_user: provider_user,
+        program: program,
+        parent_user: parent_user
+      }
+    end
+
+    test "adds assigned staff as participants when broadcast has program context", ctx do
+      staff_user = AccountsFixtures.user_fixture()
+
+      :ok =
+        ProgramStaffParticipantRepository.upsert_active(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_user_id: staff_user.id
+        })
+
+      assert {:ok, direct_conversation_id} =
+               ReplyPrivatelyToBroadcast.execute(ctx.scope, ctx.broadcast.id)
+
+      assert ParticipantRepository.is_participant?(direct_conversation_id, staff_user.id)
+    end
+
+    test "sets program_id on the new direct conversation", ctx do
+      assert {:ok, direct_conversation_id} =
+               ReplyPrivatelyToBroadcast.execute(ctx.scope, ctx.broadcast.id)
+
+      assert {:ok, conversation} = ConversationRepository.get_by_id(direct_conversation_id)
+      assert conversation.program_id == ctx.program.id
+    end
+
+    test "does not error when provider owner is also assigned as program staff", ctx do
+      :ok =
+        ProgramStaffParticipantRepository.upsert_active(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_user_id: ctx.provider_user.id
+        })
+
+      assert {:ok, direct_conversation_id} =
+               ReplyPrivatelyToBroadcast.execute(ctx.scope, ctx.broadcast.id)
+
+      assert ParticipantRepository.is_participant?(direct_conversation_id, ctx.provider_user.id)
+    end
+
+    test "does not retroactively add staff to a reused direct conversation", ctx do
+      assert {:ok, first_id} =
+               ReplyPrivatelyToBroadcast.execute(ctx.scope, ctx.broadcast.id)
+
+      staff_user = AccountsFixtures.user_fixture()
+
+      :ok =
+        ProgramStaffParticipantRepository.upsert_active(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_user_id: staff_user.id
+        })
+
+      assert {:ok, ^first_id} =
+               ReplyPrivatelyToBroadcast.execute(ctx.scope, ctx.broadcast.id)
+
+      refute ParticipantRepository.is_participant?(first_id, staff_user.id)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Threaded `broadcast.program_id` through `find_or_create_direct_conversation/4` → `create_direct_conversation/4` so derived direct conversations carry the program context.
- Added `maybe_put_program_id/2` helper, mirroring `CreateDirectConversation`, to set `program_id` on the conversation `attrs` only when present.
- Inserted `Shared.add_assigned_staff(conversation.id, program_id, provider_user_id)` inside the existing `Repo.transaction` (between participant adds and event publish) so the staff-add rolls back atomically with the rest of conversation creation.
- New `describe "execute/2 — staff auto-inclusion"` block with four red-then-green tests pinning: staff added, `program_id` set, owner-as-staff handled, no retroactive add on reuse.

## Review Focus

- **Owner-exclusion arg in `add_assigned_staff/3`** — `lib/klass_hero/messaging/application/commands/reply_privately_to_broadcast.ex:129` passes `provider_user_id` as the owner-to-exclude (not `scope.user.id`). In `BroadcastToProgram` and `CreateDirectConversation` the initiator is the provider owner, so they pass `scope.user.id`. Here the parent initiates but the conversation owner is still the provider, so `provider_user_id` is the right exclusion key.
- **Lookup semantics unchanged** — `find_direct_conversation/2` still keys on `(provider_id, scope.user.id)` only, no `program_id` filter (`reply_privately_to_broadcast.ex:103`). Existing direct conversations between this parent and provider continue to match; `program_id` is only ever set on first creation, so prior threads don't fragment.
- **Forward-only fix** — the `"does not retroactively add staff to a reused direct conversation"` test (`reply_privately_to_broadcast_test.exs:267`) explicitly locks in that pre-existing conversations are not back-filled. Issue #777 is fixed forward only; no migration.
- **Inbox-visibility gap is separate** — staff added via `Shared.add_assigned_staff/3` get a `participants` row but no `conversation_summaries` projection row, so the conversation appears via direct URL (access check passes) but not in `/staff/messages`. Filed as #817 (`[BUG][URGENT]`). Reproduces against both this branch and pre-existing `CreateDirectConversation`/`StaffAssignmentHandler` flows; out of scope for this PR.

## Test Plan

- [x] `mix test test/klass_hero/messaging/application/commands/reply_privately_to_broadcast_test.exs` — 12 pass (8 existing + 4 new)
- [x] `mix test test/klass_hero/messaging/` — 607 pass, no regressions
- [x] `mix precommit` — 4756 pass, 5 skipped, 18 excluded; clean
- [x] Manual smoke via Tidewave: provider + program + assigned staff + parent + broadcast → call `ReplyPrivatelyToBroadcast.execute/2` → verify `participants` table has staff row and `conversations.program_id` is populated for the new direct conversation.
- [x] End-to-end via Playwright: staff sends broadcast → parent replies privately → staff navigates to `/staff/messages/<direct_id>` → page renders without flash redirect (the original #777 symptom).

Closes #777.