### PR TITLE
fix: allow single-day workshops in program date validation

### DIFF
--- a/lib/klass_hero/program_catalog/adapters/driven/persistence/schemas/program_schema.ex
+++ b/lib/klass_hero/program_catalog/adapters/driven/persistence/schemas/program_schema.ex
@@ -274,21 +274,22 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramSc
     end
   end
 
-  # Trigger: start_date is on or after end_date
-  # Why: a program's start must precede its end for a valid date range
+  # Trigger: start_date is strictly after end_date
+  # Why: a program's start must be on or before its end (single-day programs allowed)
   # Outcome: changeset error on start_date
   defp validate_date_range(changeset) do
     start_date = get_field(changeset, :start_date)
     end_date = get_field(changeset, :end_date)
 
-    if is_nil(start_date) or is_nil(end_date) do
-      changeset
-    else
-      if Date.before?(start_date, end_date) do
+    cond do
+      is_nil(start_date) or is_nil(end_date) ->
         changeset
-      else
-        add_error(changeset, :start_date, "must be before end date")
-      end
+
+      Date.after?(start_date, end_date) ->
+        add_error(changeset, :start_date, "must be on or before end date")
+
+      true ->
+        changeset
     end
   end
 

--- a/lib/klass_hero/program_catalog/domain/models/program.ex
+++ b/lib/klass_hero/program_catalog/domain/models/program.ex
@@ -350,10 +350,10 @@ defmodule KlassHero.ProgramCatalog.Domain.Models.Program do
   defp validate_date_range(errors, _, nil), do: errors
 
   defp validate_date_range(errors, %Date{} = start_date, %Date{} = end_date) do
-    if Date.before?(start_date, end_date) do
-      errors
+    if Date.after?(start_date, end_date) do
+      ["start_date must be on or before end_date" | errors]
     else
-      ["start_date must be before end_date" | errors]
+      errors
     end
   end
 

--- a/test/klass_hero/program_catalog/adapters/driven/persistence/schemas/program_schema_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/persistence/schemas/program_schema_test.exs
@@ -221,7 +221,7 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramSc
       assert changeset.valid?
     end
 
-    test "rejects start_date on or after end_date" do
+    test "rejects start_date strictly after end_date" do
       attrs =
         valid_changeset_attrs(%{
           start_date: ~D[2026-07-01],
@@ -230,7 +230,18 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramSc
 
       changeset = ProgramSchema.changeset(%ProgramSchema{}, attrs)
       refute changeset.valid?
-      assert "must be before end date" in errors_on(changeset).start_date
+      assert "must be on or before end date" in errors_on(changeset).start_date
+    end
+
+    test "accepts equal start_date and end_date (single-day workshop)" do
+      attrs =
+        valid_changeset_attrs(%{
+          start_date: ~D[2026-06-15],
+          end_date: ~D[2026-06-15]
+        })
+
+      changeset = ProgramSchema.changeset(%ProgramSchema{}, attrs)
+      assert changeset.valid?
     end
 
     test "allows start_date without end_date" do

--- a/test/klass_hero/program_catalog/domain/models/program_test.exs
+++ b/test/klass_hero/program_catalog/domain/models/program_test.exs
@@ -827,7 +827,7 @@ defmodule KlassHero.ProgramCatalog.Domain.Models.ProgramTest do
       assert Enum.any?(errors, &String.contains?(&1, "time"))
     end
 
-    test "rejects start_date after end_date" do
+    test "rejects start_date strictly after end_date" do
       attrs =
         scheduling_attrs(%{
           start_date: ~D[2026-06-30],
@@ -835,20 +835,18 @@ defmodule KlassHero.ProgramCatalog.Domain.Models.ProgramTest do
         })
 
       assert {:error, errors} = Program.create(attrs)
-      assert Enum.any?(errors, &String.contains?(&1, "date"))
+      assert "start_date must be on or before end_date" in errors
     end
 
-    test "rejects equal start_date and end_date (single-day programs not allowed)" do
+    test "accepts equal start_date and end_date (single-day workshop)" do
       attrs =
         scheduling_attrs(%{
           start_date: ~D[2026-03-15],
           end_date: ~D[2026-03-15]
         })
 
-      # Trigger: Date.before?/2 returns false for equal dates
-      # Why: documents that the validation intentionally rejects same-day ranges
-      assert {:error, errors} = Program.create(attrs)
-      assert Enum.any?(errors, &String.contains?(&1, "date"))
+      assert {:ok, %Program{start_date: ~D[2026-03-15], end_date: ~D[2026-03-15]}} =
+               Program.create(attrs)
     end
 
     test "rejects invalid date types" do


### PR DESCRIPTION
## Summary

- Flipped `Date.before?/2` to `Date.after?/2` in `Program.validate_date_range/3` so equal start/end dates are accepted as a single-day workshop, updating the error string to "start_date must be on or before end_date".
- Mirrored the same fix at the persistence boundary in `ProgramSchema.validate_date_range/1` (lib/klass_hero/program_catalog/adapters/driven/persistence/schemas/program_schema.ex:280-296), collapsing nested `if/else` into a flat `cond` and updating the changeset error to "must be on or before end date".
- Updated and split tests to lock in the new behaviour: domain test flipped from "rejects equal" to "accepts equal" (single-day workshop) plus tightened error-string assertion; schema test split into separate strict-after rejection and positive equal-dates acceptance cases.

Closes #794.

## Review Focus

- **Two-layer fix, not one** — `Program.validate_date_range/3` (lib/klass_hero/program_catalog/domain/models/program.ex:352-358) and `ProgramSchema.validate_date_range/1` (program_schema.ex:280-296) duplicate the same invariant. Both layers had to flip or persistence would silently still reject. Spot-check both messages and predicates match.
- **Out of scope: registration window** — `RegistrationPeriod.new/1` (registration_period.ex:69) still rejects equal `start_date`/`end_date` for the registration window. Different invariant (zero-day signup window vs zero-day workshop) — intentionally left alone. Confirm reviewer agrees this should be a separate ticket if revisited.
- **Error-message wording change** — both layers' user-facing strings changed. No Gettext entries existed (audited `priv/gettext/`) and no LiveView template binds these strings (audited `lib/klass_hero_web/`), so this is a code-internal change with no i18n impact. Confirm no admin UI surface (e.g. Backpex) regresses.
- **Schema-layer refactor** — `program_schema.ex:283-296` swaps a nested `if/else` for a single `cond`. Behaviour-identical; verify the three branches (nil-skip, invariant-violated, default-pass) read correctly.

## Test Plan

- [x] `mix precommit` — 4769 passed, 5 skipped, 18 excluded
- [x] Tidewave REPL verification: `Program.create/1` with `start_date == end_date == ~D[2026-06-15]` returns `{:ok, %Program{}}`
- [x] Tidewave REPL verification: `Program.create/1` with `start_date > end_date` still returns `{:error, ["start_date must be on or before end_date"]}`
- [ ] Manual UI smoke: provider creates a workshop with both dates equal in the provider dashboard — expect successful save, no inline error on `start_date`
- [ ] Manual UI smoke: provider creates a workshop with start strictly after end — expect inline error reading "must be on or before end date"