### PR TITLE
fix: clear participant restrictions on edit (#795)

### DIFF
--- a/lib/klass_hero_web/components/program_components.ex
+++ b/lib/klass_hero_web/components/program_components.ex
@@ -515,12 +515,15 @@ defmodule KlassHeroWeb.ProgramComponents do
 
   def restriction_info(assigns) do
     ~H"""
-    <div class={[
-      Theme.bg(:surface),
-      Theme.rounded(:xl),
-      "shadow-sm border overflow-hidden",
-      Theme.border_color(:light)
-    ]}>
+    <div
+      :if={has_any_restriction?(@policy)}
+      class={[
+        Theme.bg(:surface),
+        Theme.rounded(:xl),
+        "shadow-sm border overflow-hidden",
+        Theme.border_color(:light)
+      ]}
+    >
       <div class={["p-4 border-b", Theme.border_color(:light)]}>
         <h3 class={["font-semibold flex items-center gap-2", Theme.text_color(:heading)]}>
           <.icon name="hero-shield-check" class="w-5 h-5 text-hero-blue-500" />
@@ -549,6 +552,20 @@ defmodule KlassHeroWeb.ProgramComponents do
     </div>
     """
   end
+
+  # Trigger: every restriction field on the policy is empty
+  # Why: rendering the card heading with no body confuses providers (issue #795)
+  # Outcome: caller renders nothing when the policy carries no restrictions
+  defp has_any_restriction?(%{
+         min_age_months: nil,
+         max_age_months: nil,
+         min_grade: nil,
+         max_grade: nil,
+         allowed_genders: genders
+       })
+       when genders in [nil, []], do: false
+
+  defp has_any_restriction?(_policy), do: true
 
   @doc false
   defp format_age_restriction(%{min_age_months: min, max_age_months: max}) when not is_nil(min) and not is_nil(max) do

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -2230,9 +2230,14 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
 
   defp any_restriction?(_parsed), do: true
 
-  # Trigger: eligibility_at is NOT NULL with a check constraint at the DB layer
-  # Why: forwarding `nil` would null-out the column on conflict and violate the constraint
-  # Outcome: dropping the key lets the mapper preserve the existing value / schema default
+  # Trigger: eligibility_at parsed as nil — only reachable via malformed callers;
+  #   the LiveView form always submits one of the radio values
+  # Why: forwarding `nil` would violate the column's NOT NULL + check constraint;
+  #   the repo's on_conflict {:replace, [:eligibility_at, ...]} would *not* preserve
+  #   any stored value either, so we don't pretend to.
+  # Outcome: drop the key so the INSERT falls back to the schema default
+  #   ("registration"); on conflict that default still replaces any stored value,
+  #   which is acceptable because the form makes nil unreachable in practice.
   defp drop_nil_eligibility_at(%{eligibility_at: nil} = attrs), do: Map.delete(attrs, :eligibility_at)
 
   defp drop_nil_eligibility_at(attrs), do: attrs

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -949,7 +949,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     with {:ok, attrs} <- maybe_add_instructor(attrs, program_params["instructor_id"], socket),
          {:ok, program} <- ProgramCatalog.create_program(attrs, socket.assigns.current_scope.provider) do
       policy_result = maybe_set_enrollment_policy(program.id, enrollment_params)
-      maybe_set_participant_policy(program.id, participant_policy_params)
+      set_participant_policy_on_create(program.id, participant_policy_params)
       capacity = resolve_capacity(policy_result, enrollment_params)
 
       new_enrollment_data = %{
@@ -1007,7 +1007,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     with {:ok, attrs} <- maybe_add_instructor(attrs, program_params["instructor_id"], socket),
          {:ok, updated} <- ProgramCatalog.update_program(program_id, attrs) do
       policy_result = maybe_set_enrollment_policy(program_id, enrollment_params)
-      maybe_set_participant_policy(program_id, participant_policy_params)
+      set_participant_policy_on_update(program_id, participant_policy_params)
 
       # Trigger: need enrollment data for the table view
       # Why: preserve existing enrollment count, update capacity from policy
@@ -2169,44 +2169,73 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     end
   end
 
-  # Trigger: all restriction fields are empty/nil
-  # Why: no policy needed when provider doesn't set any participant restrictions
-  # Outcome: skip policy creation, return :ok
-  defp maybe_set_participant_policy(program_id, params) do
-    case build_participant_policy_attrs(program_id, params) do
+  # Trigger: program just created and has no policy row yet
+  # Why: avoid persisting an all-nil policy when the provider set no restrictions
+  # Outcome: skip the upsert entirely if every restriction field is empty
+  defp set_participant_policy_on_create(program_id, params) do
+    parsed = parse_participant_policy_params(params)
+
+    case build_create_policy_attrs(program_id, parsed) do
       nil -> :ok
       attrs -> save_participant_policy(attrs, program_id)
     end
   end
 
-  defp build_participant_policy_attrs(program_id, params) do
-    min_age = parse_integer(params["min_age_months"])
-    max_age = parse_integer(params["max_age_months"])
-    min_grade = parse_integer(params["min_grade"])
-    max_grade = parse_integer(params["max_grade"])
-    eligibility_at = presence(params["eligibility_at"])
+  # Trigger: existing program edit — must allow clearing previously stored restrictions
+  # Why: short-circuiting on all-empty would leave stale DB values in place (issue #795)
+  # Outcome: always upsert, carrying explicit nils so on_conflict replaces stored values
+  defp set_participant_policy_on_update(program_id, params) do
+    parsed = parse_participant_policy_params(params)
 
-    # Trigger: hidden input for checkboxes sends [""] when none checked
-    # Why: must filter out empty strings to detect truly empty gender selection
-    # Outcome: clean list of selected gender values
-    allowed_genders =
-      (params["allowed_genders"] || [])
-      |> Enum.reject(&(&1 == ""))
+    program_id
+    |> build_update_policy_attrs(parsed)
+    |> save_participant_policy(program_id)
+  end
 
-    has_any_restriction =
-      !is_nil(min_age) or !is_nil(max_age) or !is_nil(min_grade) or
-        !is_nil(max_grade) or allowed_genders != []
+  defp parse_participant_policy_params(params) do
+    %{
+      eligibility_at: presence(params["eligibility_at"]),
+      min_age_months: parse_integer(params["min_age_months"]),
+      max_age_months: parse_integer(params["max_age_months"]),
+      min_grade: parse_integer(params["min_grade"]),
+      max_grade: parse_integer(params["max_grade"]),
+      # Trigger: hidden input for checkbox group sends [""] when none checked
+      # Why: must filter empty strings to detect truly empty gender selection
+      # Outcome: clean list of selected gender values
+      allowed_genders: Enum.reject(params["allowed_genders"] || [], &(&1 == ""))
+    }
+  end
 
-    if has_any_restriction do
-      %{program_id: program_id}
-      |> maybe_put(:eligibility_at, eligibility_at)
-      |> maybe_put(:min_age_months, min_age)
-      |> maybe_put(:max_age_months, max_age)
-      |> maybe_put(:allowed_genders, if(allowed_genders != [], do: allowed_genders))
-      |> maybe_put(:min_grade, min_grade)
-      |> maybe_put(:max_grade, max_grade)
+  defp build_create_policy_attrs(program_id, parsed) do
+    if any_restriction?(parsed) do
+      parsed
+      |> Map.put(:program_id, program_id)
+      |> drop_nil_eligibility_at()
     end
   end
+
+  defp build_update_policy_attrs(program_id, parsed) do
+    parsed
+    |> Map.put(:program_id, program_id)
+    |> drop_nil_eligibility_at()
+  end
+
+  defp any_restriction?(%{
+         min_age_months: nil,
+         max_age_months: nil,
+         min_grade: nil,
+         max_grade: nil,
+         allowed_genders: []
+       }), do: false
+
+  defp any_restriction?(_parsed), do: true
+
+  # Trigger: eligibility_at is NOT NULL with a check constraint at the DB layer
+  # Why: forwarding `nil` would null-out the column on conflict and violate the constraint
+  # Outcome: dropping the key lets the mapper preserve the existing value / schema default
+  defp drop_nil_eligibility_at(%{eligibility_at: nil} = attrs), do: Map.delete(attrs, :eligibility_at)
+
+  defp drop_nil_eligibility_at(attrs), do: attrs
 
   defp save_participant_policy(attrs, program_id) do
     case Enrollment.set_participant_policy(attrs) do
@@ -2246,9 +2275,6 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
       gettext("Program created, but enrollment capacity could not be saved. Edit the program to retry.")
     )
   end
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp parse_integer(nil), do: nil
   defp parse_integer(""), do: nil

--- a/test/klass_hero/enrollment/adapters/driven/persistence/repositories/participant_policy_repository_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/persistence/repositories/participant_policy_repository_test.exs
@@ -58,6 +58,38 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.Particip
                  max_age_months: 120
                })
     end
+
+    test "clears all restriction fields when subsequent upsert passes nils" do
+      program = insert(:program_schema)
+
+      {:ok, _initial} =
+        ParticipantPolicyRepository.upsert(%{
+          program_id: program.id,
+          eligibility_at: "program_start",
+          min_age_months: 60,
+          max_age_months: 144,
+          allowed_genders: ["female"],
+          min_grade: 1,
+          max_grade: 4
+        })
+
+      {:ok, cleared} =
+        ParticipantPolicyRepository.upsert(%{
+          program_id: program.id,
+          min_age_months: nil,
+          max_age_months: nil,
+          allowed_genders: [],
+          min_grade: nil,
+          max_grade: nil
+        })
+
+      assert cleared.min_age_months == nil
+      assert cleared.max_age_months == nil
+      assert cleared.allowed_genders == []
+      assert cleared.min_grade == nil
+      assert cleared.max_grade == nil
+      assert cleared.eligibility_at in ["program_start", "registration"]
+    end
   end
 
   describe "get_by_program_id/1" do

--- a/test/klass_hero_web/components/program_components_test.exs
+++ b/test/klass_hero_web/components/program_components_test.exs
@@ -1,0 +1,75 @@
+defmodule KlassHeroWeb.ProgramComponentsTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Enrollment.Domain.Models.ParticipantPolicy
+  alias KlassHeroWeb.ProgramComponents
+
+  describe "restriction_info/1" do
+    test "renders nothing when policy has no restrictions" do
+      policy = %ParticipantPolicy{
+        program_id: "00000000-0000-0000-0000-000000000000",
+        eligibility_at: "registration",
+        min_age_months: nil,
+        max_age_months: nil,
+        allowed_genders: [],
+        min_grade: nil,
+        max_grade: nil
+      }
+
+      html = render_component(&ProgramComponents.restriction_info/1, %{policy: policy})
+
+      refute html =~ "Participant Requirements"
+      assert String.trim(html) == ""
+    end
+
+    test "renders the card when any age restriction is set" do
+      policy = %ParticipantPolicy{
+        program_id: "00000000-0000-0000-0000-000000000000",
+        eligibility_at: "registration",
+        min_age_months: 48,
+        max_age_months: 120,
+        allowed_genders: [],
+        min_grade: nil,
+        max_grade: nil
+      }
+
+      html = render_component(&ProgramComponents.restriction_info/1, %{policy: policy})
+
+      assert html =~ "Participant Requirements"
+    end
+
+    test "renders the card when only allowed_genders is set" do
+      policy = %ParticipantPolicy{
+        program_id: "00000000-0000-0000-0000-000000000000",
+        eligibility_at: "registration",
+        min_age_months: nil,
+        max_age_months: nil,
+        allowed_genders: ["female"],
+        min_grade: nil,
+        max_grade: nil
+      }
+
+      html = render_component(&ProgramComponents.restriction_info/1, %{policy: policy})
+
+      assert html =~ "Participant Requirements"
+    end
+
+    test "renders the card when only grade restriction is set" do
+      policy = %ParticipantPolicy{
+        program_id: "00000000-0000-0000-0000-000000000000",
+        eligibility_at: "registration",
+        min_age_months: nil,
+        max_age_months: nil,
+        allowed_genders: [],
+        min_grade: 1,
+        max_grade: 4
+      }
+
+      html = render_component(&ProgramComponents.restriction_info/1, %{policy: policy})
+
+      assert html =~ "Participant Requirements"
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_live_test.exs
@@ -1161,6 +1161,125 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
     end
   end
 
+  describe "edit program - clearing participant restrictions" do
+    setup %{provider: provider} do
+      provider
+      |> Ecto.Changeset.change(
+        verified: true,
+        verified_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+      |> KlassHero.Repo.update!()
+
+      %{}
+    end
+
+    test "clears stored restrictions when all fields submitted blank", %{
+      conn: conn,
+      provider: provider
+    } do
+      program =
+        insert_program_with_listing(
+          provider_id: provider.id,
+          title: "Restricted Program"
+        )
+
+      {:ok, _policy} =
+        KlassHero.Enrollment.set_participant_policy(%{
+          program_id: program.id,
+          eligibility_at: "registration",
+          min_age_months: 60,
+          max_age_months: 144,
+          allowed_genders: ["female"],
+          min_grade: 1,
+          max_grade: 4
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view
+      |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+      |> render_click()
+
+      assert has_element?(view, "#program-form")
+
+      view
+      |> render_submit("save_program", %{
+        "program_schema" =>
+          valid_program_params(%{
+            "title" => "Restricted Program",
+            "meeting_start_time" => "09:00",
+            "meeting_end_time" => "11:00"
+          }),
+        "enrollment_policy" => %{},
+        "participant_policy" => %{
+          "eligibility_at" => "registration",
+          "min_age_months" => "",
+          "max_age_months" => "",
+          "allowed_genders" => [""],
+          "min_grade" => "",
+          "max_grade" => ""
+        }
+      })
+
+      assert_flash(view, :info, "Program updated successfully.")
+
+      assert {:ok, cleared} = KlassHero.Enrollment.get_participant_policy(to_string(program.id))
+      assert cleared.min_age_months == nil
+      assert cleared.max_age_months == nil
+      assert cleared.allowed_genders == []
+      assert cleared.min_grade == nil
+      assert cleared.max_grade == nil
+    end
+
+    test "upserts an empty policy when no prior policy existed", %{
+      conn: conn,
+      provider: provider
+    } do
+      program =
+        insert_program_with_listing(
+          provider_id: provider.id,
+          title: "Unrestricted Program"
+        )
+
+      assert {:error, :not_found} =
+               KlassHero.Enrollment.get_participant_policy(to_string(program.id))
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view
+      |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+      |> render_click()
+
+      view
+      |> render_submit("save_program", %{
+        "program_schema" =>
+          valid_program_params(%{
+            "title" => "Unrestricted Program",
+            "meeting_start_time" => "09:00",
+            "meeting_end_time" => "11:00"
+          }),
+        "enrollment_policy" => %{},
+        "participant_policy" => %{
+          "eligibility_at" => "registration",
+          "min_age_months" => "",
+          "max_age_months" => "",
+          "allowed_genders" => [""],
+          "min_grade" => "",
+          "max_grade" => ""
+        }
+      })
+
+      assert_flash(view, :info, "Program updated successfully.")
+
+      assert {:ok, policy} = KlassHero.Enrollment.get_participant_policy(to_string(program.id))
+      assert policy.min_age_months == nil
+      assert policy.max_age_months == nil
+      assert policy.allowed_genders == []
+      assert policy.min_grade == nil
+      assert policy.max_grade == nil
+    end
+  end
+
   # ===========================================================================
   # T4: roster send message button
   # ===========================================================================


### PR DESCRIPTION
## Summary
- Edit-program flow always upserts the participant policy with explicit nils so the repository's `on_conflict: {:replace, [...]}` clears stored restrictions when the provider blanks every field.
- Create-program flow keeps the existing skip-when-empty behaviour so fresh programs without restrictions don't get empty policy rows.
- `restriction_info/1` now hides itself when the policy carries no restrictions, defending against any all-nil policy row (legacy or new).

## Review Focus
- `lib/klass_hero_web/live/provider/dashboard_live.ex` — split `maybe_set_participant_policy/2` into `set_participant_policy_on_create/2` and `set_participant_policy_on_update/2`; new parser + builder helpers (`parse_participant_policy_params/1`, `build_create_policy_attrs/2`, `build_update_policy_attrs/2`, `any_restriction?/1`, `drop_nil_eligibility_at/1`). Note that `eligibility_at` is dropped when nil so the `NOT NULL` + check constraint at the DB layer is preserved.
- `lib/klass_hero_web/components/program_components.ex` — `:if`-guarded card + private `has_any_restriction?/1` multi-clause predicate.

## Test plan
- [x] `mix test test/klass_hero/enrollment/adapters/driven/persistence/repositories/participant_policy_repository_test.exs` (repo upsert clears fields when nils passed)
- [x] `mix test test/klass_hero_web/live/provider/dashboard_live_test.exs` (clear-on-edit + edit-upserts-empty-when-no-prior-policy)
- [x] `mix test test/klass_hero_web/components/program_components_test.exs` (empty policy renders nothing; populated policy renders heading)
- [x] `mix precommit` (4776 passed, 0 warnings, typography lint clean)
- [ ] Manual smoke via provider dashboard: set min/max grade, save → card visible; edit, clear both fields, save → card gone; verify `participant_policies` row reflects the clear

Closes #795