### PR TITLE
refactor: extract staff assigned-programs lookup to shared helper

### DIFF
--- a/lib/klass_hero_web/helpers/staff_live_helpers.ex
+++ b/lib/klass_hero_web/helpers/staff_live_helpers.ex
@@ -13,22 +13,22 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpers do
   alias KlassHero.Provider.Domain.Models.StaffMember
 
   @doc """
-  Loads all programs owned by the staff member's provider, alongside a
-  `MapSet` of the program ids the staff member is currently assigned to.
+  Loads the programs the staff member is currently assigned to, alongside a
+  `MapSet` of their ids.
 
   Composes `ProgramCatalog.list_programs_for_provider/1` with
   `Provider.list_assigned_programs/2`, keeping the cross-context fetch out of
   the Provider bounded context.
 
-  Returns `{all_programs, assigned_program_ids}` so callers can both render
-  the full list (e.g. dashboard streams) and check assignment membership in
-  constant time.
+  Returns `{assigned_programs, assigned_program_ids}`. The list is suitable
+  for rendering staff-scoped streams; the `MapSet` lets callers gate
+  per-program actions in constant time.
   """
   @spec load_assigned_programs(StaffMember.t()) ::
           {[ProgramListing.t()], MapSet.t(String.t())}
   def load_assigned_programs(%StaffMember{provider_id: provider_id} = staff_member) do
     all_programs = ProgramCatalog.list_programs_for_provider(provider_id)
     assigned = Provider.list_assigned_programs(staff_member, all_programs)
-    {all_programs, MapSet.new(assigned, & &1.id)}
+    {assigned, MapSet.new(assigned, & &1.id)}
   end
 end

--- a/lib/klass_hero_web/helpers/staff_live_helpers.ex
+++ b/lib/klass_hero_web/helpers/staff_live_helpers.ex
@@ -1,0 +1,34 @@
+defmodule KlassHeroWeb.Helpers.StaffLiveHelpers do
+  @moduledoc """
+  Shared lookups for staff-scoped LiveViews.
+
+  Centralizes the provider-programs-plus-assignment-filter pattern so every
+  staff LiveView mount derives the staff member's assigned programs the same
+  way.
+  """
+
+  alias KlassHero.ProgramCatalog
+  alias KlassHero.ProgramCatalog.Domain.ReadModels.ProgramListing
+  alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.Models.StaffMember
+
+  @doc """
+  Loads all programs owned by the staff member's provider, alongside a
+  `MapSet` of the program ids the staff member is currently assigned to.
+
+  Composes `ProgramCatalog.list_programs_for_provider/1` with
+  `Provider.list_assigned_programs/2`, keeping the cross-context fetch out of
+  the Provider bounded context.
+
+  Returns `{all_programs, assigned_program_ids}` so callers can both render
+  the full list (e.g. dashboard streams) and check assignment membership in
+  constant time.
+  """
+  @spec load_assigned_programs(StaffMember.t()) ::
+          {[ProgramListing.t()], MapSet.t(String.t())}
+  def load_assigned_programs(%StaffMember{provider_id: provider_id} = staff_member) do
+    all_programs = ProgramCatalog.list_programs_for_provider(provider_id)
+    assigned = Provider.list_assigned_programs(staff_member, all_programs)
+    {all_programs, MapSet.new(assigned, & &1.id)}
+  end
+end

--- a/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
@@ -4,9 +4,9 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
   alias KlassHero.Accounts.Scope
   alias KlassHero.Enrollment
   alias KlassHero.Messaging
-  alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Shared.Entitlements
+  alias KlassHeroWeb.Helpers.StaffLiveHelpers
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Theme
 
@@ -18,9 +18,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
 
     case Provider.get_provider_profile(staff_member.provider_id) do
       {:ok, provider} ->
-        all_programs = ProgramCatalog.list_programs_for_provider(staff_member.provider_id)
-        programs = Provider.list_assigned_programs(staff_member, all_programs)
-        assigned_ids = MapSet.new(programs, & &1.id)
+        {programs, assigned_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
 
         socket =
           socket

--- a/lib/klass_hero_web/live/staff/staff_participation_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.ex
@@ -2,10 +2,9 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
   use KlassHeroWeb, :live_view
 
   alias KlassHero.Participation
-  alias KlassHero.ProgramCatalog
-  alias KlassHero.Provider
   alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHeroWeb.Helpers.ParticipationEditHelpers
+  alias KlassHeroWeb.Helpers.StaffLiveHelpers
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -14,9 +13,7 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
   def mount(%{"session_id" => session_id}, _session, socket) do
     staff_member = socket.assigns.current_scope.staff_member
 
-    all_programs = ProgramCatalog.list_programs_for_provider(staff_member.provider_id)
-    assigned_programs = Provider.list_assigned_programs(staff_member, all_programs)
-    assigned_program_ids = MapSet.new(assigned_programs, & &1.id)
+    {_programs, assigned_program_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
 
     socket =
       socket

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -2,9 +2,8 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   use KlassHeroWeb, :live_view
 
   alias KlassHero.Participation
-  alias KlassHero.ProgramCatalog
-  alias KlassHero.Provider
   alias KlassHero.Shared.Domain.Events.DomainEvent
+  alias KlassHeroWeb.Helpers.StaffLiveHelpers
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -15,9 +14,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
     provider_id = staff_member.provider_id
     selected_date = Date.utc_today()
 
-    all_programs = ProgramCatalog.list_programs_for_provider(provider_id)
-    assigned_programs = Provider.list_assigned_programs(staff_member, all_programs)
-    assigned_program_ids = MapSet.new(assigned_programs, & &1.id)
+    {_programs, assigned_program_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
 
     socket =
       socket

--- a/test/klass_hero_web/helpers/staff_live_helpers_test.exs
+++ b/test/klass_hero_web/helpers/staff_live_helpers_test.exs
@@ -1,0 +1,70 @@
+defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.ProviderFixtures
+  alias KlassHeroWeb.Helpers.StaffLiveHelpers
+
+  describe "load_assigned_programs/1" do
+    test "returns all provider programs and a MapSet of every program id when staff has no tags" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      staff_member = ProviderFixtures.staff_member_fixture(provider_id: provider.id, tags: [])
+
+      program_a =
+        insert(:program_listing_schema, provider_id: provider.id, category: "sports")
+
+      program_b =
+        insert(:program_listing_schema, provider_id: provider.id, category: "arts")
+
+      {programs, assigned_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
+
+      assert Enum.map(programs, & &1.id) |> Enum.sort() ==
+               Enum.sort([program_a.id, program_b.id])
+
+      assert assigned_ids == MapSet.new([program_a.id, program_b.id])
+    end
+
+    test "MapSet contains only category-matched program ids when staff has tags" do
+      provider = ProviderFixtures.provider_profile_fixture()
+
+      staff_member =
+        ProviderFixtures.staff_member_fixture(provider_id: provider.id, tags: ["sports"])
+
+      sports_program =
+        insert(:program_listing_schema, provider_id: provider.id, category: "sports")
+
+      arts_program =
+        insert(:program_listing_schema, provider_id: provider.id, category: "arts")
+
+      {programs, assigned_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
+
+      assert Enum.map(programs, & &1.id) |> Enum.sort() ==
+               Enum.sort([sports_program.id, arts_program.id])
+
+      assert assigned_ids == MapSet.new([sports_program.id])
+    end
+
+    test "returns an empty list and empty MapSet when provider has no programs" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      staff_member = ProviderFixtures.staff_member_fixture(provider_id: provider.id, tags: [])
+
+      assert {[], assigned_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
+      assert MapSet.size(assigned_ids) == 0
+    end
+
+    test "excludes programs from other providers" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      other_provider = ProviderFixtures.provider_profile_fixture()
+      staff_member = ProviderFixtures.staff_member_fixture(provider_id: provider.id, tags: [])
+
+      own_program = insert(:program_listing_schema, provider_id: provider.id, category: "sports")
+      _foreign = insert(:program_listing_schema, provider_id: other_provider.id, category: "sports")
+
+      {programs, assigned_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
+
+      assert Enum.map(programs, & &1.id) == [own_program.id]
+      assert assigned_ids == MapSet.new([own_program.id])
+    end
+  end
+end

--- a/test/klass_hero_web/helpers/staff_live_helpers_test.exs
+++ b/test/klass_hero_web/helpers/staff_live_helpers_test.exs
@@ -7,7 +7,7 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
   alias KlassHeroWeb.Helpers.StaffLiveHelpers
 
   describe "load_assigned_programs/1" do
-    test "returns all provider programs and a MapSet of every program id when staff has no tags" do
+    test "returns every provider program when staff has no tags (empty tag list = no filter)" do
       provider = ProviderFixtures.provider_profile_fixture()
       staff_member = ProviderFixtures.staff_member_fixture(provider_id: provider.id, tags: [])
 
@@ -25,7 +25,7 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
       assert assigned_ids == MapSet.new([program_a.id, program_b.id])
     end
 
-    test "MapSet contains only category-matched program ids when staff has tags" do
+    test "returns only category-matched programs when staff has tags set" do
       provider = ProviderFixtures.provider_profile_fixture()
 
       staff_member =
@@ -34,14 +34,12 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
       sports_program =
         insert(:program_listing_schema, provider_id: provider.id, category: "sports")
 
-      arts_program =
+      _arts_program =
         insert(:program_listing_schema, provider_id: provider.id, category: "arts")
 
       {programs, assigned_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
 
-      assert Enum.map(programs, & &1.id) |> Enum.sort() ==
-               Enum.sort([sports_program.id, arts_program.id])
-
+      assert Enum.map(programs, & &1.id) == [sports_program.id]
       assert assigned_ids == MapSet.new([sports_program.id])
     end
 


### PR DESCRIPTION
## Summary

- Consolidate the duplicated `list_programs_for_provider` + `list_assigned_programs` + `MapSet.new(...)` boilerplate from 3 staff LiveViews into `KlassHeroWeb.Helpers.StaffLiveHelpers.load_assigned_programs/1`.
- The helper returns `{programs, assigned_program_ids}` so the dashboard keeps both the full list (for `stream(:programs, programs)` and `programs_empty?`) while participation and sessions consume only the `MapSet`.
- Composition stays in the web layer — the Provider bounded context's `Boundary` `deps` does not (and should not) include `ProgramCatalog`.

Closes #843

## Review Focus

- `lib/klass_hero_web/helpers/staff_live_helpers.ex` — single public function, `@spec`d, no I/O of its own beyond the two existing context queries.
- Confirm the tuple shape feels right: dashboard destructures both, participation/sessions discard the list via `_programs`.
- Test layer: `KlassHero.DataCase` with `async: true`. Helper test exercises `StaffProgramFilter.filter_by_tags/2` via the real context API rather than via Mox — contexts aren't ports in this project.

## Test Plan

- [x] `mix test test/klass_hero_web/helpers/staff_live_helpers_test.exs` — 4/4 pass
- [x] `mix test test/klass_hero_web/live/staff/` — 42/42 pass (no regressions)
- [x] `mix precommit` — 4841 pass, 5 skipped, 18 excluded; format + typography + warnings-as-errors all clean
- [x] Manual smoke (reviewer): log in as a seed staff user; visit `/staff` (dashboard), `/staff/sessions`, drill into a session for `/staff/participation/:session_id` and confirm assigned-only filtering still holds.