### PR TITLE
fix: staff inbox visibility via event-driven CQRS (#817)

### DIFF
--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -185,6 +185,16 @@ defmodule KlassHero.Application do
             priority: 10},
            {:conversations_archived,
             {KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}},
+           # participant_added: promote to integration event so CQRS projection
+           # upserts a summary row for the newly added participant
+           {:participant_added,
+            {KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10},
+           # participant_removed: promote to integration event so CQRS projection
+           # archives the removed participant's summary row
+           {:participant_removed,
+            {KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10},
            {:retention_enforced, {KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}}
          ]},
         id: :messaging_domain_event_bus

--- a/lib/klass_hero/messaging/adapters/driven/persistence/queries/conversation_queries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/queries/conversation_queries.ex
@@ -76,12 +76,22 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Queries.ConversationQu
   end
 
   @doc """
-  Filter conversations where user is NOT a participant.
+  Filter conversations where user is NOT an *active* participant.
+
+  Soft-left participations (where `left_at` is set) are treated as absent so
+  the staff-reassignment flow can re-add a user who was previously removed.
+  Without this, the LEFT JOIN would match the left row, set `p.id` to
+  non-null, and the WHERE `is_nil(p.id)` would exclude the conversation
+  forever — locking unassigned staff out of every program conversation
+  they've ever left.
   """
   def where_user_is_not_participant(query, user_id) do
     query
     |> join(:left, [conversation: c], p in ParticipantSchema,
-      on: p.conversation_id == c.id and p.user_id == ^user_id,
+      on:
+        p.conversation_id == c.id and
+          p.user_id == ^user_id and
+          is_nil(p.left_at),
       as: :excluded_participant
     )
     |> where([excluded_participant: p], is_nil(p.id))

--- a/lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_repository.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_repository.ex
@@ -257,6 +257,20 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Conversat
   end
 
   @impl true
+  def list_active_program_conversation_ids_with_participant(program_id, user_id) do
+    span do
+      set_attributes("db", operation: "select", entity: "conversation")
+
+      ConversationQueries.base()
+      |> ConversationQueries.by_program(program_id)
+      |> ConversationQueries.active_only()
+      |> ConversationQueries.where_user_is_participant(user_id)
+      |> ConversationQueries.select_ids()
+      |> Repo.all()
+    end
+  end
+
+  @impl true
   def list_expired_ids(before) do
     span do
       set_attributes("db", operation: "select", entity: "conversation")

--- a/lib/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository.ex
+++ b/lib/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository.ex
@@ -295,7 +295,14 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Participa
 
       {count, _} =
         Repo.insert_all(ParticipantSchema, entries,
-          on_conflict: :nothing,
+          # Re-activation semantics for soft-left rows:
+          # - clear `left_at` so the participant becomes active again
+          # - bump `updated_at` to capture the re-activation moment
+          # - preserve original `joined_at` (audit trail of first-join time stays authoritative)
+          on_conflict:
+            from(p in ParticipantSchema,
+              update: [set: [left_at: nil, updated_at: fragment("EXCLUDED.updated_at")]]
+            ),
           conflict_target: [:conversation_id, :user_id]
         )
 

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -57,6 +57,8 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   @conversation_archived_topic "integration:messaging:conversation_archived"
   @conversations_archived_topic "integration:messaging:conversations_archived"
   @message_data_anonymized_topic "integration:messaging:message_data_anonymized"
+  @participant_added_topic "integration:messaging:participant_added"
+  @participant_removed_topic "integration:messaging:participant_removed"
   @enrolled_children_changed_topic "messaging:enrolled_children_changed"
   @broadcast_token_regex ~r/\[broadcast:[^\]]+\]/
 
@@ -99,6 +101,8 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversation_archived_topic)
     Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversations_archived_topic)
     Phoenix.PubSub.subscribe(KlassHero.PubSub, @message_data_anonymized_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @participant_added_topic)
+    Phoenix.PubSub.subscribe(KlassHero.PubSub, @participant_removed_topic)
     Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrolled_children_changed_topic)
 
     {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
@@ -207,6 +211,38 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     )
 
     project_message_data_anonymized(event)
+    {:noreply, state}
+  end
+
+  # Trigger: Received a participant_added integration event
+  # Why: one or more users joined a conversation after creation; each needs
+  #      their own summary row so the conversation appears in their inbox
+  # Outcome: one row per new participant_user_id upserted into conversation_summaries
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :participant_added} = event}, state) do
+    Logger.debug("ConversationSummaries projecting participant_added",
+      conversation_id: event.entity_id,
+      event_id: event.event_id
+    )
+
+    project_participant_added(event)
+    {:noreply, state}
+  end
+
+  # Trigger: Received a participant_removed integration event
+  # Why: one or more users were removed from a conversation; their summary
+  #      rows must be soft-archived so the conversation disappears from
+  #      their inbox immediately
+  # Outcome: archived_at set on each affected (conversation_id, user_id) row,
+  #          preserving the first removal's timestamp on replay (COALESCE)
+  @impl true
+  def handle_info({:integration_event, %IntegrationEvent{event_type: :participant_removed} = event}, state) do
+    Logger.debug("ConversationSummaries projecting participant_removed",
+      conversation_id: event.entity_id,
+      event_id: event.event_id
+    )
+
+    project_participant_removed(event)
     {:noreply, state}
   end
 
@@ -461,11 +497,151 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
         %ConversationSummarySchema{}
         |> Ecto.Changeset.change(attrs)
         |> Repo.insert!(
-          on_conflict: {:replace_all_except, [:id, :inserted_at]},
+          # Idempotency: on replay, refresh conversation metadata only.
+          # Read-state fields (unread_count, last_read_at), message-state
+          # fields (latest_message_*, has_attachments, system_notes,
+          # enrolled_child_names) and archived_at MUST be preserved —
+          # those are owned by other event handlers (:message_sent,
+          # :messages_read, :conversation_archived).
+          on_conflict:
+            {:replace,
+             [
+               :conversation_type,
+               :provider_id,
+               :program_id,
+               :subject,
+               :other_participant_name,
+               :participant_count,
+               :updated_at
+             ]},
           conflict_target: [:conversation_id, :user_id]
         )
       end)
     end)
+  end
+
+  # Trigger: participant_added event received
+  # Why: one or more new participants joined a conversation; each needs a
+  #      summary row back-filled from the current write-model state
+  # Outcome: one row per new user_id upserted; meta refreshed on replay,
+  #          read-state fields preserved
+  defp project_participant_added(event) do
+    payload = event.payload
+    conversation_id = payload.conversation_id
+    new_user_ids = Map.get(payload, :participant_user_ids, [])
+
+    case load_conversation_with_participants(conversation_id) do
+      nil ->
+        Logger.warning(
+          "ConversationSummaries: skipping participant_added — conversation missing",
+          conversation_id: conversation_id,
+          event_id: event.event_id
+        )
+
+        :ok
+
+      conversation ->
+        upsert_participant_summary_rows(conversation, new_user_ids)
+    end
+  end
+
+  defp load_conversation_with_participants(conversation_id) do
+    from(c in ConversationSchema,
+      where: c.id == ^conversation_id,
+      preload: [:participants]
+    )
+    |> Repo.one()
+  end
+
+  defp upsert_participant_summary_rows(conversation, new_user_ids) do
+    active_participants = Enum.filter(conversation.participants, &is_nil(&1.left_at))
+    new_participants = Enum.filter(active_participants, &(&1.user_id in new_user_ids))
+
+    if new_participants == [] do
+      :ok
+    else
+      context = build_participant_context(conversation, active_participants)
+
+      entries =
+        Enum.map(new_participants, fn participant ->
+          build_summary_entry(conversation, participant, context)
+        end)
+
+      Repo.insert_all(ConversationSummarySchema, entries,
+        # Idempotency: read-state and message-state preserved on replay.
+        # `archived_at` IS in the replace list: the entry's value comes from
+        # the conversation row (via build_summary_entry). For an active
+        # conversation this is `nil`, which un-archives a row that was
+        # previously archived by `:participant_removed` — exactly what
+        # staff re-assignment needs. For an archived conversation, the
+        # entry carries the conversation's archive timestamp, so the
+        # archive state is preserved across re-events.
+        on_conflict:
+          {:replace,
+           [
+             :conversation_type,
+             :provider_id,
+             :program_id,
+             :subject,
+             :other_participant_name,
+             :participant_count,
+             :archived_at,
+             :updated_at
+           ]},
+        conflict_target: [:conversation_id, :user_id]
+      )
+
+      :ok
+    end
+  end
+
+  defp build_participant_context(conversation, active_participants) do
+    user_names = fetch_user_names(Enum.map(active_participants, & &1.user_id))
+    latest_messages = fetch_latest_messages([conversation.id])
+    unread_counts = fetch_unread_counts([conversation])
+    system_notes = fetch_system_notes([conversation.id])
+    attachment_message_ids = fetch_attachment_message_ids(latest_messages)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %{
+      active_participants: active_participants,
+      user_names: user_names,
+      latest_message: Map.get(latest_messages, conversation.id),
+      unread_counts: unread_counts,
+      system_notes: Map.get(system_notes, conversation.id, %{}),
+      attachment_message_ids: attachment_message_ids,
+      now: now
+    }
+  end
+
+  # Trigger: participant_removed event received
+  # Why: removed users should not see the conversation in their inbox
+  # Outcome: archived_at stamped on each affected row, preserving the first
+  #          removal's timestamp on replay via COALESCE
+  defp project_participant_removed(event) do
+    payload = event.payload
+    conversation_id = payload.conversation_id
+    user_ids = Map.get(payload, :participant_user_ids, [])
+
+    if user_ids == [] do
+      :ok
+    else
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      from(s in ConversationSummarySchema,
+        where: s.conversation_id == ^conversation_id and s.user_id in ^user_ids,
+        update: [
+          set: [
+            # COALESCE preserves the first removal's timestamp on replay
+            archived_at: fragment("COALESCE(?, ?)", s.archived_at, ^now),
+            updated_at: ^now
+          ]
+        ]
+      )
+      |> Repo.update_all([])
+
+      :ok
+    end
   end
 
   # Trigger: message_sent event received

--- a/lib/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -40,7 +40,10 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
   def handle(%DomainEvent{event_type: :conversation_created} = event) do
     # Trigger: conversation_created domain event dispatched from CreateDirectConversation use case
     # Why: CQRS projections need this to build denormalized conversation summaries
-    # Outcome: publish integration event; propagate failure so use case is aware
+    # Outcome: publish critical integration event; the conversation is already
+    #          committed before dispatch (post-commit pattern), and a publish
+    #          failure is caught by EventDispatchHelper which enqueues an
+    #          Oban retry for this handler.
     event.aggregate_id
     |> MessagingIntegrationEvents.conversation_created(event.payload)
     |> IntegrationEventPublishing.publish_critical("conversation_created",
@@ -51,7 +54,11 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
   def handle(%DomainEvent{event_type: :message_sent} = event) do
     # Trigger: message_sent domain event dispatched from SendMessage use case
     # Why: CQRS projections need this to update last-message summaries and unread counts
-    # Outcome: publish integration event; propagate failure so use case is aware
+    # Outcome: publish critical integration event; the message persistence is
+    #          already committed before this fires. Dispatch failures are
+    #          retried by EventDispatchHelper once issue #849 lands; until
+    #          then SendMessage uses the lower-level bus which logs failures
+    #          but does not retry.
     event.aggregate_id
     |> MessagingIntegrationEvents.message_sent(event.payload)
     |> IntegrationEventPublishing.publish_critical("message_sent",
@@ -93,8 +100,10 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
     # Trigger: participant_added domain event dispatched from AddAssignedStaff command
     # Why: CQRS projection must upsert summary rows for newly added participants;
     #      missing this leaves staff inboxes empty until a server restart re-derives
-    # Outcome: publish critical integration event; propagate failure so the
-    #          enclosing transaction rolls back the participant insert
+    # Outcome: publish critical integration event; the participant insert is
+    #          already committed before dispatch (post-commit pattern). A
+    #          publish failure does NOT roll back — EventDispatchHelper
+    #          enqueues an Oban retry so the projection eventually catches up.
     event.aggregate_id
     |> MessagingIntegrationEvents.participant_added(event.payload)
     |> IntegrationEventPublishing.publish_critical("participant_added",
@@ -106,8 +115,10 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
     # Trigger: participant_removed domain event dispatched from RemoveAssignedStaff command
     # Why: CQRS projection must soft-remove (archive) the participant's summary row
     #      so the conversation disappears from their inbox immediately
-    # Outcome: publish critical integration event; propagate failure so the
-    #          enclosing transaction rolls back the participant deletion
+    # Outcome: publish critical integration event; the leave write is already
+    #          committed before dispatch (post-commit pattern). A publish
+    #          failure does NOT roll back — EventDispatchHelper enqueues an
+    #          Oban retry so the archive eventually lands.
     event.aggregate_id
     |> MessagingIntegrationEvents.participant_removed(event.payload)
     |> IntegrationEventPublishing.publish_critical("participant_removed",

--- a/lib/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -88,4 +88,30 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
       aggregate_id: event.aggregate_id
     )
   end
+
+  def handle(%DomainEvent{event_type: :participant_added} = event) do
+    # Trigger: participant_added domain event dispatched from AddAssignedStaff command
+    # Why: CQRS projection must upsert summary rows for newly added participants;
+    #      missing this leaves staff inboxes empty until a server restart re-derives
+    # Outcome: publish critical integration event; propagate failure so the
+    #          enclosing transaction rolls back the participant insert
+    event.aggregate_id
+    |> MessagingIntegrationEvents.participant_added(event.payload)
+    |> IntegrationEventPublishing.publish_critical("participant_added",
+      conversation_id: event.aggregate_id
+    )
+  end
+
+  def handle(%DomainEvent{event_type: :participant_removed} = event) do
+    # Trigger: participant_removed domain event dispatched from RemoveAssignedStaff command
+    # Why: CQRS projection must soft-remove (archive) the participant's summary row
+    #      so the conversation disappears from their inbox immediately
+    # Outcome: publish critical integration event; propagate failure so the
+    #          enclosing transaction rolls back the participant deletion
+    event.aggregate_id
+    |> MessagingIntegrationEvents.participant_removed(event.payload)
+    |> IntegrationEventPublishing.publish_critical("participant_removed",
+      conversation_id: event.aggregate_id
+    )
+  end
 end

--- a/lib/klass_hero/messaging/adapters/driving/events/staff_assignment_handler.ex
+++ b/lib/klass_hero/messaging/adapters/driving/events/staff_assignment_handler.ex
@@ -4,17 +4,28 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
 
   On assignment:
   1. Upserts the `program_staff_participants` projection (sets active=true).
-  2. Adds the staff user as a participant to all existing active conversations
-     for that program (where they are not already a participant).
+  2. Adds the staff user as a participant to every active program conversation
+     where they are not already an active participant. The participant inserts
+     and one `:participant_added` domain event per back-filled conversation
+     are collected inside a single `Repo.transaction`; events dispatch
+     *after* the transaction commits so the `ConversationSummaries` projection
+     can read-your-own-writes on a separate DB connection.
 
   On unassignment:
   1. Deactivates the projection entry (sets active=false).
-  2. Does NOT remove staff from existing conversations (soft unassign).
+  2. Delegates to `RemoveAssignedStaff` to soft-leave the staff in every
+     active program conversation; the returned `:participant_removed` events
+     are dispatched after the wrapping transaction commits.
   """
 
   @behaviour KlassHero.Shared.Domain.Ports.Driving.ForHandlingIntegrationEvents
 
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.Application.Commands.RemoveAssignedStaff
+  alias KlassHero.Messaging.Domain.Events.MessagingEvents
+  alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Events.RetryHelpers
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
 
@@ -27,6 +38,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
                       :messaging,
                       :for_resolving_program_staff
                     ])
+  @context Messaging
 
   @impl true
   def subscribed_events, do: [:staff_assigned_to_program, :staff_unassigned_from_program]
@@ -61,7 +73,6 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
       })
 
       add_staff_to_existing_conversations(payload.program_id, payload.staff_user_id)
-      :ok
     end
 
     context = %{
@@ -76,7 +87,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
   defp handle_unassignment_with_retry(payload) do
     operation = fn ->
       @staff_projection.deactivate(payload.program_id, payload.staff_user_id)
-      :ok
+      remove_staff_from_existing_conversations(payload.program_id, payload.staff_user_id)
     end
 
     context = %{
@@ -88,6 +99,13 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
     RetryHelpers.retry_and_normalize(operation, context)
   end
 
+  # Trigger: staff assigned to a program may need to back-fill participants
+  #          in every active conversation for that program.
+  # Why: events-as-data + post-commit dispatch — the projection lives on a
+  #      separate DB connection and can only see committed writes.
+  # Outcome: participants inserted inside a single transaction; one
+  #          `:participant_added` event per back-filled conversation is
+  #          dispatched after commit.
   defp add_staff_to_existing_conversations(program_id, staff_user_id) do
     conversation_ids =
       @conversation_reader.list_active_program_conversation_ids_without_participant(
@@ -95,6 +113,55 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
         staff_user_id
       )
 
-    {:ok, _count} = @participant_repo.add_to_conversations_batch(staff_user_id, conversation_ids)
+    case conversation_ids do
+      [] ->
+        :ok
+
+      ids ->
+        Repo.transaction(fn ->
+          case @participant_repo.add_to_conversations_batch(staff_user_id, ids) do
+            {:ok, _count} ->
+              Enum.map(ids, fn conversation_id ->
+                MessagingEvents.participant_added(
+                  conversation_id,
+                  [staff_user_id],
+                  :later_assignment
+                )
+              end)
+
+            {:error, reason} ->
+              Repo.rollback(reason)
+          end
+        end)
+        |> case do
+          {:ok, events} ->
+            Enum.each(events, &EventDispatchHelper.dispatch(&1, @context))
+            :ok
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  # Trigger: staff unassigned from a program; existing participation rows must
+  #          be soft-removed so the user loses inbox visibility.
+  # Why: symmetric to add — RemoveAssignedStaff returns events as data; we
+  #      dispatch them after the wrapping transaction commits.
+  defp remove_staff_from_existing_conversations(program_id, staff_user_id) do
+    Repo.transaction(fn ->
+      case RemoveAssignedStaff.execute(program_id, staff_user_id) do
+        {:ok, {_removals, events}} -> events
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, events} ->
+        Enum.each(events, &EventDispatchHelper.dispatch(&1, @context))
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 end

--- a/lib/klass_hero/messaging/application/commands/add_assigned_staff.ex
+++ b/lib/klass_hero/messaging/application/commands/add_assigned_staff.ex
@@ -1,0 +1,54 @@
+defmodule KlassHero.Messaging.Application.Commands.AddAssignedStaff do
+  @moduledoc """
+  Adds active staff assigned to a program as participants of a conversation
+  and **returns** a `:participant_added` domain event for the caller to
+  dispatch *after* the enclosing transaction commits.
+
+  ## Why return the event instead of dispatching it?
+
+  The `ConversationSummaries` projection runs in its own GenServer on its
+  own DB connection. Under PostgreSQL READ COMMITTED isolation it cannot
+  see uncommitted writes. If we dispatched inside `Repo.transaction`, the
+  projection might process the event before the parent transaction
+  committed and skip the upsert because the conversation row "doesn't
+  exist yet". The caller therefore collects events from this command (and
+  any sibling commands) inside the transaction and dispatches them after
+  `Repo.transaction` returns `{:ok, _}` — see `EventDispatchHelper.dispatch/2`.
+
+  ## Returns
+
+  - `{:ok, {added_user_ids, events}}` — `events` is a list of zero or one
+    `DomainEvent` structs. Empty when no eligible staff exist or when
+    `program_id` is `nil`.
+  - `{:error, reason}` — when the participant batch insert fails.
+  """
+
+  alias KlassHero.Messaging.Domain.Events.MessagingEvents
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  @participant_repo Application.compile_env!(:klass_hero, [:messaging, :for_managing_participants])
+  @staff_resolver Application.compile_env!(:klass_hero, [
+                    :messaging,
+                    :for_resolving_program_staff
+                  ])
+
+  @spec execute(String.t(), String.t() | nil, String.t()) ::
+          {:ok, {[String.t()], [DomainEvent.t()]}} | {:error, term()}
+  def execute(_conversation_id, nil, _excluded_user_id), do: {:ok, {[], []}}
+
+  def execute(conversation_id, program_id, excluded_user_id) do
+    program_id
+    |> @staff_resolver.get_active_staff_user_ids()
+    |> Enum.reject(&(&1 == excluded_user_id))
+    |> add(conversation_id)
+  end
+
+  defp add([], _conversation_id), do: {:ok, {[], []}}
+
+  defp add(ids, conversation_id) do
+    with {:ok, _} <- @participant_repo.add_batch(conversation_id, ids) do
+      event = MessagingEvents.participant_added(conversation_id, ids, :initial_staff)
+      {:ok, {ids, [event]}}
+    end
+  end
+end

--- a/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
+++ b/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
@@ -12,12 +12,17 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
   """
 
   alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Application.Commands.AddAssignedStaff
   alias KlassHero.Messaging.Application.Commands.SendMessage
   alias KlassHero.Messaging.Application.Shared
   alias KlassHero.Messaging.Domain.Models.Conversation
   alias KlassHero.Messaging.Domain.Models.Message
+  alias KlassHero.Repo
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
+
+  @context KlassHero.Messaging
 
   @conversation_repo Application.compile_env!(:klass_hero, [
                        :messaging,
@@ -134,18 +139,34 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
 
   # Trigger: broadcast participants need to be present before SendMessage runs
   # Why: SendMessage.verify_participant rejects senders not in the conversation —
-  #      provider/staff sender must be added before delegation
-  # Outcome: parents, sender, and assigned staff are participants; partial failure
-  #          is recoverable via idempotent retry (add_batch, add_or_get, projection
-  #          lookup all heal on re-run)
+  #      provider/staff sender must be added before delegation. AddAssignedStaff
+  #      now returns its :participant_added domain event as data; dispatch
+  #      happens after the transaction commits so the projection on a separate
+  #      DB connection can read-your-own-writes.
+  # Outcome: parents, sender, and assigned staff added in a single transaction;
+  #          on commit, all collected events fan out via EventDispatchHelper.
   defp setup_participants(conversation, scope, parent_user_ids) do
-    with {:ok, _} <- @participant_repo.add_batch(conversation.id, parent_user_ids),
-         {:ok, _} <-
-           @participant_repo.add_or_get(%{
-             conversation_id: conversation.id,
-             user_id: scope.user.id
-           }) do
-      Shared.add_assigned_staff(conversation.id, conversation.program_id, scope.user.id)
+    Repo.transaction(fn ->
+      with {:ok, _} <- @participant_repo.add_batch(conversation.id, parent_user_ids),
+           {:ok, _} <-
+             @participant_repo.add_or_get(%{
+               conversation_id: conversation.id,
+               user_id: scope.user.id
+             }),
+           {:ok, {_staff_ids, staff_events}} <-
+             AddAssignedStaff.execute(conversation.id, conversation.program_id, scope.user.id) do
+        staff_events
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, events} ->
+        Enum.each(events, &EventDispatchHelper.dispatch(&1, @context))
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/klass_hero/messaging/application/commands/create_direct_conversation.ex
+++ b/lib/klass_hero/messaging/application/commands/create_direct_conversation.ex
@@ -3,21 +3,26 @@ defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversation do
   Use case for creating a direct 1-on-1 conversation between a provider and a parent.
 
   This use case:
-  1. Checks if the initiator can start conversations (entitlement check)
-  2. Checks if a direct conversation already exists
-  3. Creates a new conversation if none exists
-  4. Adds both parties as participants
-  5. Publishes a conversation_created event
+  1. Checks if the initiator can start conversations (entitlement check).
+  2. Returns an existing direct conversation if one is found.
+  3. Otherwise inserts the conversation, the two parties, and (if a
+     `:program_id` is provided) the program's assigned staff — all inside a
+     single `Repo.transaction`.
+  4. After the transaction commits, dispatches the collected domain events
+     (`:conversation_created` plus any `:participant_added`) so the
+     `ConversationSummaries` projection can read-your-own-writes on a
+     separate DB connection.
 
   Free-tier parents cannot initiate conversations but can receive and reply to them.
   """
 
   alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Application.Commands.AddAssignedStaff
   alias KlassHero.Messaging.Application.Shared
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Domain.Models.Conversation
   alias KlassHero.Repo
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
 
@@ -81,22 +86,44 @@ defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversation do
 
       with {:ok, conversation} <- @conversation_repo.create(attrs),
            :ok <- add_participants(conversation.id, scope.user.id, target_user_id),
-           :ok <- Shared.add_assigned_staff(conversation.id, program_id, scope.user.id) do
-        publish_event(conversation, [scope.user.id, target_user_id], provider_id)
+           {:ok, {_staff_ids, staff_events}} <-
+             AddAssignedStaff.execute(conversation.id, program_id, scope.user.id) do
+        created_event =
+          MessagingEvents.conversation_created(
+            conversation.id,
+            conversation.type,
+            provider_id,
+            [scope.user.id, target_user_id],
+            conversation.program_id
+          )
 
-        Logger.info("Created direct conversation",
-          conversation_id: conversation.id,
-          provider_id: provider_id,
-          initiator_id: scope.user.id
-        )
-
-        conversation
+        {conversation, [created_event | staff_events]}
       else
-        {:error, reason} ->
-          Repo.rollback(reason)
+        {:error, reason} -> Repo.rollback(reason)
       end
     end)
+    |> handle_commit(scope, provider_id)
   end
+
+  # Trigger: Repo.transaction returns {:ok, {conversation, events}}
+  # Why: events must be dispatched *after* commit so the projection — which
+  #      reads the write tables from a separate DB connection — can see the
+  #      committed conversation row when it processes the integration event.
+  # Outcome: events fan out via EventDispatchHelper.dispatch/2 (fire-and-
+  #          forget; critical events get Oban-backed retry on publish failure).
+  defp handle_commit({:ok, {conversation, events}}, scope, provider_id) do
+    Enum.each(events, &EventDispatchHelper.dispatch(&1, @context))
+
+    Logger.info("Created direct conversation",
+      conversation_id: conversation.id,
+      provider_id: provider_id,
+      initiator_id: scope.user.id
+    )
+
+    {:ok, conversation}
+  end
+
+  defp handle_commit({:error, reason}, _scope, _provider_id), do: {:error, reason}
 
   defp maybe_put_program_id(attrs, nil), do: attrs
   defp maybe_put_program_id(attrs, program_id), do: Map.put(attrs, :program_id, program_id)
@@ -108,19 +135,5 @@ defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversation do
            @participant_repo.add(%{conversation_id: conversation_id, user_id: user_id_2}) do
       :ok
     end
-  end
-
-  defp publish_event(conversation, participant_ids, provider_id) do
-    event =
-      MessagingEvents.conversation_created(
-        conversation.id,
-        conversation.type,
-        provider_id,
-        participant_ids,
-        conversation.program_id
-      )
-
-    DomainEventBus.dispatch(@context, event)
-    :ok
   end
 end

--- a/lib/klass_hero/messaging/application/commands/remove_assigned_staff.ex
+++ b/lib/klass_hero/messaging/application/commands/remove_assigned_staff.ex
@@ -1,0 +1,65 @@
+defmodule KlassHero.Messaging.Application.Commands.RemoveAssignedStaff do
+  @moduledoc """
+  Removes a staff member from every active conversation of a program and
+  **returns** one `:participant_removed` domain event per affected
+  conversation for the caller to dispatch *after* the enclosing
+  transaction commits.
+
+  ## Why events-as-data?
+
+  The `ConversationSummaries` projection reads from the DB on a separate
+  connection. To uphold read-your-own-writes, dispatches must occur after
+  `Repo.transaction` returns `{:ok, _}`. See
+  `KlassHero.Messaging.Application.Commands.AddAssignedStaff` for the
+  symmetric add command and the architectural rationale.
+
+  ## Returns
+
+  - `{:ok, {removals, events}}` — `removals` is a list of
+    `%{conversation_id: String.t()}`. `events` pairs 1-to-1 with
+    `removals` in the same order.
+  - `{:error, reason}` — when a `leave` write fails.
+  """
+
+  alias KlassHero.Messaging.Domain.Events.MessagingEvents
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  @conversation_reader Application.compile_env!(:klass_hero, [
+                         :messaging,
+                         :for_querying_conversations
+                       ])
+  @participant_repo Application.compile_env!(:klass_hero, [
+                      :messaging,
+                      :for_managing_participants
+                    ])
+
+  @type removal :: %{conversation_id: String.t()}
+
+  @spec execute(String.t(), String.t()) ::
+          {:ok, {[removal()], [DomainEvent.t()]}} | {:error, term()}
+  def execute(program_id, staff_user_id) do
+    program_id
+    |> @conversation_reader.list_active_program_conversation_ids_with_participant(staff_user_id)
+    |> remove_each(staff_user_id, [], [])
+  end
+
+  defp remove_each([], _staff_user_id, removals, events), do: {:ok, {Enum.reverse(removals), Enum.reverse(events)}}
+
+  defp remove_each([conversation_id | rest], staff_user_id, removals, events) do
+    with {:ok, _participant} <- @participant_repo.leave(conversation_id, staff_user_id) do
+      event =
+        MessagingEvents.participant_removed(
+          conversation_id,
+          [staff_user_id],
+          :staff_unassignment
+        )
+
+      remove_each(
+        rest,
+        staff_user_id,
+        [%{conversation_id: conversation_id} | removals],
+        [event | events]
+      )
+    end
+  end
+end

--- a/lib/klass_hero/messaging/application/commands/reply_privately_to_broadcast.ex
+++ b/lib/klass_hero/messaging/application/commands/reply_privately_to_broadcast.ex
@@ -11,10 +11,11 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast do
 
   alias KlassHero.Accounts.Scope
   alias KlassHero.Messaging
+  alias KlassHero.Messaging.Application.Commands.AddAssignedStaff
   alias KlassHero.Messaging.Application.Shared
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Repo
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
 
@@ -126,30 +127,40 @@ defmodule KlassHero.Messaging.Application.Commands.ReplyPrivatelyToBroadcast do
                conversation_id: conversation.id,
                user_id: provider_user_id
              }),
-           :ok <- Shared.add_assigned_staff(conversation.id, program_id, provider_user_id) do
-        publish_conversation_created(conversation, scope.user.id, provider_user_id, provider_id)
-        conversation
+           {:ok, {_staff_ids, staff_events}} <-
+             AddAssignedStaff.execute(conversation.id, program_id, provider_user_id) do
+        created_event =
+          MessagingEvents.conversation_created(
+            conversation.id,
+            conversation.type,
+            provider_id,
+            [scope.user.id, provider_user_id],
+            conversation.program_id
+          )
+
+        {conversation, [created_event | staff_events]}
       else
         {:error, reason} -> Repo.rollback(reason)
       end
     end)
+    |> handle_commit()
   end
+
+  # Trigger: Repo.transaction returns {:ok, {conversation, events}}
+  # Why: dispatching events post-commit lets the ConversationSummaries
+  #      projection (separate DB connection) read the committed conversation
+  #      when it processes the events.
+  # Outcome: each event fans out via EventDispatchHelper.dispatch/2; critical
+  #          events get Oban-backed retry on publish failure.
+  defp handle_commit({:ok, {conversation, events}}) do
+    Enum.each(events, &EventDispatchHelper.dispatch(&1, @context))
+    {:ok, conversation}
+  end
+
+  defp handle_commit({:error, reason}), do: {:error, reason}
 
   defp maybe_put_program_id(attrs, nil), do: attrs
   defp maybe_put_program_id(attrs, program_id), do: Map.put(attrs, :program_id, program_id)
-
-  defp publish_conversation_created(conversation, parent_user_id, provider_user_id, provider_id) do
-    event =
-      MessagingEvents.conversation_created(
-        conversation.id,
-        conversation.type,
-        provider_id,
-        [parent_user_id, provider_user_id],
-        conversation.program_id
-      )
-
-    DomainEventBus.dispatch(@context, event)
-  end
 
   # Trigger: parent initiates a private reply to a broadcast
   # Why: inserts a system note in the direct conversation so the provider

--- a/lib/klass_hero/messaging/application/commands/start_program_conversation.ex
+++ b/lib/klass_hero/messaging/application/commands/start_program_conversation.ex
@@ -9,11 +9,12 @@ defmodule KlassHero.Messaging.Application.Commands.StartProgramConversation do
   """
 
   alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Application.Commands.AddAssignedStaff
   alias KlassHero.Messaging.Application.Shared
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Domain.Models.Conversation
   alias KlassHero.Repo
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
 
@@ -61,22 +62,43 @@ defmodule KlassHero.Messaging.Application.Commands.StartProgramConversation do
     Repo.transaction(fn ->
       with {:ok, conversation} <- @conversation_repo.create(attrs),
            :ok <- add_participants(conversation.id, scope.user.id, owner_user_id),
-           :ok <- Shared.add_assigned_staff(conversation.id, program_id, scope.user.id) do
-        publish_event(conversation, [scope.user.id, owner_user_id], provider_id)
+           {:ok, {_staff_ids, staff_events}} <-
+             AddAssignedStaff.execute(conversation.id, program_id, scope.user.id) do
+        created_event =
+          MessagingEvents.conversation_created(
+            conversation.id,
+            conversation.type,
+            provider_id,
+            [scope.user.id, owner_user_id],
+            conversation.program_id
+          )
 
-        Logger.info("Created program-scoped direct conversation",
-          conversation_id: conversation.id,
-          provider_id: provider_id,
-          program_id: program_id,
-          initiator_id: scope.user.id
-        )
-
-        conversation
+        {conversation, [created_event | staff_events]}
       else
         {:error, reason} -> Repo.rollback(reason)
       end
     end)
+    |> handle_commit(scope, provider_id, program_id)
   end
+
+  # Trigger: Repo.transaction returns {:ok, {conversation, events}}
+  # Why: events fire post-commit so the projection's separate-connection
+  #      read sees the conversation row.
+  # Outcome: events fan out via EventDispatchHelper.dispatch/2.
+  defp handle_commit({:ok, {conversation, events}}, scope, provider_id, program_id) do
+    Enum.each(events, &EventDispatchHelper.dispatch(&1, @context))
+
+    Logger.info("Created program-scoped direct conversation",
+      conversation_id: conversation.id,
+      provider_id: provider_id,
+      program_id: program_id,
+      initiator_id: scope.user.id
+    )
+
+    {:ok, conversation}
+  end
+
+  defp handle_commit({:error, reason}, _scope, _provider_id, _program_id), do: {:error, reason}
 
   defp add_participants(conversation_id, user_id_1, user_id_2) do
     with {:ok, _} <-
@@ -85,19 +107,5 @@ defmodule KlassHero.Messaging.Application.Commands.StartProgramConversation do
            @participant_repo.add(%{conversation_id: conversation_id, user_id: user_id_2}) do
       :ok
     end
-  end
-
-  defp publish_event(conversation, participant_ids, provider_id) do
-    event =
-      MessagingEvents.conversation_created(
-        conversation.id,
-        conversation.type,
-        provider_id,
-        participant_ids,
-        conversation.program_id
-      )
-
-    DomainEventBus.dispatch(@context, event)
-    :ok
   end
 end

--- a/lib/klass_hero/messaging/application/shared.ex
+++ b/lib/klass_hero/messaging/application/shared.ex
@@ -1,15 +1,16 @@
 defmodule KlassHero.Messaging.Application.Shared do
   @moduledoc """
   Shared utilities for Messaging use cases.
+
+  Hosts cross-cutting helpers (participant verification, entitlement checks)
+  used by multiple commands. Staff-addition is owned by
+  `KlassHero.Messaging.Application.Commands.AddAssignedStaff`.
   """
 
   alias KlassHero.Accounts.Scope
   alias KlassHero.Shared.Entitlements
 
   require Logger
-
-  @participant_repo Application.compile_env!(:klass_hero, [:messaging, :for_managing_participants])
-  @staff_resolver Application.compile_env!(:klass_hero, [:messaging, :for_resolving_program_staff])
 
   @doc """
   Verifies that a user is a participant in a conversation.
@@ -70,31 +71,6 @@ defmodule KlassHero.Messaging.Application.Shared do
       :ok
     else
       check_entitlement(scope, metadata)
-    end
-  end
-
-  @doc """
-  Adds active assigned staff as participants to a conversation.
-
-  Queries the program staff projection for active staff user IDs and adds
-  them as conversation participants via batch insert. Excludes the owner
-  to avoid duplicate participant errors.
-
-  Returns `:ok` if program_id is nil (no program context) or after adding staff.
-  """
-  @spec add_assigned_staff(String.t(), String.t() | nil, String.t()) :: :ok | {:error, term()}
-  def add_assigned_staff(_conversation_id, nil, _owner_user_id), do: :ok
-
-  def add_assigned_staff(conversation_id, program_id, owner_user_id) do
-    staff_user_ids = @staff_resolver.get_active_staff_user_ids(program_id)
-    new_staff_ids = Enum.reject(staff_user_ids, &(&1 == owner_user_id))
-
-    case new_staff_ids do
-      [] ->
-        :ok
-
-      ids ->
-        with {:ok, _} <- @participant_repo.add_batch(conversation_id, ids), do: :ok
     end
   end
 end

--- a/lib/klass_hero/messaging/domain/events/messaging_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_events.ex
@@ -186,4 +186,60 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
       %{user_id: user_id}
     )
   end
+
+  @typedoc "Provenance of a participant_added event."
+  @type participant_added_source :: :initial_staff | :later_assignment
+
+  @doc """
+  Creates a participant_added event.
+
+  Published after one or more users are inserted into a conversation's
+  `participants` table. Promoted to a critical integration event for
+  CQRS projections.
+  """
+  @spec participant_added(
+          conversation_id :: String.t(),
+          participant_user_ids :: [String.t()],
+          source :: participant_added_source()
+        ) :: DomainEvent.t()
+  def participant_added(conversation_id, participant_user_ids, source) do
+    DomainEvent.new(
+      :participant_added,
+      conversation_id,
+      @aggregate_type,
+      %{
+        conversation_id: conversation_id,
+        participant_user_ids: participant_user_ids,
+        source: source
+      }
+    )
+  end
+
+  @typedoc "Provenance of a participant_removed event."
+  @type participant_removed_source :: :staff_unassignment
+
+  @doc """
+  Creates a participant_removed event.
+
+  Published after one or more users are removed from a conversation's
+  `participants` table. Promoted to a critical integration event for
+  CQRS projections (soft-archives summary rows).
+  """
+  @spec participant_removed(
+          conversation_id :: String.t(),
+          participant_user_ids :: [String.t()],
+          source :: participant_removed_source()
+        ) :: DomainEvent.t()
+  def participant_removed(conversation_id, participant_user_ids, source) do
+    DomainEvent.new(
+      :participant_removed,
+      conversation_id,
+      @aggregate_type,
+      %{
+        conversation_id: conversation_id,
+        participant_user_ids: participant_user_ids,
+        source: source
+      }
+    )
+  end
 end

--- a/lib/klass_hero/messaging/domain/events/messaging_integration_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_integration_events.ex
@@ -19,6 +19,10 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEvents do
     Entity type: `:conversation`.
   - `:conversations_archived` - Emitted when multiple conversations are archived
     in bulk. Entity type: `:conversation`.
+  - `:participant_added` - Emitted when one or more users are added to a
+    conversation's `participants` table (critical). Entity type: `:conversation`.
+  - `:participant_removed` - Emitted when one or more users are removed from a
+    conversation's `participants` table (critical). Entity type: `:conversation`.
   """
 
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
@@ -72,6 +76,28 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEvents do
           required(:conversation_ids) => [String.t()],
           optional(:reason) => String.t() | nil,
           optional(:count) => non_neg_integer(),
+          optional(atom()) => term()
+        }
+
+  @typedoc "Source of a `:participant_added` event."
+  @type participant_added_source :: :initial_staff | :later_assignment
+
+  @typedoc "Payload for `:participant_added` events."
+  @type participant_added_payload :: %{
+          required(:participant_user_ids) => [String.t()],
+          required(:source) => participant_added_source(),
+          optional(:conversation_id) => String.t(),
+          optional(atom()) => term()
+        }
+
+  @typedoc "Source of a `:participant_removed` event."
+  @type participant_removed_source :: :staff_unassignment
+
+  @typedoc "Payload for `:participant_removed` events."
+  @type participant_removed_payload :: %{
+          required(:participant_user_ids) => [String.t()],
+          required(:source) => participant_removed_source(),
+          optional(:conversation_id) => String.t(),
           optional(atom()) => term()
         }
 
@@ -370,5 +396,128 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEvents do
   def conversations_archived(aggregate_id, _payload, _opts) do
     raise ArgumentError,
           "conversations_archived/3 requires a non-empty aggregate_id string, got: #{inspect(aggregate_id)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # participant_added (entity type: :conversation)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Creates a `participant_added` integration event.
+
+  Published when one or more users are added to a conversation's
+  `participants` table (e.g., assigned staff joining a conversation at
+  creation time, or back-filled when staff are assigned to a program after
+  the conversation already exists).
+
+  Marked critical so CQRS projections receive every participant addition
+  durably — without this, late participants would be missing from
+  read-model summaries until a server restart re-derives them.
+
+  ## Parameters
+
+  - `conversation_id` - The conversation users were added to
+  - `payload` - Event-specific data (participant_user_ids, source)
+  - `opts` - Metadata options (correlation_id, causation_id)
+
+  ## Raises
+
+  - `ArgumentError` if `conversation_id` is nil or empty
+  - `ArgumentError` if `participant_user_ids` or `source` payload keys are missing
+  - `ArgumentError` if `participant_user_ids` is an empty list
+  """
+  def participant_added(conversation_id, payload \\ %{}, opts \\ [])
+
+  def participant_added(conversation_id, %{participant_user_ids: [_ | _] = _ids, source: _source} = payload, opts)
+      when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
+    base_payload = %{conversation_id: conversation_id}
+    opts = Keyword.put_new(opts, :criticality, :critical)
+
+    IntegrationEvent.new(
+      :participant_added,
+      @source_context,
+      :conversation,
+      conversation_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def participant_added(conversation_id, %{participant_user_ids: []}, _opts)
+      when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
+    raise ArgumentError, "participant_added requires a non-empty participant_user_ids list"
+  end
+
+  def participant_added(conversation_id, payload, _opts)
+      when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
+    missing = [:participant_user_ids, :source] -- Map.keys(payload)
+
+    raise ArgumentError,
+          "participant_added missing required payload keys: #{inspect(missing)}"
+  end
+
+  def participant_added(conversation_id, _payload, _opts) do
+    raise ArgumentError,
+          "participant_added/3 requires a non-empty conversation_id string, got: #{inspect(conversation_id)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # participant_removed (entity type: :conversation)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Creates a `participant_removed` integration event.
+
+  Published when one or more users are removed from a conversation's
+  `participants` table (e.g., staff unassigned from a program).
+
+  Marked critical so CQRS projections soft-remove (archive) the read-model
+  summary rows durably.
+
+  ## Parameters
+
+  - `conversation_id` - The conversation users were removed from
+  - `payload` - Event-specific data (participant_user_ids, source)
+  - `opts` - Metadata options (correlation_id, causation_id)
+
+  ## Raises
+
+  - `ArgumentError` if `conversation_id` is nil or empty
+  - `ArgumentError` if `participant_user_ids` or `source` payload keys are missing
+  - `ArgumentError` if `participant_user_ids` is an empty list
+  """
+  def participant_removed(conversation_id, payload \\ %{}, opts \\ [])
+
+  def participant_removed(conversation_id, %{participant_user_ids: [_ | _] = _ids, source: _source} = payload, opts)
+      when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
+    base_payload = %{conversation_id: conversation_id}
+    opts = Keyword.put_new(opts, :criticality, :critical)
+
+    IntegrationEvent.new(
+      :participant_removed,
+      @source_context,
+      :conversation,
+      conversation_id,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def participant_removed(conversation_id, %{participant_user_ids: []}, _opts)
+      when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
+    raise ArgumentError, "participant_removed requires a non-empty participant_user_ids list"
+  end
+
+  def participant_removed(conversation_id, payload, _opts)
+      when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
+    missing = [:participant_user_ids, :source] -- Map.keys(payload)
+
+    raise ArgumentError,
+          "participant_removed missing required payload keys: #{inspect(missing)}"
+  end
+
+  def participant_removed(conversation_id, _payload, _opts) do
+    raise ArgumentError,
+          "participant_removed/3 requires a non-empty conversation_id string, got: #{inspect(conversation_id)}"
   end
 end

--- a/lib/klass_hero/messaging/domain/ports/for_querying_conversations.ex
+++ b/lib/klass_hero/messaging/domain/ports/for_querying_conversations.ex
@@ -93,6 +93,20 @@ defmodule KlassHero.Messaging.Domain.Ports.ForQueryingConversations do
             ) :: [binary()]
 
   @doc """
+  Lists IDs of active conversations for a program where a specific user
+  IS an active participant.
+
+  Used by the staff-unassignment flow to find conversations from which a
+  newly-removed staff member must be detached.
+
+  Returns a list of conversation ID strings (may be empty).
+  """
+  @callback list_active_program_conversation_ids_with_participant(
+              program_id :: binary(),
+              user_id :: binary()
+            ) :: [binary()]
+
+  @doc """
   Lists IDs of conversations whose retention period has expired.
 
   Returns IDs for archived conversations where `retention_until` is

--- a/test/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_repository_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/persistence/repositories/conversation_repository_test.exs
@@ -636,5 +636,37 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Conversat
 
       assert result == []
     end
+
+    test "treats soft-left participations as 'not a participant' so the conversation is returned" do
+      # Why this matters: the staff-unassignment flow now soft-removes (sets
+      # `left_at`) instead of deleting. A subsequent re-assignment must see
+      # those conversations again — otherwise the staff is permanently locked
+      # out of every program conversation they've ever left.
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      user = AccountsFixtures.user_fixture()
+
+      conv =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          program_id: program.id,
+          type: "direct"
+        )
+
+      insert(:participant_schema,
+        conversation_id: conv.id,
+        user_id: user.id,
+        left_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      result =
+        ConversationRepository.list_active_program_conversation_ids_without_participant(
+          program.id,
+          user.id
+        )
+
+      assert result == [conv.id],
+             "left-but-recorded participations must NOT block re-assignment"
+    end
   end
 end

--- a/test/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository_test.exs
@@ -404,7 +404,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Participa
       assert ParticipantRepository.is_participant?(conv3.id, user.id)
     end
 
-    test "skips conversations where user is already a participant" do
+    test "preserves active rows untouched while inserting missing ones" do
       provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: provider.id)
       user = AccountsFixtures.user_fixture()
@@ -412,19 +412,71 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.Participa
       conv1 = insert(:conversation_schema, provider_id: provider.id, program_id: program.id)
       conv2 = insert(:conversation_schema, provider_id: provider.id, program_id: program.id)
 
-      insert(:participant_schema, conversation_id: conv1.id, user_id: user.id)
+      original_joined_at =
+        DateTime.utc_now()
+        |> DateTime.add(-3600, :second)
+        |> DateTime.truncate(:second)
 
-      assert {:ok, 1} =
+      insert(:participant_schema,
+        conversation_id: conv1.id,
+        user_id: user.id,
+        joined_at: original_joined_at
+      )
+
+      # Returned count includes the active-row no-op update + the new insert.
+      # The semantic guarantee for callers is that BOTH conversations end up
+      # with the user as an active participant — see assertions below.
+      assert {:ok, 2} =
                ParticipantRepository.add_to_conversations_batch(user.id, [conv1.id, conv2.id])
 
       assert ParticipantRepository.is_participant?(conv1.id, user.id)
       assert ParticipantRepository.is_participant?(conv2.id, user.id)
+
+      # The already-active row keeps its original joined_at — no clobber.
+      assert {:ok, reloaded} = ParticipantRepository.get(conv1.id, user.id)
+      assert reloaded.left_at == nil
+      assert DateTime.compare(reloaded.joined_at, original_joined_at) == :eq
     end
 
     test "returns {:ok, 0} for empty conversation list" do
       user = AccountsFixtures.user_fixture()
 
       assert {:ok, 0} = ParticipantRepository.add_to_conversations_batch(user.id, [])
+    end
+
+    test "re-activates a soft-left participant (clears left_at, preserves joined_at)" do
+      # Why this matters: when staff is unassigned via the new flow, their
+      # row is soft-left (left_at set). On re-assignment, this batch must
+      # bring the row back to active without rewriting the original join
+      # time — the audit trail of "first joined at" stays authoritative;
+      # `updated_at` captures the re-activation moment.
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      user = AccountsFixtures.user_fixture()
+      conv = insert(:conversation_schema, provider_id: provider.id, program_id: program.id)
+
+      original_joined_at =
+        DateTime.utc_now()
+        |> DateTime.add(-3600, :second)
+        |> DateTime.truncate(:second)
+
+      insert(:participant_schema,
+        conversation_id: conv.id,
+        user_id: user.id,
+        joined_at: original_joined_at,
+        left_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      refute ParticipantRepository.is_participant?(conv.id, user.id)
+
+      assert {:ok, _count} =
+               ParticipantRepository.add_to_conversations_batch(user.id, [conv.id])
+
+      assert ParticipantRepository.is_participant?(conv.id, user.id)
+
+      assert {:ok, reloaded} = ParticipantRepository.get(conv.id, user.id)
+      assert reloaded.left_at == nil
+      assert DateTime.compare(reloaded.joined_at, original_joined_at) == :eq
     end
   end
 end

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -405,6 +405,80 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
       assert summary_2.other_participant_name == "Alice Smith"
       assert summary_2.participant_count == 2
     end
+
+    test "re-firing event preserves last_read_at and unread_count (idempotent)" do
+      user_1 = user_fixture(name: "Alice Smith")
+      user_2 = user_fixture(name: "Bob Jones")
+
+      conversation_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :conversation_created,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            type: "direct",
+            provider_id: provider_id,
+            program_id: nil,
+            subject: nil,
+            participant_ids: [user_1.id, user_2.id]
+          }
+        )
+
+      # First firing — creates baseline rows
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:conversation_created",
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      # Simulate user_1 having read messages: messages_read flow would set
+      # last_read_at and reset unread_count. Mutate directly to isolate the
+      # idempotency assertion from the messages_read code path.
+      read_at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {1, _} =
+        Repo.update_all(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^user_1.id
+          ),
+          set: [last_read_at: read_at, unread_count: 7]
+        )
+
+      # Re-fire the same event — simulates an at-least-once redelivery
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:conversation_created",
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      summary_1 =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^user_1.id
+          )
+        )
+
+      assert summary_1.last_read_at == read_at,
+             "last_read_at must survive a :conversation_created replay"
+
+      assert summary_1.unread_count == 7,
+             "unread_count must survive a :conversation_created replay"
+
+      # Meta fields should still be in sync with the event payload
+      assert summary_1.conversation_type == "direct"
+      assert summary_1.provider_id == provider_id
+      assert summary_1.other_participant_name == "Bob Jones"
+      assert summary_1.participant_count == 2
+    end
   end
 
   describe "handle message_sent event" do
@@ -1155,6 +1229,524 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
       assert staff_summary != nil
       # Staff sees the first non-staff participant, which is parent
       assert staff_summary.other_participant_name == "Parent User"
+    end
+  end
+
+  describe "handle participant_added event" do
+    test "upserts a summary row for each newly added participant on a direct conversation" do
+      _ = :sys.get_state(@test_server_name)
+
+      provider = insert(:provider_profile_schema)
+      parent = user_fixture(name: "Parent One")
+      provider_user = user_fixture(name: "Provider Owner")
+      staff = user_fixture(name: "Staff Late")
+
+      conversation_id = Ecto.UUID.generate()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id
+      })
+
+      for {uid, ts} <- [{parent.id, now}, {provider_user.id, DateTime.add(now, 1, :second)}] do
+        Repo.insert!(%ParticipantSchema{
+          id: Ecto.UUID.generate(),
+          conversation_id: conversation_id,
+          user_id: uid,
+          joined_at: ts
+        })
+      end
+
+      # Seed an existing message so the new participant's summary back-fills
+      # last-message data and unread_count
+      Repo.insert!(%MessageSchema{
+        id: Ecto.UUID.generate(),
+        conversation_id: conversation_id,
+        sender_id: parent.id,
+        content: "Hi there",
+        message_type: "text",
+        inserted_at: now,
+        updated_at: now
+      })
+
+      # Add staff participant in write model — projection event follows
+      Repo.insert!(%ParticipantSchema{
+        id: Ecto.UUID.generate(),
+        conversation_id: conversation_id,
+        user_id: staff.id,
+        joined_at: DateTime.add(now, 2, :second)
+      })
+
+      event =
+        IntegrationEvent.new(
+          :participant_added,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_user_ids: [staff.id],
+            source: :later_assignment
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_added",
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      summary =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^staff.id
+          )
+        )
+
+      assert summary != nil, "staff summary row must exist after :participant_added"
+      assert summary.conversation_type == "direct"
+      assert summary.provider_id == provider.id
+      assert summary.participant_count == 3
+      assert summary.latest_message_content == "Hi there"
+      assert summary.latest_message_sender_id == parent.id
+      assert summary.unread_count == 1
+      assert summary.archived_at == nil
+    end
+
+    test "re-firing event preserves last_read_at and unread_count (idempotent replay)" do
+      _ = :sys.get_state(@test_server_name)
+
+      provider = insert(:provider_profile_schema)
+      parent = user_fixture(name: "Parent One")
+      staff = user_fixture(name: "Staff Late")
+
+      conversation_id = Ecto.UUID.generate()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id
+      })
+
+      Repo.insert!(%ParticipantSchema{
+        id: Ecto.UUID.generate(),
+        conversation_id: conversation_id,
+        user_id: parent.id,
+        joined_at: now
+      })
+
+      Repo.insert!(%ParticipantSchema{
+        id: Ecto.UUID.generate(),
+        conversation_id: conversation_id,
+        user_id: staff.id,
+        joined_at: DateTime.add(now, 1, :second)
+      })
+
+      event =
+        IntegrationEvent.new(
+          :participant_added,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_user_ids: [staff.id],
+            source: :later_assignment
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_added",
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      # Staff reads the conversation: simulate by setting last_read_at + zeroing unread
+      read_at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {1, _} =
+        Repo.update_all(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^staff.id
+          ),
+          set: [last_read_at: read_at, unread_count: 0]
+        )
+
+      # Replay the same event
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_added",
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      summary =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^staff.id
+          )
+        )
+
+      assert summary.last_read_at == read_at,
+             "last_read_at must survive a :participant_added replay"
+
+      assert summary.unread_count == 0,
+             "unread_count must survive a :participant_added replay"
+    end
+
+    test "inserts one summary row per user_id when payload carries a batch" do
+      _ = :sys.get_state(@test_server_name)
+
+      provider = insert(:provider_profile_schema)
+      parent = user_fixture(name: "Parent One")
+      staff_a = user_fixture(name: "Staff A")
+      staff_b = user_fixture(name: "Staff B")
+
+      conversation_id = Ecto.UUID.generate()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id
+      })
+
+      for {uid, ts} <- [
+            {parent.id, now},
+            {staff_a.id, DateTime.add(now, 1, :second)},
+            {staff_b.id, DateTime.add(now, 2, :second)}
+          ] do
+        Repo.insert!(%ParticipantSchema{
+          id: Ecto.UUID.generate(),
+          conversation_id: conversation_id,
+          user_id: uid,
+          joined_at: ts
+        })
+      end
+
+      event =
+        IntegrationEvent.new(
+          :participant_added,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_user_ids: [staff_a.id, staff_b.id],
+            source: :initial_staff
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_added",
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      summaries =
+        Repo.all(
+          from(s in ConversationSummarySchema,
+            where:
+              s.conversation_id == ^conversation_id and
+                s.user_id in ^[staff_a.id, staff_b.id],
+            order_by: s.user_id
+          )
+        )
+
+      assert length(summaries) == 2
+      assert Enum.all?(summaries, &(&1.participant_count == 3))
+      assert Enum.all?(summaries, &(&1.conversation_type == "direct"))
+    end
+
+    test "inserts row for broadcast conversation with nil other_participant_name" do
+      _ = :sys.get_state(@test_server_name)
+
+      provider = insert(:provider_profile_schema)
+      staff = user_fixture(name: "Staff Late")
+
+      conversation_id = Ecto.UUID.generate()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "program_broadcast",
+        provider_id: provider.id
+      })
+
+      Repo.insert!(%ParticipantSchema{
+        id: Ecto.UUID.generate(),
+        conversation_id: conversation_id,
+        user_id: staff.id,
+        joined_at: now
+      })
+
+      event =
+        IntegrationEvent.new(
+          :participant_added,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_user_ids: [staff.id],
+            source: :later_assignment
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_added",
+        {:integration_event, event}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      summary =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^staff.id
+          )
+        )
+
+      assert summary != nil
+      assert summary.conversation_type == "program_broadcast"
+      assert summary.other_participant_name == nil
+    end
+  end
+
+  describe "handle participant_removed event" do
+    test "soft-archives the summary row for the removed user" do
+      _ = :sys.get_state(@test_server_name)
+
+      user_1 = user_fixture(name: "Alice Smith")
+      staff = user_fixture(name: "Staff Out")
+
+      conversation_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      created =
+        IntegrationEvent.new(
+          :conversation_created,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            type: "direct",
+            provider_id: provider_id,
+            participant_ids: [user_1.id, staff.id]
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:conversation_created",
+        {:integration_event, created}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      removed =
+        IntegrationEvent.new(
+          :participant_removed,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_user_ids: [staff.id],
+            source: :staff_unassignment
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_removed",
+        {:integration_event, removed}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      staff_summary =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^staff.id
+          )
+        )
+
+      assert staff_summary != nil
+      assert staff_summary.archived_at != nil
+
+      # Non-removed users keep their row intact
+      user_1_summary =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^user_1.id
+          )
+        )
+
+      assert user_1_summary.archived_at == nil
+    end
+
+    test "replay preserves the first archived_at timestamp (COALESCE idempotency)" do
+      _ = :sys.get_state(@test_server_name)
+
+      user_1 = user_fixture(name: "Alice Smith")
+      staff = user_fixture(name: "Staff Out")
+
+      conversation_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      created =
+        IntegrationEvent.new(
+          :conversation_created,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            type: "direct",
+            provider_id: provider_id,
+            participant_ids: [user_1.id, staff.id]
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:conversation_created",
+        {:integration_event, created}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      removed =
+        IntegrationEvent.new(
+          :participant_removed,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_user_ids: [staff.id],
+            source: :staff_unassignment
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_removed",
+        {:integration_event, removed}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      first =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^staff.id,
+            select: s.archived_at
+          )
+        )
+
+      # Replay later — the second archived_at would differ if the handler
+      # blindly overwrote. COALESCE keeps the original.
+      Process.sleep(1_100)
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_removed",
+        {:integration_event, removed}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      second =
+        Repo.one(
+          from(s in ConversationSummarySchema,
+            where: s.conversation_id == ^conversation_id and s.user_id == ^staff.id,
+            select: s.archived_at
+          )
+        )
+
+      assert second == first, "first removal's archived_at must win on replay"
+    end
+
+    test "archives multiple users in a single batch event" do
+      _ = :sys.get_state(@test_server_name)
+
+      user_1 = user_fixture(name: "Alice Smith")
+      staff_a = user_fixture(name: "Staff A")
+      staff_b = user_fixture(name: "Staff B")
+
+      conversation_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      created =
+        IntegrationEvent.new(
+          :conversation_created,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            type: "direct",
+            provider_id: provider_id,
+            participant_ids: [user_1.id, staff_a.id, staff_b.id]
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:conversation_created",
+        {:integration_event, created}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      removed =
+        IntegrationEvent.new(
+          :participant_removed,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_user_ids: [staff_a.id, staff_b.id],
+            source: :staff_unassignment
+          }
+        )
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:participant_removed",
+        {:integration_event, removed}
+      )
+
+      _ = :sys.get_state(@test_server_name)
+
+      archived_count =
+        Repo.aggregate(
+          from(s in ConversationSummarySchema,
+            where:
+              s.conversation_id == ^conversation_id and
+                s.user_id in ^[staff_a.id, staff_b.id] and
+                not is_nil(s.archived_at)
+          ),
+          :count,
+          :id
+        )
+
+      assert archived_count == 2
     end
   end
 

--- a/test/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -220,4 +220,82 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
       assert_no_integration_events_published()
     end
   end
+
+  describe "handle/1 — :participant_added" do
+    test "promotes to participant_added integration event" do
+      conversation_id = Ecto.UUID.generate()
+      user_ids = [Ecto.UUID.generate(), Ecto.UUID.generate()]
+
+      domain_event =
+        DomainEvent.new(:participant_added, conversation_id, :conversation, %{
+          conversation_id: conversation_id,
+          participant_user_ids: user_ids,
+          source: :initial_staff
+        })
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+
+      event = assert_integration_event_published(:participant_added)
+      assert event.entity_id == conversation_id
+      assert event.source_context == :messaging
+      assert event.entity_type == :conversation
+      assert event.payload.participant_user_ids == user_ids
+      assert event.payload.source == :initial_staff
+      assert IntegrationEvent.critical?(event)
+    end
+
+    test "propagates publish failures as {:error, reason}" do
+      conversation_id = Ecto.UUID.generate()
+
+      domain_event =
+        DomainEvent.new(:participant_added, conversation_id, :conversation, %{
+          conversation_id: conversation_id,
+          participant_user_ids: [Ecto.UUID.generate()],
+          source: :later_assignment
+        })
+
+      TestIntegrationEventPublisher.configure_publish_error(:pubsub_down)
+
+      assert {:error, :pubsub_down} = PromoteIntegrationEvents.handle(domain_event)
+    end
+  end
+
+  describe "handle/1 — :participant_removed" do
+    test "promotes to participant_removed integration event" do
+      conversation_id = Ecto.UUID.generate()
+      user_ids = [Ecto.UUID.generate()]
+
+      domain_event =
+        DomainEvent.new(:participant_removed, conversation_id, :conversation, %{
+          conversation_id: conversation_id,
+          participant_user_ids: user_ids,
+          source: :staff_unassignment
+        })
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+
+      event = assert_integration_event_published(:participant_removed)
+      assert event.entity_id == conversation_id
+      assert event.source_context == :messaging
+      assert event.entity_type == :conversation
+      assert event.payload.participant_user_ids == user_ids
+      assert event.payload.source == :staff_unassignment
+      assert IntegrationEvent.critical?(event)
+    end
+
+    test "propagates publish failures as {:error, reason}" do
+      conversation_id = Ecto.UUID.generate()
+
+      domain_event =
+        DomainEvent.new(:participant_removed, conversation_id, :conversation, %{
+          conversation_id: conversation_id,
+          participant_user_ids: [Ecto.UUID.generate()],
+          source: :staff_unassignment
+        })
+
+      TestIntegrationEventPublisher.configure_publish_error(:pubsub_down)
+
+      assert {:error, :pubsub_down} = PromoteIntegrationEvents.handle(domain_event)
+    end
+  end
 end

--- a/test/klass_hero/messaging/adapters/driving/events/staff_assignment_handler_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/events/staff_assignment_handler_test.exs
@@ -1,12 +1,18 @@
 defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest do
-  use KlassHero.DataCase, async: true
+  use KlassHero.DataCase, async: false
 
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
 
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ParticipantRepository
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ProgramStaffParticipantRepository
   alias KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  setup do
+    setup_test_integration_events()
+    :ok
+  end
 
   describe "handle_event/1 - staff_assigned_to_program" do
     test "upserts projection when staff_user_id is present" do
@@ -49,6 +55,71 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest
       # Staff should now be a participant
       assert ParticipantRepository.is_participant?(conversation.id, staff_user_id)
     end
+
+    test "emits :participant_added per back-filled conversation with source :later_assignment" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+      staff_user = KlassHero.AccountsFixtures.user_fixture()
+
+      conv_a =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: "direct",
+          program_id: program.id
+        )
+
+      conv_b =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: "direct",
+          program_id: program.id
+        )
+
+      insert(:participant_schema, conversation_id: conv_a.id, user_id: parent_user.id)
+      insert(:participant_schema, conversation_id: conv_b.id, user_id: parent_user.id)
+
+      event = build_assignment_event(provider.id, program.id, staff_user.id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      events =
+        Enum.filter(
+          get_published_integration_events(),
+          &(&1.event_type == :participant_added)
+        )
+
+      assert length(events) == 2
+      conv_ids = events |> Enum.map(& &1.entity_id) |> Enum.sort()
+      assert conv_ids == Enum.sort([conv_a.id, conv_b.id])
+
+      assert Enum.all?(events, fn e ->
+               e.payload.participant_user_ids == [staff_user.id] and
+                 e.payload.source == :later_assignment
+             end)
+    end
+
+    test "emits no :participant_added when staff is already in every program conversation" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff_user = KlassHero.AccountsFixtures.user_fixture()
+
+      conv =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: "direct",
+          program_id: program.id
+        )
+
+      insert(:participant_schema, conversation_id: conv.id, user_id: staff_user.id)
+
+      event = build_assignment_event(provider.id, program.id, staff_user.id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      refute Enum.any?(
+               get_published_integration_events(),
+               &(&1.event_type == :participant_added)
+             )
+    end
   end
 
   describe "handle_event/1 - staff_unassigned_from_program" do
@@ -67,6 +138,57 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest
       assert :ok = StaffAssignmentHandler.handle_event(event)
 
       assert [] = ProgramStaffParticipantRepository.get_active_staff_user_ids(program_id)
+    end
+
+    test "removes staff from active program conversations and emits :participant_removed per conversation" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+      staff_user = KlassHero.AccountsFixtures.user_fixture()
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_user.id
+      })
+
+      conv_a =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: "direct",
+          program_id: program.id
+        )
+
+      conv_b =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: "direct",
+          program_id: program.id
+        )
+
+      insert(:participant_schema, conversation_id: conv_a.id, user_id: parent_user.id)
+      insert(:participant_schema, conversation_id: conv_a.id, user_id: staff_user.id)
+      insert(:participant_schema, conversation_id: conv_b.id, user_id: parent_user.id)
+      insert(:participant_schema, conversation_id: conv_b.id, user_id: staff_user.id)
+
+      event = build_unassignment_event(provider.id, program.id, staff_user.id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      refute ParticipantRepository.is_participant?(conv_a.id, staff_user.id)
+      refute ParticipantRepository.is_participant?(conv_b.id, staff_user.id)
+
+      events =
+        Enum.filter(
+          get_published_integration_events(),
+          &(&1.event_type == :participant_removed)
+        )
+
+      assert length(events) == 2
+
+      assert Enum.all?(events, fn e ->
+               e.payload.participant_user_ids == [staff_user.id] and
+                 e.payload.source == :staff_unassignment
+             end)
     end
   end
 

--- a/test/klass_hero/messaging/application/commands/add_assigned_staff_test.exs
+++ b/test/klass_hero/messaging/application/commands/add_assigned_staff_test.exs
@@ -1,0 +1,164 @@
+defmodule KlassHero.Messaging.Application.Commands.AddAssignedStaffTest do
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
+
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ParticipantRepository
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ProgramStaffParticipantRepository
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSchema
+  alias KlassHero.Messaging.Application.Commands.AddAssignedStaff
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  setup do
+    setup_test_integration_events()
+    :ok
+  end
+
+  describe "execute/3 — events-as-data contract" do
+    test "returns {:ok, {added_ids, [DomainEvent]}} and does NOT dispatch the event itself" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      owner = AccountsFixtures.user_fixture()
+      staff_a = AccountsFixtures.user_fixture()
+      staff_b = AccountsFixtures.user_fixture()
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_a.id
+      })
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_b.id
+      })
+
+      conversation_id = Ecto.UUID.generate()
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id,
+        program_id: program.id
+      })
+
+      assert {:ok, {:ok, {added_ids, events}}} =
+               Repo.transaction(fn ->
+                 AddAssignedStaff.execute(conversation_id, program.id, owner.id)
+               end)
+
+      assert Enum.sort(added_ids) == Enum.sort([staff_a.id, staff_b.id])
+      assert ParticipantRepository.is_participant?(conversation_id, staff_a.id)
+      assert ParticipantRepository.is_participant?(conversation_id, staff_b.id)
+
+      assert [%DomainEvent{} = event] = events
+      assert event.event_type == :participant_added
+      assert event.aggregate_id == conversation_id
+      assert event.aggregate_type == :conversation
+      assert Enum.sort(event.payload.participant_user_ids) == Enum.sort([staff_a.id, staff_b.id])
+      assert event.payload.source == :initial_staff
+
+      # Critical: the command must NOT dispatch the event itself —
+      # post-commit dispatch is the caller's responsibility so the projection
+      # can read-your-own-writes after Repo.transaction commits.
+      refute Enum.any?(
+               get_published_integration_events(),
+               &(&1.event_type == :participant_added)
+             )
+    end
+
+    test "excludes the owner from participant additions and from event payload" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      owner = AccountsFixtures.user_fixture()
+      staff = AccountsFixtures.user_fixture()
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: owner.id
+      })
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff.id
+      })
+
+      conversation_id = Ecto.UUID.generate()
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id,
+        program_id: program.id
+      })
+
+      assert {:ok, {:ok, {added_ids, [event]}}} =
+               Repo.transaction(fn ->
+                 AddAssignedStaff.execute(conversation_id, program.id, owner.id)
+               end)
+
+      assert added_ids == [staff.id]
+      refute ParticipantRepository.is_participant?(conversation_id, owner.id)
+      assert event.payload.participant_user_ids == [staff.id]
+    end
+
+    test "no staff assigned to program — returns {:ok, {[], []}} and no events" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      owner = AccountsFixtures.user_fixture()
+
+      conversation_id = Ecto.UUID.generate()
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id,
+        program_id: program.id
+      })
+
+      assert {:ok, {:ok, {[], []}}} =
+               Repo.transaction(fn ->
+                 AddAssignedStaff.execute(conversation_id, program.id, owner.id)
+               end)
+    end
+
+    test "nil program_id — returns {:ok, {[], []}} immediately" do
+      owner = AccountsFixtures.user_fixture()
+      conversation_id = Ecto.UUID.generate()
+
+      assert {:ok, {[], []}} = AddAssignedStaff.execute(conversation_id, nil, owner.id)
+    end
+
+    test "owner is the only staff member — returns {:ok, {[], []}}" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      owner = AccountsFixtures.user_fixture()
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: owner.id
+      })
+
+      conversation_id = Ecto.UUID.generate()
+
+      Repo.insert!(%ConversationSchema{
+        id: conversation_id,
+        type: "direct",
+        provider_id: provider.id,
+        program_id: program.id
+      })
+
+      assert {:ok, {:ok, {[], []}}} =
+               Repo.transaction(fn ->
+                 AddAssignedStaff.execute(conversation_id, program.id, owner.id)
+               end)
+    end
+  end
+end

--- a/test/klass_hero/messaging/application/commands/create_direct_conversation_test.exs
+++ b/test/klass_hero/messaging/application/commands/create_direct_conversation_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversationTest do
-  use KlassHero.DataCase, async: true
+  use KlassHero.DataCase, async: false
 
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
 
   alias KlassHero.Accounts.Scope
@@ -11,6 +12,7 @@ defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversationTest 
   alias KlassHero.Messaging.Application.Commands.CreateDirectConversation
   alias KlassHero.Messaging.Domain.Models.Conversation
   alias KlassHero.Provider.Domain.Models.ProviderProfile
+  alias KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher
 
   describe "execute/4 with opts" do
     test "skips entitlement check when skip_entitlement_check: true" do
@@ -115,6 +117,11 @@ defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversationTest 
   end
 
   describe "staff auto-inclusion" do
+    setup do
+      setup_test_integration_events()
+      :ok
+    end
+
     test "adds assigned staff as participants when conversation has program context" do
       provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: provider.id)
@@ -131,6 +138,66 @@ defmodule KlassHero.Messaging.Application.Commands.CreateDirectConversationTest 
       assert {:ok, conversation} =
                CreateDirectConversation.execute(scope, provider.id, target_user.id, program_id: program.id)
 
+      assert ParticipantRepository.is_participant?(conversation.id, staff_user.id)
+    end
+
+    test "publishes :participant_added integration event when staff are added" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      scope = build_scope_with_provider(provider, :professional)
+      target_user = AccountsFixtures.user_fixture()
+      staff_user = AccountsFixtures.user_fixture()
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_user.id
+      })
+
+      assert {:ok, conversation} =
+               CreateDirectConversation.execute(
+                 scope,
+                 provider.id,
+                 target_user.id,
+                 program_id: program.id
+               )
+
+      event = assert_integration_event_published(:participant_added)
+      assert event.entity_id == conversation.id
+      assert event.payload.participant_user_ids == [staff_user.id]
+      assert event.payload.source == :initial_staff
+    end
+
+    test "post-commit dispatch contract: publish failure does NOT roll back the conversation" do
+      # Why this matters: events are dispatched *after* Repo.transaction commits,
+      # so a publish failure (e.g. PubSub down) cannot poison the user's flow.
+      # The persisted state stays consistent; Oban retries the publish for
+      # critical events.
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      scope = build_scope_with_provider(provider, :professional)
+      target_user = AccountsFixtures.user_fixture()
+      staff_user = AccountsFixtures.user_fixture()
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_user.id
+      })
+
+      TestIntegrationEventPublisher.configure_publish_error(:pubsub_down)
+
+      assert {:ok, conversation} =
+               CreateDirectConversation.execute(
+                 scope,
+                 provider.id,
+                 target_user.id,
+                 program_id: program.id
+               )
+
+      # Conversation persists despite the publish failure
+      assert ParticipantRepository.is_participant?(conversation.id, scope.user.id)
+      assert ParticipantRepository.is_participant?(conversation.id, target_user.id)
       assert ParticipantRepository.is_participant?(conversation.id, staff_user.id)
     end
 

--- a/test/klass_hero/messaging/application/commands/remove_assigned_staff_test.exs
+++ b/test/klass_hero/messaging/application/commands/remove_assigned_staff_test.exs
@@ -1,0 +1,141 @@
+defmodule KlassHero.Messaging.Application.Commands.RemoveAssignedStaffTest do
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
+
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ParticipantRepository
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ConversationSchema
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.ParticipantSchema
+  alias KlassHero.Messaging.Application.Commands.RemoveAssignedStaff
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  setup do
+    setup_test_integration_events()
+    :ok
+  end
+
+  describe "execute/2 — events-as-data contract" do
+    test "returns {:ok, {removals, events}} and does NOT dispatch the events itself" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff = AccountsFixtures.user_fixture()
+      parent_a = AccountsFixtures.user_fixture()
+      parent_b = AccountsFixtures.user_fixture()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      conv_a = insert_conversation(provider.id, program.id)
+      conv_b = insert_conversation(provider.id, program.id)
+      insert_participant(conv_a, staff.id, now)
+      insert_participant(conv_a, parent_a.id, now)
+      insert_participant(conv_b, staff.id, now)
+      insert_participant(conv_b, parent_b.id, now)
+
+      assert {:ok, {:ok, {removed, events}}} =
+               Repo.transaction(fn ->
+                 RemoveAssignedStaff.execute(program.id, staff.id)
+               end)
+
+      assert Enum.sort(Enum.map(removed, & &1.conversation_id)) ==
+               Enum.sort([conv_a, conv_b])
+
+      refute ParticipantRepository.is_participant?(conv_a, staff.id)
+      refute ParticipantRepository.is_participant?(conv_b, staff.id)
+
+      assert length(events) == 2
+      assert Enum.all?(events, &match?(%DomainEvent{event_type: :participant_removed}, &1))
+
+      event_conv_ids = events |> Enum.map(& &1.aggregate_id) |> Enum.sort()
+      assert event_conv_ids == Enum.sort([conv_a, conv_b])
+
+      assert Enum.all?(events, fn e ->
+               e.payload.participant_user_ids == [staff.id] and
+                 e.payload.source == :staff_unassignment
+             end)
+
+      # Critical: events are returned as data, NOT dispatched in-band.
+      refute Enum.any?(
+               get_published_integration_events(),
+               &(&1.event_type == :participant_removed)
+             )
+    end
+
+    test "staff in zero conversations — returns {:ok, {[], []}}" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff = AccountsFixtures.user_fixture()
+
+      assert {:ok, {:ok, {[], []}}} =
+               Repo.transaction(fn ->
+                 RemoveAssignedStaff.execute(program.id, staff.id)
+               end)
+    end
+
+    test "skips archived conversations" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff = AccountsFixtures.user_fixture()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      archived_conv = insert_conversation(provider.id, program.id, archived_at: now)
+      insert_participant(archived_conv, staff.id, now)
+
+      assert {:ok, {:ok, {[], []}}} =
+               Repo.transaction(fn ->
+                 RemoveAssignedStaff.execute(program.id, staff.id)
+               end)
+
+      assert ParticipantRepository.is_participant?(archived_conv, staff.id)
+    end
+
+    test "leaves non-program conversations alone" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      other_program = insert(:program_schema, provider_id: provider.id)
+      staff = AccountsFixtures.user_fixture()
+      parent = AccountsFixtures.user_fixture()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      target_conv = insert_conversation(provider.id, program.id)
+      other_conv = insert_conversation(provider.id, other_program.id)
+      insert_participant(target_conv, staff.id, now)
+      insert_participant(target_conv, parent.id, now)
+      insert_participant(other_conv, staff.id, now)
+
+      assert {:ok, {:ok, {removed, [event]}}} =
+               Repo.transaction(fn ->
+                 RemoveAssignedStaff.execute(program.id, staff.id)
+               end)
+
+      assert Enum.map(removed, & &1.conversation_id) == [target_conv]
+      assert event.aggregate_id == target_conv
+      refute ParticipantRepository.is_participant?(target_conv, staff.id)
+      assert ParticipantRepository.is_participant?(other_conv, staff.id)
+    end
+  end
+
+  defp insert_conversation(provider_id, program_id, opts \\ []) do
+    id = Ecto.UUID.generate()
+
+    Repo.insert!(%ConversationSchema{
+      id: id,
+      type: "direct",
+      provider_id: provider_id,
+      program_id: program_id,
+      archived_at: Keyword.get(opts, :archived_at)
+    })
+
+    id
+  end
+
+  defp insert_participant(conversation_id, user_id, joined_at) do
+    Repo.insert!(%ParticipantSchema{
+      id: Ecto.UUID.generate(),
+      conversation_id: conversation_id,
+      user_id: user_id,
+      joined_at: joined_at
+    })
+  end
+end

--- a/test/klass_hero/messaging/domain/events/messaging_events_test.exs
+++ b/test/klass_hero/messaging/domain/events/messaging_events_test.exs
@@ -138,4 +138,48 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEventsTest do
       assert event.payload.user_id == user_id
     end
   end
+
+  describe "participant_added/3" do
+    test "creates event with correct type and payload" do
+      conversation_id = Ecto.UUID.generate()
+      user_ids = [Ecto.UUID.generate(), Ecto.UUID.generate()]
+
+      event = MessagingEvents.participant_added(conversation_id, user_ids, :initial_staff)
+
+      assert event.event_type == :participant_added
+      assert event.aggregate_id == conversation_id
+      assert event.aggregate_type == :conversation
+      assert event.payload.conversation_id == conversation_id
+      assert event.payload.participant_user_ids == user_ids
+      assert event.payload.source == :initial_staff
+    end
+
+    test "accepts :later_assignment source" do
+      event =
+        MessagingEvents.participant_added(
+          Ecto.UUID.generate(),
+          [Ecto.UUID.generate()],
+          :later_assignment
+        )
+
+      assert event.payload.source == :later_assignment
+    end
+  end
+
+  describe "participant_removed/3" do
+    test "creates event with correct type and payload" do
+      conversation_id = Ecto.UUID.generate()
+      user_ids = [Ecto.UUID.generate()]
+
+      event =
+        MessagingEvents.participant_removed(conversation_id, user_ids, :staff_unassignment)
+
+      assert event.event_type == :participant_removed
+      assert event.aggregate_id == conversation_id
+      assert event.aggregate_type == :conversation
+      assert event.payload.conversation_id == conversation_id
+      assert event.payload.participant_user_ids == user_ids
+      assert event.payload.source == :staff_unassignment
+    end
+  end
 end

--- a/test/klass_hero/messaging/domain/events/messaging_integration_events_test.exs
+++ b/test/klass_hero/messaging/domain/events/messaging_integration_events_test.exs
@@ -306,4 +306,196 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEventsTest do
                    end
     end
   end
+
+  describe "participant_added/3" do
+    test "creates event with correct type, source_context, and entity_type" do
+      conversation_id = Ecto.UUID.generate()
+
+      event =
+        MessagingIntegrationEvents.participant_added(conversation_id, %{
+          participant_user_ids: [Ecto.UUID.generate()],
+          source: :initial_staff
+        })
+
+      assert event.event_type == :participant_added
+      assert event.source_context == :messaging
+      assert event.entity_type == :conversation
+      assert event.entity_id == conversation_id
+    end
+
+    test "base_payload conversation_id wins over caller-supplied" do
+      real_id = Ecto.UUID.generate()
+      staff_id = Ecto.UUID.generate()
+
+      event =
+        MessagingIntegrationEvents.participant_added(real_id, %{
+          conversation_id: "should-be-overridden",
+          participant_user_ids: [staff_id],
+          source: :later_assignment,
+          extra: "data"
+        })
+
+      assert event.payload.conversation_id == real_id
+      assert event.payload.participant_user_ids == [staff_id]
+      assert event.payload.source == :later_assignment
+      assert event.payload.extra == "data"
+    end
+
+    test "marks event as critical by default" do
+      conversation_id = Ecto.UUID.generate()
+
+      event =
+        MessagingIntegrationEvents.participant_added(conversation_id, %{
+          participant_user_ids: [Ecto.UUID.generate()],
+          source: :initial_staff
+        })
+
+      assert IntegrationEvent.critical?(event)
+    end
+
+    test "raises when required payload keys are missing" do
+      conversation_id = Ecto.UUID.generate()
+
+      assert_raise ArgumentError,
+                   ~r/participant_added missing required payload keys/,
+                   fn -> MessagingIntegrationEvents.participant_added(conversation_id, %{}) end
+
+      assert_raise ArgumentError,
+                   ~r/participant_added missing required payload keys/,
+                   fn ->
+                     MessagingIntegrationEvents.participant_added(conversation_id, %{
+                       participant_user_ids: ["u1"]
+                     })
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/participant_added missing required payload keys/,
+                   fn ->
+                     MessagingIntegrationEvents.participant_added(conversation_id, %{
+                       source: :initial_staff
+                     })
+                   end
+    end
+
+    test "raises when participant_user_ids is empty" do
+      conversation_id = Ecto.UUID.generate()
+
+      assert_raise ArgumentError,
+                   ~r/participant_added requires a non-empty participant_user_ids list/,
+                   fn ->
+                     MessagingIntegrationEvents.participant_added(conversation_id, %{
+                       participant_user_ids: [],
+                       source: :initial_staff
+                     })
+                   end
+    end
+
+    test "raises for nil or empty conversation_id" do
+      valid_payload = %{participant_user_ids: ["u1"], source: :initial_staff}
+
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty conversation_id string/,
+                   fn -> MessagingIntegrationEvents.participant_added(nil, valid_payload) end
+
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty conversation_id string/,
+                   fn -> MessagingIntegrationEvents.participant_added("", valid_payload) end
+    end
+  end
+
+  describe "participant_removed/3" do
+    test "creates event with correct type, source_context, and entity_type" do
+      conversation_id = Ecto.UUID.generate()
+
+      event =
+        MessagingIntegrationEvents.participant_removed(conversation_id, %{
+          participant_user_ids: [Ecto.UUID.generate()],
+          source: :staff_unassignment
+        })
+
+      assert event.event_type == :participant_removed
+      assert event.source_context == :messaging
+      assert event.entity_type == :conversation
+      assert event.entity_id == conversation_id
+    end
+
+    test "base_payload conversation_id wins over caller-supplied" do
+      real_id = Ecto.UUID.generate()
+      staff_id = Ecto.UUID.generate()
+
+      event =
+        MessagingIntegrationEvents.participant_removed(real_id, %{
+          conversation_id: "should-be-overridden",
+          participant_user_ids: [staff_id],
+          source: :staff_unassignment,
+          extra: "data"
+        })
+
+      assert event.payload.conversation_id == real_id
+      assert event.payload.participant_user_ids == [staff_id]
+      assert event.payload.source == :staff_unassignment
+      assert event.payload.extra == "data"
+    end
+
+    test "marks event as critical by default" do
+      conversation_id = Ecto.UUID.generate()
+
+      event =
+        MessagingIntegrationEvents.participant_removed(conversation_id, %{
+          participant_user_ids: [Ecto.UUID.generate()],
+          source: :staff_unassignment
+        })
+
+      assert IntegrationEvent.critical?(event)
+    end
+
+    test "raises when required payload keys are missing" do
+      conversation_id = Ecto.UUID.generate()
+
+      assert_raise ArgumentError,
+                   ~r/participant_removed missing required payload keys/,
+                   fn -> MessagingIntegrationEvents.participant_removed(conversation_id, %{}) end
+
+      assert_raise ArgumentError,
+                   ~r/participant_removed missing required payload keys/,
+                   fn ->
+                     MessagingIntegrationEvents.participant_removed(conversation_id, %{
+                       participant_user_ids: ["u1"]
+                     })
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/participant_removed missing required payload keys/,
+                   fn ->
+                     MessagingIntegrationEvents.participant_removed(conversation_id, %{
+                       source: :staff_unassignment
+                     })
+                   end
+    end
+
+    test "raises when participant_user_ids is empty" do
+      conversation_id = Ecto.UUID.generate()
+
+      assert_raise ArgumentError,
+                   ~r/participant_removed requires a non-empty participant_user_ids list/,
+                   fn ->
+                     MessagingIntegrationEvents.participant_removed(conversation_id, %{
+                       participant_user_ids: [],
+                       source: :staff_unassignment
+                     })
+                   end
+    end
+
+    test "raises for nil or empty conversation_id" do
+      valid_payload = %{participant_user_ids: ["u1"], source: :staff_unassignment}
+
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty conversation_id string/,
+                   fn -> MessagingIntegrationEvents.participant_removed(nil, valid_payload) end
+
+      assert_raise ArgumentError,
+                   ~r/requires a non-empty conversation_id string/,
+                   fn -> MessagingIntegrationEvents.participant_removed("", valid_payload) end
+    end
+  end
 end

--- a/test/klass_hero/messaging/staff_messaging_integration_test.exs
+++ b/test/klass_hero/messaging/staff_messaging_integration_test.exs
@@ -99,10 +99,13 @@ defmodule KlassHero.Messaging.StaffMessagingIntegrationTest do
                  )
                )
 
-      # 6. Staff is still a participant in the existing conversation (soft unassign)
-      assert ParticipantRepository.is_participant?(conversation.id, ctx.staff_user.id)
+      # 6. Staff is removed from the existing conversation — #817 closes the
+      #    inbox-visibility gap symmetrically: on unassignment the handler
+      #    drops the participant row and emits :participant_removed so the
+      #    projection archives the staff's summary row.
+      refute ParticipantRepository.is_participant?(conversation.id, ctx.staff_user.id)
 
-      # 7. But projection is deactivated
+      # 7. And projection is deactivated
       assert [] = ProgramStaffParticipantRepository.get_active_staff_user_ids(ctx.program.id)
     end
   end

--- a/test/klass_hero/messaging/staff_messaging_integration_test.exs
+++ b/test/klass_hero/messaging/staff_messaging_integration_test.exs
@@ -99,10 +99,12 @@ defmodule KlassHero.Messaging.StaffMessagingIntegrationTest do
                  )
                )
 
-      # 6. Staff is removed from the existing conversation — #817 closes the
+      # 6. Staff is no longer an active participant — #817 closes the
       #    inbox-visibility gap symmetrically: on unassignment the handler
-      #    drops the participant row and emits :participant_removed so the
-      #    projection archives the staff's summary row.
+      #    soft-leaves the participant row (sets `left_at` via leave/2; the
+      #    row is preserved so re-assignment can re-activate it) and emits
+      #    :participant_removed so the projection archives the staff's
+      #    summary row.
       refute ParticipantRepository.is_participant?(conversation.id, ctx.staff_user.id)
 
       # 7. And projection is deactivated

--- a/test/klass_hero_web/live/staff/messages_live/staff_inbox_visibility_test.exs
+++ b/test/klass_hero_web/live/staff/messages_live/staff_inbox_visibility_test.exs
@@ -1,0 +1,339 @@
+defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
+  @moduledoc """
+  Regression tests for #817: staff members added to conversations must
+  appear in `/staff/messages` without a server restart. Exercises the full
+  `CreateDirectConversation` → `AddAssignedStaff` → `:participant_added`
+  event flow → `ConversationSummaries` projection → `ListConversations`
+  query → LiveView render.
+
+  Uses `async: false` so the shared Ecto sandbox lets the supervised
+  projection process see the test's DB writes.
+  """
+
+  use KlassHeroWeb.ConnCase, async: false
+
+  import KlassHero.AccountsFixtures
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory, only: [insert: 2]
+  import KlassHero.ProviderFixtures
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ProgramStaffParticipantRepository
+  alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
+  alias KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler
+  alias KlassHero.Messaging.Application.Commands.CreateDirectConversation
+  alias KlassHero.Provider.Domain.Models.ProviderProfile
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  @projection_name :inbox_e2e_projection
+
+  setup do
+    # Projections are not started in the test supervision tree by default
+    # (see config/test.exs `start_projections: false`). Start one per test
+    # so the event flow has a live consumer.
+    pid = start_supervised!({ConversationSummaries, name: @projection_name})
+    _ = :sys.get_state(@projection_name)
+
+    # In test env the integration-event publisher captures to process state
+    # (see TestIntegrationEventPublisher). For an end-to-end inbox flow we
+    # must replay those captured events to the PubSub topic the projection
+    # is subscribed to.
+    setup_test_integration_events()
+
+    {:ok, projection: pid}
+  end
+
+  defp flush_to_projection do
+    get_published_integration_events()
+    |> Enum.each(fn event ->
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        "integration:messaging:#{event.event_type}",
+        {:integration_event, event}
+      )
+    end)
+
+    clear_integration_events()
+    _ = :sys.get_state(@projection_name)
+    :ok
+  end
+
+  describe "staff inbox visibility" do
+    test "staff sees a direct conversation created in a program they were assigned to before creation",
+         %{conn: conn} do
+      provider_owner = user_fixture()
+      provider = provider_profile_fixture(%{identity_id: provider_owner.id})
+      program = insert(:program_schema, provider_id: provider.id)
+      parent = user_fixture()
+
+      staff_user = user_fixture(intended_roles: [:staff_provider])
+
+      staff_member_fixture(%{
+        provider_id: provider.id,
+        user_id: staff_user.id,
+        active: true,
+        invitation_status: :accepted
+      })
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_user.id
+      })
+
+      scope = %Scope{
+        user: provider_owner,
+        roles: [:provider],
+        parent: nil,
+        provider: %ProviderProfile{
+          id: provider.id,
+          identity_id: provider_owner.id,
+          business_name: "Test Provider",
+          subscription_tier: :professional
+        }
+      }
+
+      assert {:ok, conversation} =
+               CreateDirectConversation.execute(scope, provider.id, parent.id, program_id: program.id)
+
+      flush_to_projection()
+
+      staff_conn = log_in_user(conn, staff_user)
+      {:ok, view, _html} = live(staff_conn, ~p"/staff/messages")
+
+      assert has_element?(view, "#conversations")
+
+      assert has_element?(view, "#conversations a[href*='#{conversation.id}']"),
+             "expected the newly-created conversation #{conversation.id} to appear in /staff/messages"
+
+      refute has_element?(view, "#conversations-empty-state")
+    end
+
+    test "staff sees a conversation they were added to after the fact (program staff assignment)",
+         %{conn: conn} do
+      provider_owner = user_fixture()
+      provider = provider_profile_fixture(%{identity_id: provider_owner.id})
+      program = insert(:program_schema, provider_id: provider.id)
+      parent = user_fixture()
+
+      # Conversation exists BEFORE staff is assigned to the program
+      scope = %Scope{
+        user: provider_owner,
+        roles: [:provider],
+        parent: nil,
+        provider: %ProviderProfile{
+          id: provider.id,
+          identity_id: provider_owner.id,
+          business_name: "Test Provider",
+          subscription_tier: :professional
+        }
+      }
+
+      assert {:ok, conversation} =
+               CreateDirectConversation.execute(scope, provider.id, parent.id, program_id: program.id)
+
+      flush_to_projection()
+
+      # Now assign staff via the integration event the Provider context would send
+      staff_user = user_fixture(intended_roles: [:staff_provider])
+
+      staff_member_fixture(%{
+        provider_id: provider.id,
+        user_id: staff_user.id,
+        active: true,
+        invitation_status: :accepted
+      })
+
+      assignment_event = %IntegrationEvent{
+        event_id: Ecto.UUID.generate(),
+        event_type: :staff_assigned_to_program,
+        source_context: :provider,
+        entity_type: :staff_member,
+        entity_id: Ecto.UUID.generate(),
+        occurred_at: DateTime.utc_now(),
+        payload: %{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: Ecto.UUID.generate(),
+          staff_user_id: staff_user.id,
+          assigned_at: DateTime.utc_now()
+        }
+      }
+
+      assert :ok = StaffAssignmentHandler.handle_event(assignment_event)
+
+      flush_to_projection()
+
+      staff_conn = log_in_user(conn, staff_user)
+      {:ok, view, _html} = live(staff_conn, ~p"/staff/messages")
+
+      assert has_element?(view, "#conversations a[href*='#{conversation.id}']"),
+             "expected the back-filled conversation to appear in /staff/messages without a server restart"
+    end
+
+    test "staff stops seeing a conversation after being unassigned from its program",
+         %{conn: conn} do
+      provider_owner = user_fixture()
+      provider = provider_profile_fixture(%{identity_id: provider_owner.id})
+      program = insert(:program_schema, provider_id: provider.id)
+      parent = user_fixture()
+
+      staff_user = user_fixture(intended_roles: [:staff_provider])
+
+      staff_member_fixture(%{
+        provider_id: provider.id,
+        user_id: staff_user.id,
+        active: true,
+        invitation_status: :accepted
+      })
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_user.id
+      })
+
+      scope = %Scope{
+        user: provider_owner,
+        roles: [:provider],
+        parent: nil,
+        provider: %ProviderProfile{
+          id: provider.id,
+          identity_id: provider_owner.id,
+          business_name: "Test Provider",
+          subscription_tier: :professional
+        }
+      }
+
+      assert {:ok, conversation} =
+               CreateDirectConversation.execute(scope, provider.id, parent.id, program_id: program.id)
+
+      flush_to_projection()
+
+      # Now unassign the staff
+      unassignment_event = %IntegrationEvent{
+        event_id: Ecto.UUID.generate(),
+        event_type: :staff_unassigned_from_program,
+        source_context: :provider,
+        entity_type: :staff_member,
+        entity_id: Ecto.UUID.generate(),
+        occurred_at: DateTime.utc_now(),
+        payload: %{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: Ecto.UUID.generate(),
+          staff_user_id: staff_user.id,
+          unassigned_at: DateTime.utc_now()
+        }
+      }
+
+      assert :ok = StaffAssignmentHandler.handle_event(unassignment_event)
+
+      flush_to_projection()
+
+      staff_conn = log_in_user(conn, staff_user)
+      {:ok, view, _html} = live(staff_conn, ~p"/staff/messages")
+
+      refute has_element?(view, "#conversations a[href*='#{conversation.id}']"),
+             "expected the conversation to disappear from the unassigned staff's inbox"
+    end
+
+    test "full cycle: assign → unassign → re-assign — inbox visibility tracks each step",
+         %{conn: conn} do
+      provider_owner = user_fixture()
+      provider = provider_profile_fixture(%{identity_id: provider_owner.id})
+      program = insert(:program_schema, provider_id: provider.id)
+      parent = user_fixture()
+
+      staff_user = user_fixture(intended_roles: [:staff_provider])
+
+      staff_member_fixture(%{
+        provider_id: provider.id,
+        user_id: staff_user.id,
+        active: true,
+        invitation_status: :accepted
+      })
+
+      ProgramStaffParticipantRepository.upsert_active(%{
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_user_id: staff_user.id
+      })
+
+      scope = %Scope{
+        user: provider_owner,
+        roles: [:provider],
+        parent: nil,
+        provider: %ProviderProfile{
+          id: provider.id,
+          identity_id: provider_owner.id,
+          business_name: "Test Provider",
+          subscription_tier: :professional
+        }
+      }
+
+      # ACT 1 — create conversation; staff is included from the start
+      assert {:ok, conversation} =
+               CreateDirectConversation.execute(scope, provider.id, parent.id, program_id: program.id)
+
+      flush_to_projection()
+
+      staff_conn = log_in_user(conn, staff_user)
+      {:ok, view, _html} = live(staff_conn, ~p"/staff/messages")
+
+      assert has_element?(view, "#conversations a[href*='#{conversation.id}']"),
+             "ACT 1: staff should see the conversation after initial create"
+
+      # ACT 2 — unassign staff; conversation disappears from inbox
+      unassignment_event = %IntegrationEvent{
+        event_id: Ecto.UUID.generate(),
+        event_type: :staff_unassigned_from_program,
+        source_context: :provider,
+        entity_type: :staff_member,
+        entity_id: Ecto.UUID.generate(),
+        occurred_at: DateTime.utc_now(),
+        payload: %{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: Ecto.UUID.generate(),
+          staff_user_id: staff_user.id,
+          unassigned_at: DateTime.utc_now()
+        }
+      }
+
+      assert :ok = StaffAssignmentHandler.handle_event(unassignment_event)
+      flush_to_projection()
+
+      {:ok, view, _html} = live(log_in_user(conn, staff_user), ~p"/staff/messages")
+
+      refute has_element?(view, "#conversations a[href*='#{conversation.id}']"),
+             "ACT 2: staff should NOT see the conversation after unassignment"
+
+      # ACT 3 — re-assign the SAME staff; conversation must re-appear
+      reassignment_event = %IntegrationEvent{
+        event_id: Ecto.UUID.generate(),
+        event_type: :staff_assigned_to_program,
+        source_context: :provider,
+        entity_type: :staff_member,
+        entity_id: Ecto.UUID.generate(),
+        occurred_at: DateTime.utc_now(),
+        payload: %{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: Ecto.UUID.generate(),
+          staff_user_id: staff_user.id,
+          assigned_at: DateTime.utc_now()
+        }
+      }
+
+      assert :ok = StaffAssignmentHandler.handle_event(reassignment_event)
+      flush_to_projection()
+
+      {:ok, view, _html} = live(log_in_user(conn, staff_user), ~p"/staff/messages")
+
+      assert has_element?(view, "#conversations a[href*='#{conversation.id}']"),
+             "ACT 3: previously-unassigned staff should see the conversation again after re-assignment"
+    end
+  end
+end


### PR DESCRIPTION
Closes #817.

## Summary

- Added two new CQRS commands (`AddAssignedStaff`, `RemoveAssignedStaff`) that own the staff-participation lifecycle and return their domain events as data instead of dispatching them inline.
- Introduced two new critical integration events (`:participant_added`, `:participant_removed`) driving a `ConversationSummaries` projection to upsert and soft-archive summary rows symmetrically.
- Refactored `CreateDirectConversation`, `ReplyPrivatelyToBroadcast`, `StartProgramConversation`, `BroadcastToProgram`, and `StaffAssignmentHandler` (both add and remove paths) to collect events inside `Repo.transaction` and dispatch them via `EventDispatchHelper.dispatch/2` after commit.
- Fixed the latent re-assignment defect: `where_user_is_not_participant/2` now treats soft-left rows as absent, and `add_to_conversations_batch/2` upserts to clear `left_at` while preserving `joined_at` so previously-unassigned staff can be re-onboarded cleanly.
- Hardened projection idempotency: `:conversation_created` upsert switched to an explicit `{:replace, [meta fields]}` list preserving read-state; `:participant_removed` uses `COALESCE(archived_at, $now)` so the first removal timestamp wins on replay.
- Deleted `Shared.add_assigned_staff/3` (logic now lives in the dedicated `AddAssignedStaff` command per the CQRS direction).

## Review Focus

- **Cross-process read-your-own-writes via post-commit dispatch** — previously events fired *inside* `Repo.transaction`, but the `ConversationSummaries` projection runs in its own GenServer on a separate DB connection and could not see uncommitted writes (it logged ``ConversationSummaries: skipping participant_added — conversation missing``). The new pattern is best examined at `lib/klass_hero/messaging/application/commands/create_direct_conversation.ex:105` (`handle_commit/3`) and the matching shape in `staff_assignment_handler.ex:118-141` and `reply_privately_to_broadcast.ex`. Atomicity story: tx rollback discards the events accumulator; on commit, critical events use the existing `EventDispatchHelper.dispatch/2` Oban-retry path for publish-failure durability.
- **Soft-left re-activation semantics** — `lib/klass_hero/messaging/adapters/driven/persistence/queries/conversation_queries.ex:88` adds `is_nil(p.left_at)` to the LEFT JOIN ON condition so soft-left rows no longer block back-fill queries. Paired with `lib/klass_hero/messaging/adapters/driven/persistence/repositories/participant_repository.ex:302` (`on_conflict` UPDATE that clears `left_at` and bumps `updated_at` while preserving the original `joined_at`). The combination is what makes assign → unassign → re-assign cycles work; before, the staff was permanently locked out of any program they had ever left.
- **Projection idempotency** — `lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex:528` (`project_participant_added/1`) and `:621` (`project_participant_removed/1`). The `:participant_added` upsert's `replace` field list intentionally includes `archived_at` so a re-assigned staff's summary row gets un-archived (the entry's `archived_at` comes from the active conversation = nil). The `:participant_removed` handler wraps `archived_at` in `COALESCE(archived_at, $now)` so replays preserve the first removal timestamp.
- **Events-as-data shape change in command contracts** — `AddAssignedStaff.execute/3` and `RemoveAssignedStaff.execute/2` now return `{:ok, {result, events}}`. All call sites updated (4 commands + 1 handler). Worth scanning for any caller I may have missed; `grep -rn 'AddAssignedStaff\|RemoveAssignedStaff' lib` should match only the 5 expected files plus the test files.
- **Boundary / DI / config** — `lib/klass_hero/application.ex` registers `:participant_added` and `:participant_removed` against the messaging `DomainEventBus`. No new config keys; new commands compose existing ports (`for_managing_participants`, `for_resolving_program_staff`, `for_querying_conversations`).

## Test Plan

- [x] `mix precommit` clean — compile --warnings-as-errors, format, lint_typography, full 4835-test suite passing
- [x] `mix credo --min-priority=high` clean (0 issues across 1058 files / 6082 mods+funs)
- [x] Unit-level RED-GREEN cycles for each of the 7 implementation steps
- [x] End-to-end LiveView regression in `staff_inbox_visibility_test.exs`: assign → unassign → re-assign, asserting `/staff/messages` visibility at each transition
- [x] Live Tidewave verification against the running Phoenix dev server: real provider + program + parent + staff cycle; observed `conversation_summaries` rows transition `archived_at: nil → timestamp → nil`; observed `conversation_participants.left_at` transition `nil → timestamp → nil`; no `skipping participant_added` warnings in logs
- [x] Manual Playwright smoke on `/staff/messages` once merged to dev — login as `uitest-staff@example.com`, confirm new staffed-program conversation appears without server restart
- [x] Optional: extend the post-commit dispatch pattern to `:message_sent` if production logs show the same race window (latent, lower frequency)

## Out of scope (intentionally)

- True outbox table for at-least-once delivery across process crashes between commit and dispatch — current Oban-retry on critical events is acceptable; full outbox is a future refinement.
- Migrating `:message_sent` to post-commit dispatch — same latent race, but separate change since `SendMessage` has a different transaction shape.