### PR TITLE
fix: display assigned instructor on program detail page

### DIFF
--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -36,6 +36,7 @@ defmodule KlassHero.ProgramCatalog do
     top_level?: true,
     deps: [KlassHero, KlassHero.Provider, KlassHero.Shared, KlassHero.Enrollment],
     exports: [
+      Domain.Models.Instructor,
       Domain.Models.Program,
       Domain.ReadModels.ProgramListing,
       Domain.Services.ProgramCategories

--- a/lib/klass_hero/program_catalog/domain/models/instructor.ex
+++ b/lib/klass_hero/program_catalog/domain/models/instructor.ex
@@ -19,6 +19,14 @@ defmodule KlassHero.ProgramCatalog.Domain.Models.Instructor do
           headshot_url: String.t() | nil
         }
 
+  @spec initials(t()) :: String.t()
+  def initials(%__MODULE__{name: name}) do
+    name
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.take(2)
+    |> Enum.map_join("", fn token -> token |> String.first() |> String.upcase() end)
+  end
+
   @spec new(map()) :: {:ok, t()} | {:error, [String.t()]}
   def new(attrs) when is_map(attrs) do
     attrs_with_defaults = Map.put_new(attrs, :headshot_url, nil)

--- a/lib/klass_hero_web/components/program_components.ex
+++ b/lib/klass_hero_web/components/program_components.ex
@@ -615,6 +615,101 @@ defmodule KlassHeroWeb.ProgramComponents do
     end
   end
 
+  @doc """
+  Renders a hero card for an instructor or staff member on the program detail page.
+
+  Accepts a plain prop map so both `Instructor` (sparse: only `id`/`name`/`initials`)
+  and `StaffMember` (rich: role/bio/tags/qualifications) can share one component.
+  Optional fields are gracefully hidden when `nil` or `[]`.
+
+  ## Examples
+
+      <.hero_card
+        id="hero-card-instructor-abc123"
+        name="Ada Lovelace"
+        initials="AL"
+        headshot_url={nil}
+        badge="Lead Instructor"
+      />
+  """
+  attr :id, :string, required: true
+  attr :name, :string, required: true
+  attr :initials, :string, required: true
+  attr :headshot_url, :string, default: nil
+  attr :role, :string, default: nil
+  attr :bio, :string, default: nil
+  attr :tags, :list, default: []
+  attr :qualifications, :list, default: []
+  attr :badge, :string, default: nil
+
+  def hero_card(assigns) do
+    ~H"""
+    <div id={@id} class="flex items-start space-x-4">
+      <img
+        :if={@headshot_url}
+        src={@headshot_url}
+        alt={@name}
+        class={["w-16 h-16 object-cover flex-shrink-0", Theme.rounded(:full)]}
+      />
+      <div
+        :if={!@headshot_url}
+        class={[
+          "w-16 h-16 flex items-center justify-center text-white text-xl font-bold flex-shrink-0",
+          Theme.rounded(:full),
+          Theme.gradient(:primary)
+        ]}
+      >
+        {@initials}
+      </div>
+      <div class="flex-1">
+        <span
+          :if={@badge}
+          class={[
+            "inline-block px-2 py-0.5 mb-1 text-xs font-semibold uppercase tracking-wide bg-hero-blue-100 text-hero-blue-700",
+            Theme.rounded(:full)
+          ]}
+        >
+          {@badge}
+        </span>
+        <h4 class={["font-semibold", Theme.text_color(:heading)]}>
+          {@name}
+        </h4>
+        <p :if={@role} class={["text-sm mb-2", Theme.text_color(:muted)]}>
+          {@role}
+        </p>
+        <p
+          :if={@bio}
+          class={["text-sm leading-relaxed mb-3", Theme.text_color(:secondary)]}
+        >
+          {@bio}
+        </p>
+        <div :if={@tags != []} class="flex flex-wrap gap-1.5 mb-2">
+          <span
+            :for={tag <- @tags}
+            class={[
+              "px-2 py-0.5 text-xs font-medium bg-hero-cyan-100 text-hero-cyan",
+              Theme.rounded(:full)
+            ]}
+          >
+            {tag}
+          </span>
+        </div>
+        <div :if={@qualifications != []} class="flex flex-wrap gap-1.5">
+          <span
+            :for={qual <- @qualifications}
+            class={[
+              "px-2 py-0.5 text-xs font-medium border border-hero-grey-300 text-hero-grey-600",
+              Theme.rounded(:md)
+            ]}
+          >
+            {qual}
+          </span>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   defp humanize_gender("female"), do: gettext("Female")
   defp humanize_gender("male"), do: gettext("Male")
   defp humanize_gender("diverse"), do: gettext("Diverse")

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -9,10 +9,10 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHeroWeb.Helpers.TaskHelpers
+  alias KlassHeroWeb.Presenters.HeroCardsPresenter
   alias KlassHeroWeb.Presenters.ParticipantPolicyPresenter
   alias KlassHeroWeb.Presenters.ProgramPresenter
   alias KlassHeroWeb.Presenters.ProviderPresenter
-  alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Theme
 
   @impl true
@@ -54,12 +54,14 @@ defmodule KlassHeroWeb.ProgramDetailLive do
         provider_profile =
           TaskHelpers.safe_await(provider_task, nil, label: "ProgramDetailLive.provider_profile")
 
+        hero_cards = HeroCardsPresenter.for_program(program.instructor, team_members)
+
         socket =
           socket
           |> assign(page_title: program.title)
           |> assign(program: program)
           |> assign(program_icon_name: ProgramPresenter.icon_name(program.category))
-          |> assign(team_members: team_members)
+          |> assign(hero_cards: hero_cards)
           |> assign(registration_status: ProgramCatalog.registration_status(program))
           |> assign(participant_policy: participant_policy)
           |> assign(provider_profile: provider_profile)
@@ -124,9 +126,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   end
 
   defp load_team_members(program_id) when is_binary(program_id) do
-    program_id
-    |> Provider.list_active_staff_for_program()
-    |> StaffMemberPresenter.to_card_view_list()
+    Provider.list_active_staff_for_program(program_id)
   end
 
   defp load_provider_profile(nil), do: nil
@@ -418,8 +418,8 @@ defmodule KlassHeroWeb.ProgramDetailLive do
         <%!-- Participant Requirements Section --%>
         <.restriction_info :if={@participant_policy} policy={@participant_policy} />
 
-        <%!-- Meet the Heroes Section — only shown when real team members exist --%>
-        <section :if={@team_members != []}>
+        <%!-- Meet the Heroes Section — renders the assigned instructor (first) and any program staff --%>
+        <section :if={@hero_cards != []}>
           <div class={[
             Theme.bg(:surface),
             Theme.rounded(:xl),
@@ -429,68 +429,12 @@ defmodule KlassHeroWeb.ProgramDetailLive do
             <div class={["p-4 border-b", Theme.border_color(:light)]}>
               <h3 class={["font-semibold flex items-center gap-2", Theme.text_color(:heading)]}>
                 <.icon name="hero-user" class="w-5 h-5 text-hero-blue-500" />
-                {ngettext("Meet the Hero", "Meet the Heroes", length(@team_members))}
+                {ngettext("Meet the Hero", "Meet the Heroes", length(@hero_cards))}
               </h3>
             </div>
             <div class="p-6">
               <div class="space-y-6">
-                <div :for={member <- @team_members} class="flex items-start space-x-4">
-                  <img
-                    :if={member.headshot_url}
-                    src={member.headshot_url}
-                    alt={member.full_name}
-                    class={[
-                      "w-16 h-16 object-cover flex-shrink-0",
-                      Theme.rounded(:full)
-                    ]}
-                  />
-                  <div
-                    :if={!member.headshot_url}
-                    class={[
-                      "w-16 h-16 flex items-center justify-center text-white text-xl font-bold flex-shrink-0",
-                      Theme.rounded(:full),
-                      Theme.gradient(:primary)
-                    ]}
-                  >
-                    {member.initials}
-                  </div>
-                  <div class="flex-1">
-                    <h4 class={["font-semibold", Theme.text_color(:heading)]}>
-                      {member.full_name}
-                    </h4>
-                    <p :if={member.role} class={["text-sm mb-2", Theme.text_color(:muted)]}>
-                      {member.role}
-                    </p>
-                    <p
-                      :if={member.bio}
-                      class={["text-sm leading-relaxed mb-3", Theme.text_color(:secondary)]}
-                    >
-                      {member.bio}
-                    </p>
-                    <div :if={member.tags != []} class="flex flex-wrap gap-1.5 mb-2">
-                      <span
-                        :for={tag <- member.tags}
-                        class={[
-                          "px-2 py-0.5 text-xs font-medium bg-hero-cyan-100 text-hero-cyan",
-                          Theme.rounded(:full)
-                        ]}
-                      >
-                        {tag}
-                      </span>
-                    </div>
-                    <div :if={member.qualifications != []} class="flex flex-wrap gap-1.5">
-                      <span
-                        :for={qual <- member.qualifications}
-                        class={[
-                          "px-2 py-0.5 text-xs font-medium border border-hero-grey-300 text-hero-grey-600",
-                          Theme.rounded(:md)
-                        ]}
-                      >
-                        {qual}
-                      </span>
-                    </div>
-                  </div>
-                </div>
+                <.hero_card :for={card <- @hero_cards} {card} />
               </div>
             </div>
           </div>

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -45,8 +45,8 @@ defmodule KlassHeroWeb.ProgramDetailLive do
             load_provider_profile(program.provider_id)
           end)
 
-        team_members =
-          TaskHelpers.safe_await(team_task, [], label: "ProgramDetailLive.team_members")
+        staff_members =
+          TaskHelpers.safe_await(team_task, [], label: "ProgramDetailLive.staff_members")
 
         participant_policy =
           TaskHelpers.safe_await(policy_task, nil, label: "ProgramDetailLive.participant_policy")
@@ -54,7 +54,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
         provider_profile =
           TaskHelpers.safe_await(provider_task, nil, label: "ProgramDetailLive.provider_profile")
 
-        hero_cards = HeroCardsPresenter.for_program(program.instructor, team_members)
+        hero_cards = HeroCardsPresenter.for_program(program.instructor, staff_members)
 
         socket =
           socket

--- a/lib/klass_hero_web/presenters/hero_cards_presenter.ex
+++ b/lib/klass_hero_web/presenters/hero_cards_presenter.ex
@@ -1,0 +1,47 @@
+defmodule KlassHeroWeb.Presenters.HeroCardsPresenter do
+  @moduledoc """
+  Assembles the ordered list of hero-card prop maps rendered in the "Meet the Heroes"
+  section of the program detail page.
+
+  Two data sources feed this list:
+
+    * The program's `Instructor` value object (denormalized snapshot of one
+      `staff_members` row — `programs.instructor_id` references `staff_members.id`).
+    * The program's assigned staff members (rows in `program_staff_assignments`).
+
+  When the same person appears in both sources (instructor.id == staff_member.id),
+  a single merged card is rendered: the staff member's richer view (role, bio,
+  tags, qualifications) is preserved and the "Lead Instructor" badge is applied
+  on top. Otherwise the instructor card is rendered first and staff follow.
+  """
+
+  use Gettext, backend: KlassHeroWeb.Gettext
+
+  alias KlassHero.ProgramCatalog.Domain.Models.Instructor
+  alias KlassHero.Provider.Domain.Models.StaffMember
+  alias KlassHeroWeb.Presenters.InstructorPresenter
+  alias KlassHeroWeb.Presenters.StaffMemberPresenter
+
+  @spec for_program(Instructor.t() | nil, [StaffMember.t()]) :: [map()]
+  def for_program(nil, staff_members) when is_list(staff_members) do
+    StaffMemberPresenter.to_hero_card_list(staff_members)
+  end
+
+  def for_program(%Instructor{} = instructor, staff_members) when is_list(staff_members) do
+    {matching, others} = Enum.split_with(staff_members, &(&1.id == instructor.id))
+
+    case matching do
+      [lead | _] ->
+        [merge_lead(lead) | StaffMemberPresenter.to_hero_card_list(others)]
+
+      [] ->
+        [InstructorPresenter.to_hero_card(instructor) | StaffMemberPresenter.to_hero_card_list(others)]
+    end
+  end
+
+  defp merge_lead(%StaffMember{} = staff) do
+    staff
+    |> StaffMemberPresenter.to_hero_card()
+    |> Map.put(:badge, gettext("Lead Instructor"))
+  end
+end

--- a/lib/klass_hero_web/presenters/hero_cards_presenter.ex
+++ b/lib/klass_hero_web/presenters/hero_cards_presenter.ex
@@ -30,18 +30,13 @@ defmodule KlassHeroWeb.Presenters.HeroCardsPresenter do
   def for_program(%Instructor{} = instructor, staff_members) when is_list(staff_members) do
     {matching, others} = Enum.split_with(staff_members, &(&1.id == instructor.id))
 
-    case matching do
-      [lead | _] ->
-        [merge_lead(lead) | StaffMemberPresenter.to_hero_card_list(others)]
+    lead_card =
+      case matching do
+        [lead | _] -> StaffMemberPresenter.to_hero_card(lead)
+        [] -> InstructorPresenter.to_hero_card(instructor)
+      end
+      |> Map.put(:badge, gettext("Lead Instructor"))
 
-      [] ->
-        [InstructorPresenter.to_hero_card(instructor) | StaffMemberPresenter.to_hero_card_list(others)]
-    end
-  end
-
-  defp merge_lead(%StaffMember{} = staff) do
-    staff
-    |> StaffMemberPresenter.to_hero_card()
-    |> Map.put(:badge, gettext("Lead Instructor"))
+    [lead_card | StaffMemberPresenter.to_hero_card_list(others)]
   end
 end

--- a/lib/klass_hero_web/presenters/instructor_presenter.ex
+++ b/lib/klass_hero_web/presenters/instructor_presenter.ex
@@ -3,13 +3,10 @@ defmodule KlassHeroWeb.Presenters.InstructorPresenter do
   Transforms a Program's `Instructor` value object into the prop shape consumed by
   `KlassHeroWeb.ProgramComponents.hero_card/1`.
 
-  The Instructor value object is intentionally thin (id, name, optional headshot).
-  This presenter widens it into the same prop shape the staff-member card uses,
-  filling rich fields with `nil` / `[]` and tagging the card with a "Lead Instructor"
-  badge so it is visually distinguished from staff cards.
+  Pure transform — no badge or i18n logic. The `Lead Instructor` semantic is
+  applied by `KlassHeroWeb.Presenters.HeroCardsPresenter`, which is the only
+  caller of this module.
   """
-
-  use Gettext, backend: KlassHeroWeb.Gettext
 
   alias KlassHero.ProgramCatalog.Domain.Models.Instructor
 
@@ -20,20 +17,13 @@ defmodule KlassHeroWeb.Presenters.InstructorPresenter do
     %{
       id: "hero-card-instructor-#{instructor.id}",
       name: instructor.name,
-      initials: initials_from_name(instructor.name),
+      initials: Instructor.initials(instructor),
       headshot_url: instructor.headshot_url,
       role: nil,
       bio: nil,
       tags: [],
       qualifications: [],
-      badge: gettext("Lead Instructor")
+      badge: nil
     }
-  end
-
-  defp initials_from_name(name) do
-    name
-    |> String.split(~r/\s+/, trim: true)
-    |> Enum.take(2)
-    |> Enum.map_join("", fn token -> token |> String.first() |> String.upcase() end)
   end
 end

--- a/lib/klass_hero_web/presenters/instructor_presenter.ex
+++ b/lib/klass_hero_web/presenters/instructor_presenter.ex
@@ -1,0 +1,39 @@
+defmodule KlassHeroWeb.Presenters.InstructorPresenter do
+  @moduledoc """
+  Transforms a Program's `Instructor` value object into the prop shape consumed by
+  `KlassHeroWeb.ProgramComponents.hero_card/1`.
+
+  The Instructor value object is intentionally thin (id, name, optional headshot).
+  This presenter widens it into the same prop shape the staff-member card uses,
+  filling rich fields with `nil` / `[]` and tagging the card with a "Lead Instructor"
+  badge so it is visually distinguished from staff cards.
+  """
+
+  use Gettext, backend: KlassHeroWeb.Gettext
+
+  alias KlassHero.ProgramCatalog.Domain.Models.Instructor
+
+  @spec to_hero_card(Instructor.t() | nil) :: map() | nil
+  def to_hero_card(nil), do: nil
+
+  def to_hero_card(%Instructor{} = instructor) do
+    %{
+      id: "hero-card-instructor-#{instructor.id}",
+      name: instructor.name,
+      initials: initials_from_name(instructor.name),
+      headshot_url: instructor.headshot_url,
+      role: nil,
+      bio: nil,
+      tags: [],
+      qualifications: [],
+      badge: gettext("Lead Instructor")
+    }
+  end
+
+  defp initials_from_name(name) do
+    name
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.take(2)
+    |> Enum.map_join("", fn token -> token |> String.first() |> String.upcase() end)
+  end
+end

--- a/lib/klass_hero_web/presenters/staff_member_presenter.ex
+++ b/lib/klass_hero_web/presenters/staff_member_presenter.ex
@@ -42,6 +42,32 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenter do
   end
 
   @doc """
+  Builds the prop shape consumed by `KlassHeroWeb.ProgramComponents.hero_card/1`.
+
+  Mirrors the card view but renames `:full_name -> :name`, adds a stable DOM id,
+  and leaves `:badge` nil (staff are not "Lead Instructor").
+  """
+  @spec to_hero_card(StaffMember.t()) :: map()
+  def to_hero_card(%StaffMember{} = staff) do
+    %{
+      id: "hero-card-staff-#{staff.id}",
+      name: StaffMember.full_name(staff),
+      initials: StaffMember.initials(staff),
+      headshot_url: staff.headshot_url,
+      role: staff.role,
+      bio: staff.bio,
+      tags: staff.tags || [],
+      qualifications: staff.qualifications || [],
+      badge: nil
+    }
+  end
+
+  @spec to_hero_card_list([StaffMember.t()]) :: [map()]
+  def to_hero_card_list(staff_members) when is_list(staff_members) do
+    Enum.map(staff_members, &to_hero_card/1)
+  end
+
+  @doc """
   Business-owner-facing view. Extends the card view with pay_rate + formatted rate_label.
   """
   @spec to_admin_view(StaffMember.t()) :: map()

--- a/test/klass_hero_web/components/program_components_hero_card_test.exs
+++ b/test/klass_hero_web/components/program_components_hero_card_test.exs
@@ -1,0 +1,72 @@
+defmodule KlassHeroWeb.ProgramComponentsHeroCardTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHeroWeb.ProgramComponents
+
+  @full_attrs %{
+    id: "hero-card-staff-abc123",
+    name: "Ada Lovelace",
+    initials: "AL",
+    headshot_url: "https://example.com/ada.jpg",
+    role: "Mathematics Lead",
+    bio: "Pioneer of analytical engines.",
+    tags: ["math", "science"],
+    qualifications: ["MSc Computer Science", "First-Aid Certified"],
+    badge: "Lead Instructor"
+  }
+
+  describe "hero_card/1" do
+    test "renders full shape with every optional field populated" do
+      html = render_component(&ProgramComponents.hero_card/1, @full_attrs)
+      doc = LazyHTML.from_fragment(html)
+
+      assert Enum.any?(LazyHTML.query(doc, "#hero-card-staff-abc123"))
+
+      assert html =~ "Ada Lovelace"
+      assert html =~ "Mathematics Lead"
+      assert html =~ "Pioneer of analytical engines."
+      assert html =~ "Lead Instructor"
+
+      img = LazyHTML.query(doc, "img[src=\"https://example.com/ada.jpg\"]")
+      assert Enum.any?(img), "expected an <img> with the headshot src"
+
+      assert html =~ "math"
+      assert html =~ "science"
+      assert html =~ "MSc Computer Science"
+      assert html =~ "First-Aid Certified"
+    end
+
+    test "renders sparse shape with only required fields" do
+      attrs = %{id: "hero-card-instructor-xyz", name: "Dr. Strange", initials: "DS"}
+
+      html = render_component(&ProgramComponents.hero_card/1, attrs)
+      doc = LazyHTML.from_fragment(html)
+
+      assert Enum.any?(LazyHTML.query(doc, "#hero-card-instructor-xyz"))
+      assert html =~ "Dr. Strange"
+      assert html =~ "DS"
+
+      refute Enum.any?(LazyHTML.query(doc, "img")), "no headshot → no <img> element"
+
+      refute html =~ "Mathematics Lead"
+      refute html =~ "Pioneer of analytical engines."
+      refute html =~ "Lead Instructor"
+    end
+
+    test "renders badge text when :badge attr is set" do
+      attrs = Map.put(@full_attrs, :badge, "Lead Instructor")
+      html = render_component(&ProgramComponents.hero_card/1, attrs)
+
+      assert html =~ "Lead Instructor"
+    end
+
+    test "omits badge text when :badge attr is nil" do
+      attrs = Map.put(@full_attrs, :badge, nil)
+      html = render_component(&ProgramComponents.hero_card/1, attrs)
+
+      refute html =~ "Lead Instructor"
+    end
+  end
+end

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -222,6 +222,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
 
       {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
 
+      assert has_element?(view, "#hero-card-staff-#{staff.id}")
       assert html =~ "Coach Smith"
       assert html =~ "Head Coach"
       assert has_element?(view, "h3", "Meet the Hero")
@@ -262,7 +263,118 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       assert has_element?(view, "h3", "Meet the Heroes")
     end
 
-    test "program without staff hides instructor section", %{conn: conn} do
+    test "program with assigned instructor (no staff assignments) renders Lead Instructor card",
+         %{conn: conn} do
+      provider = provider_profile_fixture()
+
+      instructor =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Dr.",
+          last_name: "Strange"
+        )
+
+      program =
+        insert(:program_schema,
+          provider_id: provider.id,
+          title: "Music for Kids",
+          instructor_id: instructor.id,
+          instructor_name: "Dr. Strange",
+          instructor_headshot_url: nil
+        )
+
+      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "#hero-card-instructor-#{instructor.id}")
+      assert html =~ "Dr. Strange"
+      assert html =~ "Lead Instructor"
+      assert has_element?(view, "h3", "Meet the Hero")
+    end
+
+    test "program with instructor and staff renders instructor first", %{conn: conn} do
+      provider = provider_profile_fixture()
+
+      instructor =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Marie",
+          last_name: "Curie"
+        )
+
+      program =
+        insert(:program_schema,
+          provider_id: provider.id,
+          title: "Combined Camp",
+          instructor_id: instructor.id,
+          instructor_name: "Marie Curie",
+          instructor_headshot_url: nil
+        )
+
+      staff =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Coach",
+          last_name: "Smith",
+          role: "Assistant"
+        )
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: staff.id
+      )
+
+      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "#hero-card-instructor-#{instructor.id}")
+      assert has_element?(view, "#hero-card-staff-#{staff.id}")
+
+      instructor_pos = :binary.match(html, "hero-card-instructor-#{instructor.id}") |> elem(0)
+      staff_pos = :binary.match(html, "hero-card-staff-#{staff.id}") |> elem(0)
+
+      assert instructor_pos < staff_pos,
+             "expected instructor card to render before staff card; got instructor at #{instructor_pos}, staff at #{staff_pos}"
+    end
+
+    test "instructor who is also an assigned staff renders one merged card", %{conn: conn} do
+      provider = provider_profile_fixture()
+
+      lead =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Alice",
+          last_name: "Lead",
+          role: "Head Coach",
+          bio: "10 years experience"
+        )
+
+      program =
+        insert(:program_schema,
+          provider_id: provider.id,
+          instructor_id: lead.id,
+          instructor_name: "Alice Lead",
+          instructor_headshot_url: nil
+        )
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: lead.id
+      )
+
+      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "#hero-card-staff-#{lead.id}")
+      refute has_element?(view, "#hero-card-instructor-#{lead.id}")
+
+      assert html =~ "Head Coach"
+      assert html =~ "10 years experience"
+      assert html =~ "Lead Instructor"
+
+      assert has_element?(view, "h3", "Meet the Hero")
+    end
+
+    test "program without instructor or staff hides hero section", %{conn: conn} do
       program = insert(:program_schema, title: "Art Class")
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
 

--- a/test/klass_hero_web/presenters/hero_cards_presenter_test.exs
+++ b/test/klass_hero_web/presenters/hero_cards_presenter_test.exs
@@ -1,0 +1,112 @@
+defmodule KlassHeroWeb.Presenters.HeroCardsPresenterTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.ProgramCatalog.Domain.Models.Instructor
+  alias KlassHero.Provider.Domain.Models.StaffMember
+  alias KlassHeroWeb.Presenters.HeroCardsPresenter
+
+  defp staff(attrs) do
+    base = %StaffMember{
+      id: attrs[:id] || Ecto.UUID.generate(),
+      provider_id: "prov-1",
+      first_name: attrs[:first_name] || "First",
+      last_name: attrs[:last_name] || "Last",
+      role: attrs[:role],
+      bio: attrs[:bio],
+      headshot_url: attrs[:headshot_url],
+      tags: attrs[:tags] || [],
+      qualifications: attrs[:qualifications] || []
+    }
+
+    base
+  end
+
+  defp instructor(id, name) do
+    %Instructor{id: id, name: name, headshot_url: nil}
+  end
+
+  describe "for_program/2" do
+    test "returns [] when instructor is nil and staff is empty" do
+      assert HeroCardsPresenter.for_program(nil, []) == []
+    end
+
+    test "returns plain staff hero cards when instructor is nil" do
+      s1 = staff(first_name: "Alice", last_name: "Smith")
+      s2 = staff(first_name: "Bob", last_name: "Jones")
+
+      result = HeroCardsPresenter.for_program(nil, [s1, s2])
+
+      assert length(result) == 2
+      assert Enum.map(result, & &1.name) == ["Alice Smith", "Bob Jones"]
+      assert Enum.all?(result, &is_nil(&1.badge))
+    end
+
+    test "returns single instructor card when no staff are assigned" do
+      i = instructor("inst-id-1", "Marie Curie")
+
+      result = HeroCardsPresenter.for_program(i, [])
+
+      assert [card] = result
+      assert card.id == "hero-card-instructor-inst-id-1"
+      assert card.name == "Marie Curie"
+      assert card.badge == "Lead Instructor"
+    end
+
+    test "puts instructor card first when no staff id matches the instructor" do
+      i = instructor("inst-id-2", "Marie Curie")
+      s1 = staff(id: "staff-1", first_name: "Coach", last_name: "Smith", role: "Assistant")
+      s2 = staff(id: "staff-2", first_name: "Coach", last_name: "Brown")
+
+      result = HeroCardsPresenter.for_program(i, [s1, s2])
+
+      assert length(result) == 3
+
+      assert Enum.map(result, & &1.id) == [
+               "hero-card-instructor-inst-id-2",
+               "hero-card-staff-staff-1",
+               "hero-card-staff-staff-2"
+             ]
+
+      [instructor_card | _] = result
+      assert instructor_card.badge == "Lead Instructor"
+    end
+
+    test "merges into single card when instructor.id matches a staff member's id" do
+      shared_id = "shared-uuid-42"
+      i = instructor(shared_id, "Alice Lead")
+
+      lead =
+        staff(
+          id: shared_id,
+          first_name: "Alice",
+          last_name: "Lead",
+          role: "Head Coach",
+          bio: "10 years experience",
+          tags: ["sports", "youth"],
+          qualifications: ["UEFA B"]
+        )
+
+      other = staff(id: "staff-other", first_name: "Bob", last_name: "Helper", role: "Assistant")
+
+      result = HeroCardsPresenter.for_program(i, [lead, other])
+
+      assert length(result) == 2
+
+      [first, second] = result
+
+      # First card: the merged "lead" — staff DOM id, badge attached, rich fields preserved
+      assert first.id == "hero-card-staff-#{shared_id}"
+      assert first.badge == "Lead Instructor"
+      assert first.role == "Head Coach"
+      assert first.bio == "10 years experience"
+      assert first.tags == ["sports", "youth"]
+      assert first.qualifications == ["UEFA B"]
+      assert first.name == "Alice Lead"
+
+      # Second card: the other staff, unchanged
+      assert second.id == "hero-card-staff-staff-other"
+      assert is_nil(second.badge)
+      assert second.role == "Assistant"
+    end
+  end
+end


### PR DESCRIPTION
Closes #796.

## Summary

- Extracted a reusable `hero_card/1` function component (`program_components.ex`) and removed ~90 lines of inline "Meet the Heroes" markup from `program_detail_live.ex`.
- Added `KlassHeroWeb.Presenters.InstructorPresenter` and `StaffMemberPresenter.to_hero_card/1` so instructor (`Instructor` VO) and staff member (`StaffMember`) collapse into one prop shape.
- Added `KlassHeroWeb.Presenters.HeroCardsPresenter.for_program/2` which orders instructor first when present, and merges into a single card when `instructor.id == staff_member.id` — transplanting the "Lead Instructor" badge onto the richer staff view (preserves role, bio, tags, qualifications).
- Exported `KlassHero.ProgramCatalog.Domain.Models.Instructor` from the `ProgramCatalog` Boundary so the web presenter can reach it (only consumer; no other contexts touch).
- Test coverage: 4 component cases + 5 presenter cases + 4 LiveView cases. Full suite 4788/4788 green.

## Review Focus

- **Dedup correctness** — `lib/klass_hero_web/presenters/hero_cards_presenter.ex:32-39`. The match-found branch calls `StaffMemberPresenter.to_hero_card/1` then `Map.put(:badge, ...)`, so rich staff fields are preserved and the badge is transplanted. Verify this is the right precedence (staff data wins over instructor VO).
- **Identity assumption** — `programs.instructor_id` references `staff_members.id` (`priv/repo/migrations/20260226000005_create_programs.exs:19`). Dedup key is the bare PK comparison `&(&1.id == instructor.id)` in `hero_cards_presenter.ex:32`. No second equality dimension needed.
- **Boundary export** — `lib/klass_hero/program_catalog.ex:38-43` now exports `Domain.Models.Instructor`. Only `InstructorPresenter` consumes it; no Provider context reach-in.
- **LiveView simplification** — `lib/klass_hero_web/live/program_detail_live.ex:58` is now a one-line delegate to `HeroCardsPresenter.for_program/2`. The old `build_hero_cards/2` private + a misleading "no shared id" comment were removed.
- **Gettext** — new key `gettext("Lead Instructor")` (`instructor_presenter.ex:28`, `hero_cards_presenter.ex:43`) reaches runtime via msgid fallback. Not extracted to `.po` in this PR; a focused gettext sync is deferred (running `mix gettext.extract --merge` here would dump 183 unrelated stale keys).

## Test Plan

- [x] `mix precommit` — 4788 passed, 5 skipped, 18 excluded; format + credo + typography lint + warnings-as-errors green
- [x] Component tests: `mix test test/klass_hero_web/components/program_components_hero_card_test.exs` (4/4)
- [x] Presenter tests: `mix test test/klass_hero_web/presenters/hero_cards_presenter_test.exs` (5/5)
- [x] LiveView tests: `mix test test/klass_hero_web/live/program_detail_live_test.exs` (28/28)
- [x] Live test-drive via Tidewave + Playwright: instructor-only path verified on real program `Piano for Beginners`; dedup path verified by transiently seeding a `program_staff_assignments` row matching `instructor_id`, then cleaned up (`.test-drive-reports/test-drive-2026-05-12-796.md`)
- [x] Mobile 375x667 — hero card 278px wide, no overflow
- [x] Manual: open any `/programs/<id>` where the program has an instructor and confirm "Meet the Hero" section with a Lead Instructor badge
- [x] Manual (optional): open a program where the instructor is also explicitly assigned as staff (none in current seeds) and confirm a single merged card renders

## Follow-up

- #840 — `[TASK] Move instructor to role flag on program_staff_assignments`. Structural refactor that would remove `HeroCardsPresenter`'s merge logic entirely. Low priority; UI is correct as-is.