### PR TITLE
fix: allow attachments in provider and staff broadcasts (#778)

### DIFF
--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -185,7 +185,6 @@ defmodule KlassHero.Application do
             priority: 10},
            {:conversations_archived,
             {KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}},
-           {:broadcast_sent, {KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}},
            {:retention_enforced, {KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}}
          ]},
         id: :messaging_domain_event_bus

--- a/lib/klass_hero/messaging/adapters/driving/events/event_handlers/notify_live_views.ex
+++ b/lib/klass_hero/messaging/adapters/driving/events/event_handlers/notify_live_views.ex
@@ -15,7 +15,6 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveVi
 
   - `:message_sent`           → `"conversation:{id}"`
   - `:messages_read`          → `"conversation:{id}"`
-  - `:broadcast_sent`         → `"conversation:{id}"`
   - `:conversation_created`   → `"user:{id}:messages"` per participant (fan-out)
   - `:conversations_archived` → `"messaging:bulk_operations"`
   - `:retention_enforced`     → `"messaging:bulk_operations"`
@@ -41,11 +40,6 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveVi
   end
 
   def handle(%DomainEvent{event_type: :messages_read} = event) do
-    topic = conversation_topic(event.payload.conversation_id)
-    SharedNotifyLiveViews.safe_publish(event, topic)
-  end
-
-  def handle(%DomainEvent{event_type: :broadcast_sent} = event) do
     topic = conversation_topic(event.payload.conversation_id)
     SharedNotifyLiveViews.safe_publish(event, topic)
   end

--- a/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
+++ b/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
@@ -88,6 +88,11 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
   defp execute_broadcast(scope, program_id, content, provider_id, opts) do
     subject = Keyword.get(opts, :subject)
     attachments = Keyword.get(opts, :attachments, [])
+    # Trigger: attachment-only broadcast composer submits an empty content string
+    # Why: SendMessage.trim_content/1 preserves "", so the persisted message would
+    #      carry content: "" while attachment-only direct messages carry content: nil
+    # Outcome: attachment-only broadcasts match direct-message behaviour
+    normalized_content = normalize_content(content, attachments)
 
     with :ok <- Shared.maybe_check_entitlement(scope, opts, provider_id: provider_id),
          {:ok, parent_user_ids} <- get_enrolled_parent_user_ids(program_id),
@@ -95,7 +100,7 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
          {:ok, conversation} <- get_or_create_broadcast_conversation(provider_id, program_id, subject),
          :ok <- setup_participants(conversation, scope, parent_user_ids),
          {:ok, message} <-
-           SendMessage.execute(conversation.id, scope.user.id, content,
+           SendMessage.execute(conversation.id, scope.user.id, normalized_content,
              conversation: conversation,
              attachments: attachments
            ) do
@@ -117,6 +122,15 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
 
   defp verify_has_recipients([]), do: {:error, :no_enrollments}
   defp verify_has_recipients(_), do: :ok
+
+  defp normalize_content(nil, _attachments), do: nil
+
+  defp normalize_content(content, attachments) when is_binary(content) do
+    case {String.trim(content), attachments} do
+      {"", [_ | _]} -> nil
+      {trimmed, _} -> trimmed
+    end
+  end
 
   # Trigger: broadcast participants need to be present before SendMessage runs
   # Why: SendMessage.verify_participant rejects senders not in the conversation —

--- a/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
+++ b/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
@@ -5,22 +5,20 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
   This use case:
   1. Checks if the provider can send broadcasts (entitlement check)
   2. Creates or retrieves the program broadcast conversation
-  3. Adds all enrolled parents as participants
-  4. Sends the broadcast message
-  5. Publishes events for real-time updates
+  3. Adds all enrolled parents (and assigned staff) as participants
+  4. Delegates message creation to `SendMessage`, which handles validation,
+     attachment uploads, transactional persistence, and `:message_sent` event
+     publication
   """
 
   alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Application.Commands.SendMessage
   alias KlassHero.Messaging.Application.Shared
-  alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Domain.Models.Conversation
   alias KlassHero.Messaging.Domain.Models.Message
-  alias KlassHero.Repo
-  alias KlassHero.Shared.DomainEventBus
 
   require Logger
 
-  @context KlassHero.Messaging
   @conversation_repo Application.compile_env!(:klass_hero, [
                        :messaging,
                        :for_managing_conversations
@@ -33,7 +31,6 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
                          :messaging,
                          :for_querying_enrollments
                        ])
-  @message_repo Application.compile_env!(:klass_hero, [:messaging, :for_managing_messages])
   @participant_repo Application.compile_env!(:klass_hero, [:messaging, :for_managing_participants])
 
   @doc """
@@ -45,6 +42,8 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
   - content: The message content
   - opts: Optional parameters
     - subject: Subject line for the broadcast
+    - attachments: List of `%{binary, filename, content_type, size}` maps,
+      forwarded verbatim to `SendMessage`
     - provider_id: Explicit provider ID (defaults to scope.provider.id).
       Required when scope.provider is nil (e.g. staff member scopes).
     - skip_entitlement_check: When true, skips the entitlement check.
@@ -54,13 +53,24 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
   - `{:ok, conversation, message, recipient_count}` - Broadcast sent
   - `{:error, :not_entitled}` - Provider cannot send broadcasts
   - `{:error, :no_enrollments}` - No enrolled parents to broadcast to
-  - `{:error, reason}` - Other errors
+  - `{:error, :missing_provider_id}` - Could not resolve a provider_id
+  - `{:error, reason}` - Errors surfaced from `SendMessage` (validation, upload, persistence)
   """
   @spec execute(Scope.t(), String.t(), String.t(), keyword()) ::
           {:ok, Conversation.t(), Message.t(), non_neg_integer()}
-          | {:error, :not_entitled | :no_enrollments | term()}
+          | {:error,
+             :not_entitled
+             | :no_enrollments
+             | :missing_provider_id
+             | :empty_message
+             | :too_many_attachments
+             | :invalid_attachment_type
+             | :attachment_too_large
+             | :upload_failed
+             | :not_participant
+             | :broadcast_reply_not_allowed
+             | term()}
   def execute(%Scope{} = scope, program_id, content, opts \\ []) do
-    subject = Keyword.get(opts, :subject)
     provider_id = Keyword.get(opts, :provider_id) || (scope.provider && scope.provider.id)
 
     if is_nil(provider_id) do
@@ -71,18 +81,25 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
 
       {:error, :missing_provider_id}
     else
-      execute_broadcast(scope, program_id, subject, content, provider_id, opts)
+      execute_broadcast(scope, program_id, content, provider_id, opts)
     end
   end
 
-  defp execute_broadcast(scope, program_id, subject, content, provider_id, opts) do
+  defp execute_broadcast(scope, program_id, content, provider_id, opts) do
+    subject = Keyword.get(opts, :subject)
+    attachments = Keyword.get(opts, :attachments, [])
+
     with :ok <- Shared.maybe_check_entitlement(scope, opts, provider_id: provider_id),
          {:ok, parent_user_ids} <- get_enrolled_parent_user_ids(program_id),
          :ok <- verify_has_recipients(parent_user_ids),
-         {:ok, conversation, message} <-
-           create_broadcast(scope, program_id, subject, content, parent_user_ids, provider_id) do
+         {:ok, conversation} <- get_or_create_broadcast_conversation(provider_id, program_id, subject),
+         :ok <- setup_participants(conversation, scope, parent_user_ids),
+         {:ok, message} <-
+           SendMessage.execute(conversation.id, scope.user.id, content,
+             conversation: conversation,
+             attachments: attachments
+           ) do
       recipient_count = length(parent_user_ids)
-      publish_event(conversation, program_id, provider_id, message.id, recipient_count)
 
       Logger.info("Broadcast sent to program",
         program_id: program_id,
@@ -95,50 +112,27 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
   end
 
   defp get_enrolled_parent_user_ids(program_id) do
-    parent_ids = @enrollment_resolver.get_enrolled_parent_user_ids(program_id)
-    {:ok, parent_ids}
+    {:ok, @enrollment_resolver.get_enrolled_parent_user_ids(program_id)}
   end
 
   defp verify_has_recipients([]), do: {:error, :no_enrollments}
   defp verify_has_recipients(_), do: :ok
 
-  defp create_broadcast(scope, program_id, subject, content, parent_user_ids, provider_id) do
-    # Trigger: get-or-create runs OUTSIDE the transaction
-    # Why: unique constraint violation inside Repo.transaction aborts the Postgres
-    #      transaction — subsequent queries fail with 25P02 (in_failed_sql_transaction)
-    # Outcome: conversation lookup/creation is isolated; only participant + message
-    #          creation needs transactional consistency
-    with {:ok, conversation} <-
-           get_or_create_broadcast_conversation(provider_id, program_id, subject),
-         {:ok, {conversation, message}} <-
-           execute_broadcast_transaction(conversation, scope, content, parent_user_ids) do
-      {:ok, conversation, message}
+  # Trigger: broadcast participants need to be present before SendMessage runs
+  # Why: SendMessage.verify_participant rejects senders not in the conversation —
+  #      provider/staff sender must be added before delegation
+  # Outcome: parents, sender, and assigned staff are participants; partial failure
+  #          is recoverable via idempotent retry (add_batch, add_or_get, projection
+  #          lookup all heal on re-run)
+  defp setup_participants(conversation, scope, parent_user_ids) do
+    with {:ok, _} <- @participant_repo.add_batch(conversation.id, parent_user_ids),
+         {:ok, _} <-
+           @participant_repo.add_or_get(%{
+             conversation_id: conversation.id,
+             user_id: scope.user.id
+           }) do
+      Shared.add_assigned_staff(conversation.id, conversation.program_id, scope.user.id)
     end
-  end
-
-  defp execute_broadcast_transaction(conversation, scope, content, parent_user_ids) do
-    Repo.transaction(fn ->
-      with {:ok, _participants} <-
-             @participant_repo.add_batch(conversation.id, parent_user_ids),
-           {:ok, _} <-
-             @participant_repo.add_or_get(%{
-               conversation_id: conversation.id,
-               user_id: scope.user.id
-             }),
-           :ok <-
-             Shared.add_assigned_staff(conversation.id, conversation.program_id, scope.user.id),
-           {:ok, message} <-
-             @message_repo.create(%{
-               conversation_id: conversation.id,
-               sender_id: scope.user.id,
-               content: String.trim(content),
-               message_type: :text
-             }) do
-        {conversation, message}
-      else
-        {:error, reason} -> Repo.rollback(reason)
-      end
-    end)
   end
 
   defp get_or_create_broadcast_conversation(provider_id, program_id, subject) do
@@ -169,19 +163,5 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
             @conversation_reader.find_active_broadcast_for_program(provider_id, program_id)
         end
     end
-  end
-
-  defp publish_event(conversation, program_id, provider_id, message_id, recipient_count) do
-    event =
-      MessagingEvents.broadcast_sent(
-        conversation.id,
-        program_id,
-        provider_id,
-        message_id,
-        recipient_count
-      )
-
-    DomainEventBus.dispatch(@context, event)
-    :ok
   end
 end

--- a/lib/klass_hero/messaging/domain/events/messaging_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_events.ex
@@ -101,33 +101,6 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   end
 
   @doc """
-  Creates a broadcast_sent event.
-
-  Published when a program broadcast is sent.
-  """
-  @spec broadcast_sent(
-          conversation_id :: String.t(),
-          program_id :: String.t(),
-          provider_id :: String.t(),
-          message_id :: String.t(),
-          recipient_count :: non_neg_integer()
-        ) :: DomainEvent.t()
-  def broadcast_sent(conversation_id, program_id, provider_id, message_id, recipient_count) do
-    DomainEvent.new(
-      :broadcast_sent,
-      conversation_id,
-      @aggregate_type,
-      %{
-        conversation_id: conversation_id,
-        program_id: program_id,
-        provider_id: provider_id,
-        message_id: message_id,
-        recipient_count: recipient_count
-      }
-    )
-  end
-
-  @doc """
   Creates a conversation_archived event.
 
   Published when a conversation is archived.

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -229,6 +229,73 @@ defmodule KlassHeroWeb.MessagingComponents do
   end
 
   @doc """
+  Renders attachment upload affordances for forms outside the chat dock.
+
+  Three stacked sections: per-entry error list, preview chips with cancel +
+  progress, and a labeled "Attach photo" trigger that opens the file picker.
+  Designed to be embedded inside the caller's `<.form>`, sharing the live
+  socket's `:attachments` upload. The caller owns the textarea and submit
+  button.
+  """
+  attr :uploads, :any, required: true
+  attr :label, :string, default: nil
+
+  def attachment_uploader(assigns) do
+    ~H"""
+    <div class="space-y-2">
+      <div :if={upload_errors(@uploads.attachments) != []}>
+        <p
+          :for={err <- upload_errors(@uploads.attachments)}
+          class="text-xs text-red-600"
+        >
+          {upload_error_to_string(err)}
+        </p>
+      </div>
+      <div
+        :if={@uploads.attachments.entries != []}
+        class="flex gap-2 overflow-x-auto"
+      >
+        <div
+          :for={entry <- @uploads.attachments.entries}
+          class="relative flex-shrink-0"
+        >
+          <.live_img_preview
+            entry={entry}
+            class={[
+              "w-16 h-16 rounded-lg object-cover",
+              upload_errors(@uploads.attachments, entry) != [] && "ring-2 ring-red-400"
+            ]}
+          />
+          <button
+            type="button"
+            phx-click="cancel-upload"
+            phx-value-ref={entry.ref}
+            aria-label={gettext("Remove attachment")}
+            class="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-red-500 text-white flex items-center justify-center text-xs shadow-sm"
+          >
+            &times;
+          </button>
+          <div
+            :if={entry.progress > 0 and entry.progress < 100}
+            class="absolute bottom-0 left-0 right-0 h-1 bg-gray-200 rounded-b-lg overflow-hidden"
+          >
+            <div class="h-full bg-hero-blue-600 transition-all" style={"width: #{entry.progress}%"} />
+          </div>
+        </div>
+      </div>
+      <label
+        for={@uploads.attachments.ref}
+        class="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-hero-blue-600 cursor-pointer"
+      >
+        <.icon name="hero-paper-clip" class="w-5 h-5" />
+        <span>{@label || gettext("Attach photo")}</span>
+        <.live_file_input upload={@uploads.attachments} class="hidden" />
+      </label>
+    </div>
+    """
+  end
+
+  @doc """
   Renders a message input form with optional upload support.
 
   When `uploads` is provided, renders attachment previews, a file input button,

--- a/lib/klass_hero_web/live/messaging_live_helper.ex
+++ b/lib/klass_hero_web/live/messaging_live_helper.ex
@@ -465,7 +465,14 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
     cancel_upload(socket, :attachments, ref)
   end
 
-  defp consume_attachment_uploads(socket) do
+  @doc """
+  Consumes pending `:attachments` uploads on the socket, reads each file
+  into memory, and returns a list of file-data maps in the shape expected
+  by `Messaging.send_message/4` and `Messaging.broadcast_to_program/4`:
+  `%{binary, filename, content_type, size}`. Files that fail to read are
+  logged and dropped.
+  """
+  def consume_attachment_uploads(socket) do
     results =
       consume_uploaded_entries(socket, :attachments, fn %{path: path}, entry ->
         case File.read(path) do
@@ -491,18 +498,22 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
     Enum.reject(results, &is_nil/1)
   end
 
-  defp upload_error_message(:empty_message), do: gettext("Please enter a message or attach a photo.")
+  @doc """
+  Translates attachment / message error atoms into user-facing flash messages.
+  Unknown reasons fall through to a generic message.
+  """
+  def upload_error_message(:empty_message), do: gettext("Please enter a message or attach a photo.")
 
-  defp upload_error_message(:too_many_attachments),
+  def upload_error_message(:too_many_attachments),
     do: gettext("Too many files (max %{max}).", max: Attachment.max_per_message())
 
-  defp upload_error_message(:invalid_attachment_type), do: gettext("Only images are accepted (JPG, PNG, GIF, WebP).")
+  def upload_error_message(:invalid_attachment_type), do: gettext("Only images are accepted (JPG, PNG, GIF, WebP).")
 
-  defp upload_error_message(:attachment_too_large),
+  def upload_error_message(:attachment_too_large),
     do: gettext("File is too large (max %{mb} MB).", mb: div(Attachment.max_file_size_bytes(), 1_048_576))
 
-  defp upload_error_message(:upload_failed), do: gettext("Failed to upload files. Please try again.")
-  defp upload_error_message(_), do: gettext("Something went wrong. Please try again.")
+  def upload_error_message(:upload_failed), do: gettext("Failed to upload files. Please try again.")
+  def upload_error_message(_), do: gettext("Something went wrong. Please try again.")
 
   defp subscribe_to_conversation(conversation_id) do
     topic = Messaging.conversation_topic(conversation_id)

--- a/lib/klass_hero_web/live/provider/broadcast_live.ex
+++ b/lib/klass_hero_web/live/provider/broadcast_live.ex
@@ -8,8 +8,11 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
   use KlassHeroWeb, :live_view
 
   alias KlassHero.Messaging
+  alias KlassHero.Messaging.Domain.Models.Attachment
   alias KlassHero.ProgramCatalog
   alias KlassHero.Shared.Entitlements
+  alias KlassHeroWeb.MessagingComponents
+  alias KlassHeroWeb.MessagingLiveHelper
 
   require Logger
 
@@ -39,6 +42,11 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
           |> assign(:program, program)
           |> assign(:form, form)
           |> assign(:sending, false)
+          |> allow_upload(:attachments,
+            accept: ~w(.jpg .jpeg .png .gif .webp),
+            max_entries: Attachment.max_per_message(),
+            max_file_size: Attachment.max_file_size_bytes()
+          )
 
         {:ok, socket}
 
@@ -57,49 +65,68 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
   end
 
   @impl true
+  def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+    {:noreply, MessagingLiveHelper.cancel_attachment_upload(socket, ref)}
+  end
+
+  @impl true
   def handle_event("send_broadcast", %{"subject" => subject, "content" => content}, socket) do
     content = String.trim(content)
     subject = String.trim(subject)
+    attachments = MessagingLiveHelper.consume_attachment_uploads(socket)
 
-    if content == "" do
+    if content == "" and attachments == [] do
       {:noreply, put_flash(socket, :error, gettext("Message content is required"))}
     else
-      socket = assign(socket, :sending, true)
-      scope = socket.assigns.current_scope
-      program_id = socket.assigns.program.id
+      send_broadcast(socket, subject, content, attachments)
+    end
+  end
 
-      opts = if subject == "", do: [], else: [subject: subject]
+  defp send_broadcast(socket, subject, content, attachments) do
+    socket = assign(socket, :sending, true)
+    scope = socket.assigns.current_scope
+    program_id = socket.assigns.program.id
 
-      case Messaging.broadcast_to_program(scope, program_id, content, opts) do
-        {:ok, conversation, _message, recipient_count} ->
-          {:noreply,
-           socket
-           |> put_flash(
-             :info,
-             gettext("Broadcast sent to %{count} parents", count: recipient_count)
-           )
-           |> push_navigate(to: ~p"/provider/messages/#{conversation.id}")}
+    opts =
+      [attachments: attachments] ++
+        if subject == "", do: [], else: [subject: subject]
 
-        {:error, :not_entitled} ->
-          {:noreply,
-           socket
-           |> assign(:sending, false)
-           |> put_flash(:error, gettext("Your subscription tier doesn't support broadcasts"))}
+    case Messaging.broadcast_to_program(scope, program_id, content, opts) do
+      {:ok, conversation, _message, recipient_count} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :info,
+           gettext("Broadcast sent to %{count} parents", count: recipient_count)
+         )
+         |> push_navigate(to: ~p"/provider/messages/#{conversation.id}")}
 
-        {:error, :no_enrollments} ->
-          {:noreply,
-           socket
-           |> assign(:sending, false)
-           |> put_flash(:error, gettext("No parents are enrolled in this program"))}
+      {:error, :not_entitled} ->
+        {:noreply,
+         socket
+         |> assign(:sending, false)
+         |> put_flash(:error, gettext("Your subscription tier doesn't support broadcasts"))}
 
-        {:error, reason} ->
-          Logger.error("Failed to send broadcast", reason: reason)
+      {:error, :no_enrollments} ->
+        {:noreply,
+         socket
+         |> assign(:sending, false)
+         |> put_flash(:error, gettext("No parents are enrolled in this program"))}
 
-          {:noreply,
-           socket
-           |> assign(:sending, false)
-           |> put_flash(:error, gettext("Failed to send broadcast"))}
-      end
+      {:error, reason}
+      when reason in [:too_many_attachments, :invalid_attachment_type, :attachment_too_large, :upload_failed] ->
+        {:noreply,
+         socket
+         |> assign(:sending, false)
+         |> put_flash(:error, MessagingLiveHelper.upload_error_message(reason))}
+
+      {:error, reason} ->
+        Logger.error("Failed to send broadcast", reason: reason)
+
+        {:noreply,
+         socket
+         |> assign(:sending, false)
+         |> put_flash(:error, gettext("Failed to send broadcast"))}
     end
   end
 
@@ -166,6 +193,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
                 placeholder={gettext("Write your message to all enrolled parents...")}
               >{Phoenix.HTML.Form.input_value(@form, :content)}</textarea>
             </div>
+
+            <MessagingComponents.attachment_uploader uploads={@uploads} />
 
             <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
               <div class="flex gap-3">

--- a/lib/klass_hero_web/live/staff/staff_broadcast_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_broadcast_live.ex
@@ -9,9 +9,12 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLive do
   use KlassHeroWeb, :live_view
 
   alias KlassHero.Messaging
+  alias KlassHero.Messaging.Domain.Models.Attachment
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Shared.Entitlements
+  alias KlassHeroWeb.MessagingComponents
+  alias KlassHeroWeb.MessagingLiveHelper
 
   require Logger
 
@@ -63,6 +66,11 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLive do
             |> assign(:provider, provider)
             |> assign(:form, form)
             |> assign(:sending, false)
+            |> allow_upload(:attachments,
+              accept: ~w(.jpg .jpeg .png .gif .webp),
+              max_entries: Attachment.max_per_message(),
+              max_file_size: Attachment.max_file_size_bytes()
+            )
 
           {:ok, socket}
         else
@@ -102,50 +110,72 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLive do
   end
 
   @impl true
+  def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+    {:noreply, MessagingLiveHelper.cancel_attachment_upload(socket, ref)}
+  end
+
+  @impl true
   def handle_event("send_broadcast", %{"subject" => subject, "content" => content}, socket) do
     content = String.trim(content)
     subject = String.trim(subject)
+    attachments = MessagingLiveHelper.consume_attachment_uploads(socket)
 
-    if content == "" do
+    if content == "" and attachments == [] do
       {:noreply, put_flash(socket, :error, gettext("Message content is required"))}
     else
-      socket = assign(socket, :sending, true)
-      scope = socket.assigns.current_scope
-      program_id = socket.assigns.program.id
-      provider_id = socket.assigns.provider.id
+      send_broadcast(socket, subject, content, attachments)
+    end
+  end
 
-      opts =
-        [provider_id: provider_id, skip_entitlement_check: true] ++
-          if(subject == "", do: [], else: [subject: subject])
+  defp send_broadcast(socket, subject, content, attachments) do
+    socket = assign(socket, :sending, true)
+    scope = socket.assigns.current_scope
+    program_id = socket.assigns.program.id
+    provider_id = socket.assigns.provider.id
 
-      case Messaging.broadcast_to_program(scope, program_id, content, opts) do
-        {:ok, conversation, _message, recipient_count} ->
-          {:noreply,
-           socket
-           |> put_flash(
-             :info,
-             gettext("Broadcast sent to %{count} parents", count: recipient_count)
-           )
-           |> push_navigate(to: ~p"/staff/messages/#{conversation.id}")}
+    opts =
+      [provider_id: provider_id, skip_entitlement_check: true, attachments: attachments] ++
+        if(subject == "", do: [], else: [subject: subject])
 
-        {:error, :no_enrollments} ->
-          {:noreply,
-           socket
-           |> assign(:sending, false)
-           |> put_flash(:error, gettext("No parents are enrolled in this program"))}
+    case Messaging.broadcast_to_program(scope, program_id, content, opts) do
+      {:ok, conversation, _message, recipient_count} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :info,
+           gettext("Broadcast sent to %{count} parents", count: recipient_count)
+         )
+         |> push_navigate(to: ~p"/staff/messages/#{conversation.id}")}
 
-        {:error, reason} ->
-          Logger.error("Failed to send staff broadcast",
-            reason: inspect(reason),
-            program_id: program_id,
-            provider_id: provider_id
-          )
+      {:error, :no_enrollments} ->
+        {:noreply,
+         socket
+         |> assign(:sending, false)
+         |> put_flash(:error, gettext("No parents are enrolled in this program"))}
 
-          {:noreply,
-           socket
-           |> assign(:sending, false)
-           |> put_flash(:error, gettext("Failed to send broadcast"))}
-      end
+      {:error, reason}
+      when reason in [
+             :too_many_attachments,
+             :invalid_attachment_type,
+             :attachment_too_large,
+             :upload_failed
+           ] ->
+        {:noreply,
+         socket
+         |> assign(:sending, false)
+         |> put_flash(:error, MessagingLiveHelper.upload_error_message(reason))}
+
+      {:error, reason} ->
+        Logger.error("Failed to send staff broadcast",
+          reason: inspect(reason),
+          program_id: program_id,
+          provider_id: provider_id
+        )
+
+        {:noreply,
+         socket
+         |> assign(:sending, false)
+         |> put_flash(:error, gettext("Failed to send broadcast"))}
     end
   end
 
@@ -202,6 +232,8 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLive do
                 placeholder={gettext("Write your message to all enrolled parents...")}
               >{Phoenix.HTML.Form.input_value(@form, :content)}</textarea>
             </div>
+
+            <MessagingComponents.attachment_uploader uploads={@uploads} />
 
             <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
               <div class="flex gap-3">

--- a/test/e2e/messaging/broadcast_test.exs
+++ b/test/e2e/messaging/broadcast_test.exs
@@ -68,6 +68,10 @@ defmodule KlassHeroWeb.E2E.Messaging.BroadcastTest do
         Query.css("[data-role=message]", text: "Field trip tomorrow at 9am!")
       )
 
+      # Test event publishers don't use PubSub, so the ConversationSummaries
+      # projection never receives the integration event in E2E — rebuild manually.
+      rebuild_summaries()
+
       parent_session
       |> visit_conversations(:parent)
       |> assert_has(Query.css("[data-role=conversation-card]", text: "Field trip tomorrow at 9am!"))
@@ -87,6 +91,10 @@ defmodule KlassHeroWeb.E2E.Messaging.BroadcastTest do
         provider_session,
         Query.css("[data-role=message]", text: "Reminder: bring sunscreen")
       )
+
+      # Test event publishers don't use PubSub, so the ConversationSummaries
+      # projection never receives the integration event in E2E — rebuild manually.
+      rebuild_summaries()
 
       parent_session
       |> visit_conversations(:parent)

--- a/test/e2e/messaging/broadcast_test.exs
+++ b/test/e2e/messaging/broadcast_test.exs
@@ -68,10 +68,6 @@ defmodule KlassHeroWeb.E2E.Messaging.BroadcastTest do
         Query.css("[data-role=message]", text: "Field trip tomorrow at 9am!")
       )
 
-      # Rebuild summaries — broadcast_sent events don't yet emit the
-      # integration events the CQRS projection listens to
-      rebuild_summaries()
-
       parent_session
       |> visit_conversations(:parent)
       |> assert_has(Query.css("[data-role=conversation-card]", text: "Field trip tomorrow at 9am!"))
@@ -91,8 +87,6 @@ defmodule KlassHeroWeb.E2E.Messaging.BroadcastTest do
         provider_session,
         Query.css("[data-role=message]", text: "Reminder: bring sunscreen")
       )
-
-      rebuild_summaries()
 
       parent_session
       |> visit_conversations(:parent)

--- a/test/klass_hero/messaging/adapters/driving/events/event_handlers/notify_live_views_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/events/event_handlers/notify_live_views_test.exs
@@ -48,25 +48,6 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveVi
     end
   end
 
-  describe "handle/1 — :broadcast_sent" do
-    test "publishes to conversation topic" do
-      conversation_id = Ecto.UUID.generate()
-
-      event =
-        DomainEvent.new(:broadcast_sent, conversation_id, :conversation, %{
-          conversation_id: conversation_id,
-          program_id: Ecto.UUID.generate(),
-          provider_id: Ecto.UUID.generate(),
-          message_id: Ecto.UUID.generate(),
-          recipient_count: 5
-        })
-
-      assert :ok = NotifyLiveViews.handle(event)
-
-      assert_event_published(:broadcast_sent, %{conversation_id: conversation_id})
-    end
-  end
-
   describe "handle/1 — :conversation_created" do
     test "fans out to user topic for each participant" do
       conversation_id = Ecto.UUID.generate()

--- a/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
+++ b/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
@@ -300,6 +300,30 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgramTest do
       assert hd(message.attachments).original_filename == "announcement.jpg"
     end
 
+    test "attachment-only broadcast persists nil content" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      for content <- ["", "   "] do
+        assert {:ok, _conversation, message, _count} =
+                 BroadcastToProgram.execute(scope, program.id, content, attachments: [@photo]),
+               "expected attachment-only broadcast to succeed for content #{inspect(content)}"
+
+        assert message.content == nil,
+               "expected content nil for attachment-only broadcast, got #{inspect(message.content)}"
+      end
+    end
+
     test "surfaces SendMessage validation errors" do
       provider = insert(:provider_profile_schema)
       program = insert(:program_schema)

--- a/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
+++ b/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgramTest do
   use KlassHero.DataCase, async: true
 
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
 
   alias KlassHero.Accounts.Scope
@@ -270,8 +271,138 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgramTest do
     end
   end
 
+  describe "execute/4 — attachments" do
+    @photo %{
+      binary: "fake-image-bytes",
+      filename: "announcement.jpg",
+      content_type: "image/jpeg",
+      size: 1_000
+    }
+
+    test "persists attachments alongside the broadcast message" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, _conversation, message, _count} =
+               BroadcastToProgram.execute(scope, program.id, "Look at this!", attachments: [@photo])
+
+      assert length(message.attachments) == 1
+      assert hd(message.attachments).original_filename == "announcement.jpg"
+    end
+
+    test "surfaces SendMessage validation errors" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      too_many =
+        for i <- 1..6 do
+          %{binary: "x", filename: "p#{i}.jpg", content_type: "image/jpeg", size: 1_000}
+        end
+
+      pdf = [%{binary: "x", filename: "doc.pdf", content_type: "application/pdf", size: 1_000}]
+
+      oversized =
+        [%{binary: "x", filename: "huge.jpg", content_type: "image/jpeg", size: 11_000_000}]
+
+      cases = [
+        {too_many, :too_many_attachments},
+        {pdf, :invalid_attachment_type},
+        {oversized, :attachment_too_large}
+      ]
+
+      for {attachments, expected_error} <- cases do
+        assert {:error, ^expected_error} =
+                 BroadcastToProgram.execute(scope, program.id, "Hi", attachments: attachments),
+               "expected #{inspect(expected_error)} for #{length(attachments)} files of type " <>
+                 "#{inspect(Enum.map(attachments, & &1.content_type))}"
+      end
+    end
+  end
+
+  describe "execute/4 — event publishing" do
+    setup do
+      setup_test_events()
+      :ok
+    end
+
+    test "publishes :message_sent with conversation, sender, and content" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, conversation, message, _count} =
+               BroadcastToProgram.execute(scope, program.id, "Announcement")
+
+      assert_event_published(:message_sent, %{
+        conversation_id: conversation.id,
+        message_id: message.id,
+        sender_id: scope.user.id,
+        content: "Announcement"
+      })
+    end
+
+    test "does not publish :broadcast_sent" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, _conv, _msg, _count} =
+               BroadcastToProgram.execute(scope, program.id, "Announcement")
+
+      published_types = Enum.map(get_published_events(), & &1.event_type)
+      refute :broadcast_sent in published_types
+    end
+  end
+
   defp build_scope_with_provider(provider_schema, tier) do
     user = AccountsFixtures.user_fixture()
+
+    # Trigger: factory binds provider row to a throwaway unconfirmed user
+    # Why: SendMessage's provider_owner? check compares scope.user.id against the
+    #      provider row's identity_id; mismatch surfaces as :broadcast_reply_not_allowed
+    # Outcome: rebind the row to our confirmed user so ownership checks pass
+    {:ok, _} =
+      provider_schema
+      |> Ecto.Changeset.change(identity_id: user.id)
+      |> KlassHero.Repo.update()
 
     provider_profile = %ProviderProfile{
       id: provider_schema.id,

--- a/test/klass_hero/messaging/domain/events/messaging_events_test.exs
+++ b/test/klass_hero/messaging/domain/events/messaging_events_test.exs
@@ -88,32 +88,6 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEventsTest do
     end
   end
 
-  describe "broadcast_sent/5" do
-    test "creates event with correct type and payload" do
-      conversation_id = Ecto.UUID.generate()
-      program_id = Ecto.UUID.generate()
-      provider_id = Ecto.UUID.generate()
-      message_id = Ecto.UUID.generate()
-
-      event =
-        MessagingEvents.broadcast_sent(
-          conversation_id,
-          program_id,
-          provider_id,
-          message_id,
-          15
-        )
-
-      assert event.event_type == :broadcast_sent
-      assert event.aggregate_id == conversation_id
-      assert event.aggregate_type == :conversation
-      assert event.payload.program_id == program_id
-      assert event.payload.provider_id == provider_id
-      assert event.payload.message_id == message_id
-      assert event.payload.recipient_count == 15
-    end
-  end
-
   describe "conversation_archived/2" do
     test "creates event with correct type and payload" do
       conversation_id = Ecto.UUID.generate()

--- a/test/klass_hero/messaging/messaging_integration_test.exs
+++ b/test/klass_hero/messaging/messaging_integration_test.exs
@@ -254,6 +254,15 @@ defmodule KlassHero.Messaging.MessagingIntegrationTest do
   defp build_scope_with_provider(provider_schema, tier) do
     user = AccountsFixtures.user_fixture()
 
+    # Trigger: factory binds provider row to a throwaway unconfirmed user
+    # Why: SendMessage's provider_owner? check compares scope.user.id against the
+    #      provider row's identity_id; mismatch surfaces as :broadcast_reply_not_allowed
+    # Outcome: rebind the row to our confirmed user so ownership checks pass
+    {:ok, _} =
+      provider_schema
+      |> Ecto.Changeset.change(identity_id: user.id)
+      |> KlassHero.Repo.update()
+
     provider_profile = %ProviderProfile{
       id: provider_schema.id,
       identity_id: user.id,

--- a/test/klass_hero_web/live/provider/broadcast_live_test.exs
+++ b/test/klass_hero_web/live/provider/broadcast_live_test.exs
@@ -185,6 +185,53 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
     end
   end
 
+  describe "broadcast with attachments" do
+    setup :register_and_log_in_provider
+
+    @png_bytes <<137, 80, 78, 71, 13, 10, 26, 10>>
+
+    test "renders the attachment uploader trigger", %{conn: conn} do
+      program = insert(:program_schema)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
+
+      assert has_element?(view, "label", "Attach photo")
+      assert has_element?(view, "input[type='file']")
+    end
+
+    test "sends broadcast with photo attachment and navigates to conversation", %{conn: conn} do
+      program = insert(:program_schema)
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
+
+      photo =
+        file_input(view, "#broadcast-form", :attachments, [
+          %{name: "announcement.jpg", content: @png_bytes, type: "image/jpeg"}
+        ])
+
+      render_upload(photo, "announcement.jpg")
+
+      view
+      |> form("#broadcast-form", %{
+        "subject" => "",
+        "content" => "Check this out"
+      })
+      |> render_submit()
+
+      {path, flash} = assert_redirect(view)
+      assert path =~ "/provider/messages/"
+      assert flash["info"] =~ "Broadcast sent"
+    end
+  end
+
   describe "cancel navigation" do
     setup :register_and_log_in_provider
 

--- a/test/klass_hero_web/live/staff/staff_broadcast_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_broadcast_live_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLiveTest do
   import KlassHero.AccountsFixtures
   import KlassHero.Factory, only: [insert: 2]
   import KlassHero.ProviderFixtures
+  import Phoenix.LiveViewTest
 
   describe "staff broadcast (entitled)" do
     setup %{conn: conn} do
@@ -67,6 +68,38 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLiveTest do
 
       {path, _flash} = assert_redirect(view)
       assert path =~ "/staff/messages/"
+    end
+
+    @png_bytes <<137, 80, 78, 71, 13, 10, 26, 10>>
+
+    test "renders the attachment uploader trigger", %{conn: conn, program: program} do
+      {:ok, view, _html} = live(conn, ~p"/staff/programs/#{program.id}/broadcast")
+
+      assert has_element?(view, "label", "Attach photo")
+      assert has_element?(view, "input[type='file']")
+    end
+
+    test "sends broadcast with photo attachment and navigates to staff messages",
+         %{conn: conn, program: program} do
+      {:ok, view, _html} = live(conn, ~p"/staff/programs/#{program.id}/broadcast")
+
+      photo =
+        file_input(view, "#staff-broadcast-form", :attachments, [
+          %{name: "team_photo.jpg", content: @png_bytes, type: "image/jpeg"}
+        ])
+
+      render_upload(photo, "team_photo.jpg")
+
+      view
+      |> form("#staff-broadcast-form", %{
+        "subject" => "",
+        "content" => "Look at the team!"
+      })
+      |> render_submit()
+
+      {path, flash} = assert_redirect(view)
+      assert path =~ "/staff/messages/"
+      assert flash["info"] =~ "Broadcast sent"
     end
 
     test "rejects broadcast for non-assigned program", %{conn: conn, provider: provider} do


### PR DESCRIPTION
Closes #778.

## Summary

- Provider + staff broadcast composers gain photo attachments (same limits as direct messages: 5 files, 10 MB each, JPG/PNG/GIF/WebP).
- `BroadcastToProgram` now orchestrates participant setup, then delegates message authoring to `SendMessage`. Single source of truth for validation, S3 upload, transactional persist + attachment cleanup.
- Drops `:broadcast_sent` (zero non-test consumers) in favour of `:message_sent`. Side benefit: `ConversationSummaries.project_message_sent/1` now increments unread counts for broadcast recipients — closing the gap documented by the `rebuild_summaries()` workaround in `test/e2e/messaging/broadcast_test.exs`.
- Extracts a reusable `MessagingComponents.attachment_uploader/1` (error list + preview chips + paperclip trigger) and promotes `MessagingLiveHelper.consume_attachment_uploads/1` + `upload_error_message/1` to public.

## Review focus

- **Atomicity shift** in `BroadcastToProgram.execute/4` — outer `Repo.transaction` removed. Each unit (participant add, SendMessage's own persist tx) is independently durable; partial failure is recoverable via idempotent `add_batch` + `find_active_broadcast_for_program` retry. Validated with the user that eventual consistency is acceptable for this surface.
- **Event surface change** — `MessagingEvents.broadcast_sent/5`, the `NotifyLiveViews` clause, and the bus registration all gone. Audited consumers across `lib/` + projection GenServers before deleting (only `NotifyLiveViews` referenced it, same topic as `:message_sent`).
- **Test helper rebind** in `broadcast_to_program_test.exs` + `messaging_integration_test.exs` — pre-existing bug surfaced by `SendMessage`'s defense-in-depth `provider_owner?` check. Helper now updates the inserted provider row's `identity_id` to match the scope user.

## Test plan

- [x] `mix precommit` — 4767 passed, 5 skipped (unchanged)
- [x] `mix test test/klass_hero/messaging/` — 612 passed (down 2 from deleted dead-event tests)
- [x] `mix test test/klass_hero_web/live/provider/broadcast_live_test.exs` — 16 passed (+2 upload tests)
- [x] `mix test test/klass_hero_web/live/staff/staff_broadcast_live_test.exs` — 6 passed (+2 upload tests)
- [x] Manual flow (Playwright + MinIO): provider sends broadcast with PNG attachment, flash "Broadcast sent to N parents" appears, redirected to conversation, image renders inline

## Follow-up issues to file

1. Refactor `messaging_components.ex`'s `message_input/1` to compose `attachment_uploader/1` (consolidate the two upload-UI sites).
2. Wire `StubStorageAdapter` Agent lifecycle into broader messaging test setup if S3 stub coverage expands.
3. Tidy `notify_live_views.ex` topic doc block now that `:broadcast_sent` is gone.