### PR TITLE
refactor: extract projection boilerplate into Shared.Projection macro

### DIFF
--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -74,3 +74,4 @@ The codebase is moving toward Command Query Responsibility Segregation:
 - Phoenix web adapters (driving adapters)
 - Event handler and worker adapters (driving adapters under `adapters/driving/`)
 - Configuration and dependency injection
+- Event-driven projections (driven adapters under `adapters/driven/projections/`) — use `KlassHero.Shared.Projection` (base macro) and optionally `KlassHero.Shared.Projection.WithBootstrapRetry` (linear-backoff retry). The calling module declares `:topics` in `use Projection, ...` and implements `bootstrap_impl/0` and `handle_event/2`. See `ProviderPrograms` for the canonical example.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -57,3 +57,7 @@ This command:
 - Use `@tag` to tag specific tests, and `mix test --only tag` to run only those tests
 - Use `assert_raise` for testing expected exceptions: `assert_raise ArgumentError, fn -> invalid_function() end`
 - Use `mix help test` for full documentation on running tests
+
+## Projection Tests: `async: false`
+
+Test modules covering event-driven projections (modules under `**/adapters/driven/projections/`) use `use KlassHero.DataCase, async: false`. Projection GenServers run DB queries during `init/1`'s `{:continue, :bootstrap}` before the test process can call `Ecto.Adapters.SQL.Sandbox.allow/3` on the spawned pid, so the only reliable fix is shared-sandbox mode (which `async: false` flips on automatically via `DataCase.setup_sandbox/1`). Don't add `Sandbox.allow` calls in these files — they're redundant under shared mode. This rule does NOT apply to macro-level tests like `test/klass_hero/shared/projection_test.exs`, which exercise the macro against `Agent`-backed fakes with no DB at all and stay `async: true`.

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -10,10 +10,9 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
 
   ## Architecture
 
-  This is a "driven adapter" in the Ports & Adapters architecture — it's
-  driven by integration events from the Messaging context. The read-side
-  repository (`ConversationSummariesRepository`) queries the table this
-  projection writes.
+  Built on KlassHero.Shared.Projection + WithBootstrapRetry + WithDomainEvents.
+  The read-side repository (`ConversationSummariesRepository`) queries the table
+  this projection writes.
 
   ## Startup Behavior
 
@@ -34,7 +33,21 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     for rows where the anonymized user was the other participant
   """
 
-  use GenServer
+  use KlassHero.Shared.Projection,
+    topics: [
+      "integration:messaging:conversation_created",
+      "integration:messaging:message_sent",
+      "integration:messaging:messages_read",
+      "integration:messaging:conversation_archived",
+      "integration:messaging:conversations_archived",
+      "integration:messaging:message_data_anonymized",
+      "integration:messaging:participant_added",
+      "integration:messaging:participant_removed",
+      "messaging:enrolled_children_changed"
+    ]
+
+  use KlassHero.Shared.Projection.WithBootstrapRetry
+  use KlassHero.Shared.Projection.WithDomainEvents
 
   import Ecto.Query
 
@@ -44,259 +57,100 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.EnrolledChildrenSchema
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.MessageSchema
   alias KlassHero.Repo
-  alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
-
-  require Logger
+  alias KlassHero.Shared.Projection
+  alias KlassHero.Shared.Projection.WithDomainEvents
 
   @user_resolver Application.compile_env!(:klass_hero, [:messaging, :for_resolving_users])
-
-  @conversation_created_topic "integration:messaging:conversation_created"
-  @message_sent_topic "integration:messaging:message_sent"
-  @messages_read_topic "integration:messaging:messages_read"
-  @conversation_archived_topic "integration:messaging:conversation_archived"
-  @conversations_archived_topic "integration:messaging:conversations_archived"
-  @message_data_anonymized_topic "integration:messaging:message_data_anonymized"
-  @participant_added_topic "integration:messaging:participant_added"
-  @participant_removed_topic "integration:messaging:participant_removed"
-  @enrolled_children_changed_topic "messaging:enrolled_children_changed"
   @broadcast_token_regex ~r/\[broadcast:[^\]]+\]/
 
-  # Client API
+  # Behaviour callbacks ───────────────────────────────────────────────────────
 
-  @doc """
-  Starts the ConversationSummaries projection GenServer.
+  @impl Projection
+  def bootstrap_impl, do: bootstrap_from_write_tables()
 
-  ## Options
-
-  - `:name` - Process name (defaults to `__MODULE__`)
-  """
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
-  end
-
-  @doc """
-  Rebuilds the conversation_summaries read table from the write tables.
-
-  Useful after seeding write tables directly (bypassing integration events).
-  Blocks until the rebuild is complete.
-  """
-  @spec rebuild(GenServer.name()) :: :ok
-  def rebuild(name \\ __MODULE__) do
-    GenServer.call(name, :rebuild, :infinity)
-  end
-
-  # Server Callbacks
-
-  @impl true
-  def init(_opts) do
-    # Trigger: GenServer is starting
-    # Why: subscribe to events before bootstrapping to avoid missing events
-    #      that arrive between bootstrap completion and subscription
-    # Outcome: subscribed to all six relevant topics
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversation_created_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @message_sent_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @messages_read_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversation_archived_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversations_archived_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @message_data_anonymized_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @participant_added_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @participant_removed_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrolled_children_changed_topic)
-
-    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
-  end
-
-  @impl true
-  def handle_continue(:bootstrap, state) do
-    # Trigger: GenServer initialization complete
-    # Why: project all existing conversations from write tables into read table
-    # Outcome: conversation_summaries table populated with current data
-    attempt_bootstrap(state)
-  end
-
-  # Trigger: external caller requests a full rebuild (e.g. after seeding)
-  # Why: seeds insert into write tables without emitting integration events
-  # Outcome: conversation_summaries read table refreshed from write tables
-  @impl true
-  def handle_call(:rebuild, _from, state) do
-    count = bootstrap_from_write_tables()
-    Logger.info("ConversationSummaries rebuilt", count: count)
-    {:reply, :ok, %{state | bootstrapped: true}}
-  end
-
-  @impl true
-  def handle_info(:retry_bootstrap, state) do
-    {:noreply, state, {:continue, :bootstrap}}
-  end
-
-  # Trigger: Received a conversation_created integration event
-  # Why: a new conversation was created, each participant needs a summary row
-  # Outcome: one row per participant inserted into conversation_summaries
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :conversation_created} = event}, state) do
+  @impl Projection
+  def handle_event(:conversation_created, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting conversation_created",
       conversation_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_conversation_created(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received a message_sent integration event
-  # Why: latest message fields must be updated, unread_count incremented for non-senders
-  # Outcome: all summary rows for this conversation updated
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :message_sent} = event}, state) do
+  def handle_event(:message_sent, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting message_sent",
       conversation_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_message_sent(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received a messages_read integration event
-  # Why: the user has read all messages, unread_count should be reset
-  # Outcome: summary row for {conversation_id, user_id} updated
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :messages_read} = event}, state) do
+  def handle_event(:messages_read, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting messages_read",
       conversation_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_messages_read(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received a conversation_archived integration event
-  # Why: conversation is being archived, all summary rows must reflect this
-  # Outcome: archived_at set for all rows of the conversation
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :conversation_archived} = event}, state) do
+  def handle_event(:conversation_archived, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting conversation_archived",
       conversation_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_conversation_archived(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received a conversations_archived integration event (bulk)
-  # Why: multiple conversations archived at once, all summary rows must reflect this
-  # Outcome: archived_at set for all rows of the affected conversations
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :conversations_archived} = event}, state) do
+  def handle_event(:conversations_archived, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting conversations_archived",
       event_id: event.event_id
     )
 
     project_conversations_archived(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received a message_data_anonymized integration event
-  # Why: a user's data was anonymized (GDPR), their display name must be replaced
-  # Outcome: other_participant_name set to "Deleted User" for affected rows
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :message_data_anonymized} = event}, state) do
+  def handle_event(:message_data_anonymized, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting message_data_anonymized",
       user_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_message_data_anonymized(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received a participant_added integration event
-  # Why: one or more users joined a conversation after creation; each needs
-  #      their own summary row so the conversation appears in their inbox
-  # Outcome: one row per new participant_user_id upserted into conversation_summaries
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :participant_added} = event}, state) do
+  def handle_event(:participant_added, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting participant_added",
       conversation_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_participant_added(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received a participant_removed integration event
-  # Why: one or more users were removed from a conversation; their summary
-  #      rows must be soft-archived so the conversation disappears from
-  #      their inbox immediately
-  # Outcome: archived_at set on each affected (conversation_id, user_id) row,
-  #          preserving the first removal's timestamp on replay (COALESCE)
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :participant_removed} = event}, state) do
+  def handle_event(:participant_removed, %IntegrationEvent{} = event) do
     Logger.debug("ConversationSummaries projecting participant_removed",
       conversation_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_participant_removed(event)
-    {:noreply, state}
   end
 
-  # Trigger: Received an enrolled_children_changed domain event from EnrolledChildren projection
-  # Why: conversation summary needs updated child names for display
-  # Outcome: enrolled_child_names column updated for all rows of the conversation
-  @impl true
-  def handle_info({:domain_event, %DomainEvent{event_type: :enrolled_children_changed} = event}, state) do
+  @impl WithDomainEvents
+  def handle_domain_event(:enrolled_children_changed, event) do
     Logger.debug("ConversationSummaries projecting enrolled_children_changed",
       conversation_id: event.aggregate_id
     )
 
     project_enrolled_children_changed(event)
-    {:noreply, state}
-  end
-
-  # Catch-all for unhandled messages — logged so misrouted events are traceable
-  @impl true
-  def handle_info(msg, state) do
-    Logger.warning("ConversationSummaries received unexpected message",
-      message: inspect(msg, limit: 200)
-    )
-
-    {:noreply, state}
   end
 
   # Private Functions — Bootstrap
-
-  # Trigger: bootstrap attempt with retry logic
-  # Why: transient DB failures shouldn't crash the GenServer immediately
-  # Outcome: successful bootstrap or scheduled retry (up to 3 times before crashing)
-  defp attempt_bootstrap(state) do
-    count = bootstrap_from_write_tables()
-    Logger.info("ConversationSummaries projection started", count: count)
-    {:noreply, %{state | bootstrapped: true}}
-  rescue
-    error ->
-      retry_count = Map.get(state, :retry_count, 0) + 1
-
-      if retry_count > 3 do
-        # Trigger: exhausted retries
-        # Why: persistent failure indicates real infrastructure issue
-        # Outcome: crash to let supervisor handle with its own restart strategy
-        reraise error, __STACKTRACE__
-      else
-        Logger.error("ConversationSummaries: bootstrap failed, scheduling retry",
-          error: Exception.message(error),
-          retry_count: retry_count
-        )
-
-        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
-        {:noreply, Map.put(state, :retry_count, retry_count)}
-      end
-  end
 
   # Trigger: bootstrap phase — read table may be empty or stale
   # Why: cold start recovery — populate read table from authoritative write tables

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -1,20 +1,24 @@
 defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
   @moduledoc """
-  Event-driven projection maintaining the `messaging_enrolled_children` lookup table.
+  Event-driven projection maintaining the `messaging_enrolled_children` read table.
 
-  This GenServer subscribes to cross-context integration events from
-  Enrollment and Family, plus Messaging's own `conversation_created` event.
-  It maintains a local lookup of enrolled children per parent+program,
-  then emits `enrolled_children_changed` domain events that the
-  `ConversationSummaries` projection consumes.
+  Mirrors the enrolment + child + parent context needed for Messaging features so
+  that conversation summaries can display which child(ren) a conversation is about
+  without joining across context boundaries.
 
-  ## Event Subscriptions
+  Built on `KlassHero.Shared.Projection` (base) + `Projection.WithBootstrapRetry`
+  (linear-backoff retry on transient bootstrap failure).
 
-  - `integration:enrollment:enrollment_created` — upserts a lookup row
-  - `integration:enrollment:enrollment_cancelled` — deletes a lookup row
-  - `integration:family:child_created` — updates child_first_name
-  - `integration:family:child_updated` — updates child_first_name
-  - `integration:messaging:conversation_created` — triggers name resolution for new conversations
+  ## Event handling
+
+  - `:enrollment_created` — inserts enrollment row(s)
+  - `:enrollment_cancelled` — deletes rows for that enrollment
+  - `:child_created` — updates child_first_name across rows
+  - `:child_updated` — updates child_first_name across rows
+  - `:conversation_created` — broadcasts `:enrolled_children_changed` domain event for downstream projections
+
+  After every state-changing operation, emits a `:enrolled_children_changed`
+  domain event so dependent projections (ConversationSummaries) can refresh.
 
   ## Cross-Context Coupling
 
@@ -41,7 +45,16 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
   tracks replacing all of these with dedicated cross-context ports.
   """
 
-  use GenServer
+  use KlassHero.Shared.Projection,
+    topics: [
+      "integration:enrollment:enrollment_created",
+      "integration:enrollment:enrollment_cancelled",
+      "integration:family:child_created",
+      "integration:family:child_updated",
+      "integration:messaging:conversation_created"
+    ]
+
+  use KlassHero.Shared.Projection.WithBootstrapRetry
 
   import Ecto.Query
 
@@ -50,175 +63,27 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
-
-  require Logger
-
-  @enrollment_created_topic "integration:enrollment:enrollment_created"
-  @enrollment_cancelled_topic "integration:enrollment:enrollment_cancelled"
-  @child_created_topic "integration:family:child_created"
-  @child_updated_topic "integration:family:child_updated"
-  @conversation_created_topic "integration:messaging:conversation_created"
+  alias KlassHero.Shared.Projection
 
   @enrolled_children_changed_topic "messaging:enrolled_children_changed"
 
-  # Client API
+  # Behaviour callbacks ───────────────────────────────────────────────────────
 
-  @doc """
-  Starts the EnrolledChildren projection GenServer.
+  @impl Projection
+  def bootstrap_impl, do: bootstrap_from_write_tables()
 
-  ## Options
+  @impl Projection
+  def handle_event(:enrollment_created, %IntegrationEvent{} = event), do: project_enrollment_created(event)
 
-  - `:name` - Process name (defaults to `__MODULE__`)
-  """
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
-  end
+  def handle_event(:enrollment_cancelled, %IntegrationEvent{} = event), do: project_enrollment_cancelled(event)
 
-  @doc """
-  Rebuilds the messaging_enrolled_children read table from the write tables.
+  def handle_event(:child_created, %IntegrationEvent{} = event), do: project_child_name_change(event)
 
-  Useful after seeding write tables directly (bypassing integration events).
-  Blocks until the rebuild is complete.
-  """
-  @spec rebuild(GenServer.name()) :: :ok
-  def rebuild(name \\ __MODULE__) do
-    GenServer.call(name, :rebuild, :infinity)
-  end
+  def handle_event(:child_updated, %IntegrationEvent{} = event), do: project_child_name_change(event)
 
-  # Server Callbacks
+  def handle_event(:conversation_created, %IntegrationEvent{} = event), do: project_conversation_created(event)
 
-  @impl true
-  def init(_opts) do
-    # Trigger: GenServer is starting
-    # Why: subscribe to events before bootstrapping to avoid missing events
-    #      that arrive between bootstrap completion and subscription
-    # Outcome: subscribed to all five relevant topics
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrollment_created_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @enrollment_cancelled_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @child_created_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @child_updated_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @conversation_created_topic)
-
-    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
-  end
-
-  @impl true
-  def handle_continue(:bootstrap, state) do
-    # Trigger: GenServer initialization complete
-    # Why: project all existing enrollments from write tables into read table
-    # Outcome: messaging_enrolled_children table populated with current data
-    attempt_bootstrap(state)
-  end
-
-  # Trigger: external caller requests a full rebuild (e.g. after seeding)
-  # Why: seeds insert into write tables without emitting integration events
-  # Outcome: messaging_enrolled_children read table refreshed from write tables
-  @impl true
-  def handle_call(:rebuild, _from, state) do
-    count = bootstrap_from_write_tables()
-    Logger.info("EnrolledChildren rebuilt", count: count)
-    {:reply, :ok, %{state | bootstrapped: true}}
-  end
-
-  @impl true
-  def handle_info(:retry_bootstrap, state) do
-    {:noreply, state, {:continue, :bootstrap}}
-  end
-
-  # Trigger: Received an enrollment_created integration event
-  # Why: a new enrollment was created, upsert a lookup row
-  # Outcome: one row inserted/updated in messaging_enrolled_children
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :enrollment_created} = event}, state) do
-    Logger.debug("EnrolledChildren projecting enrollment_created",
-      enrollment_id: event.entity_id
-    )
-
-    project_enrollment_created(event)
-    {:noreply, state}
-  end
-
-  # Trigger: Received an enrollment_cancelled integration event
-  # Why: enrollment cancelled, remove the lookup row
-  # Outcome: row deleted from messaging_enrolled_children
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :enrollment_cancelled} = event}, state) do
-    Logger.debug("EnrolledChildren projecting enrollment_cancelled",
-      enrollment_id: event.entity_id
-    )
-
-    project_enrollment_cancelled(event)
-    {:noreply, state}
-  end
-
-  # Trigger: Received a child_created integration event
-  # Why: new child may need first_name populated in existing lookup rows
-  # Outcome: child_first_name updated for matching rows
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_created} = event}, state) do
-    Logger.debug("EnrolledChildren projecting child_created", child_id: event.entity_id)
-    project_child_name_change(event)
-    {:noreply, state}
-  end
-
-  # Trigger: Received a child_updated integration event
-  # Why: child name may have changed, update lookup rows
-  # Outcome: child_first_name updated for matching rows
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_updated} = event}, state) do
-    Logger.debug("EnrolledChildren projecting child_updated", child_id: event.entity_id)
-    project_child_name_change(event)
-    {:noreply, state}
-  end
-
-  # Trigger: Received a conversation_created integration event
-  # Why: new conversation may need child names resolved for its participants
-  # Outcome: enrolled_children_changed emitted if any participant has enrolled children
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :conversation_created} = event}, state) do
-    project_conversation_created(event)
-    {:noreply, state}
-  end
-
-  # Catch-all for unhandled messages — logged so misrouted events are traceable
-  @impl true
-  def handle_info(msg, state) do
-    Logger.warning("EnrolledChildren received unexpected message",
-      message: inspect(msg, limit: 200)
-    )
-
-    {:noreply, state}
-  end
-
-  # Private — Bootstrap
-
-  # Trigger: bootstrap attempt with retry logic
-  # Why: transient DB failures shouldn't crash the GenServer immediately
-  # Outcome: successful bootstrap or scheduled retry (up to 3 times before crashing)
-  defp attempt_bootstrap(state) do
-    count = bootstrap_from_write_tables()
-    Logger.info("EnrolledChildren projection started", count: count)
-    {:noreply, %{state | bootstrapped: true}}
-  rescue
-    error ->
-      retry_count = Map.get(state, :retry_count, 0) + 1
-
-      if retry_count > 3 do
-        # Trigger: exhausted retries
-        # Why: persistent failure indicates real infrastructure issue
-        # Outcome: crash to let supervisor handle with its own restart strategy
-        reraise error, __STACKTRACE__
-      else
-        Logger.error("EnrolledChildren: bootstrap failed, scheduling retry",
-          error: Exception.message(error),
-          retry_count: retry_count
-        )
-
-        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
-        {:noreply, Map.put(state, :retry_count, retry_count)}
-      end
-  end
+  # Private — Bootstrap ───────────────────────────────────────────────────────
 
   # Trigger: bootstrap phase — read table may be empty or stale
   # Why: cold start recovery — populate read table from authoritative write tables
@@ -260,7 +125,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
     end
   end
 
-  # Private — Event Projections
+  # Private — Event Projections ───────────────────────────────────────────────
 
   # Trigger: enrollment_created event received
   # Why: a new enrollment needs a lookup row so child names can be resolved
@@ -405,7 +270,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
     end)
   end
 
-  # Private — Re-derivation
+  # Private — Re-derivation ───────────────────────────────────────────────────
 
   # Trigger: a row in messaging_enrolled_children was added, removed, or updated
   # Why: downstream consumers (ConversationSummaries) need the updated child name list

--- a/lib/klass_hero/program_catalog/adapters/driven/projections/program_listings.ex
+++ b/lib/klass_hero/program_catalog/adapters/driven/projections/program_listings.ex
@@ -2,32 +2,34 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings d
   @moduledoc """
   Event-driven projection maintaining the `program_listings` read table.
 
-  This GenServer subscribes to integration events and keeps the denormalized
-  `program_listings` table in sync with the write model. On startup it
-  bootstraps from the `programs` write table, then incrementally applies
-  changes as events arrive.
+  Mirrors program data + provider verification status from write tables so
+  Program Catalog queries can serve denormalised reads without joins.
 
-  ## Architecture
+  Built on `KlassHero.Shared.Projection` (base) + `Projection.WithBootstrapRetry`
+  (linear-backoff retry on transient bootstrap failure).
 
-  This is a "driven adapter" in the Ports & Adapters architecture — it's driven
-  by integration events from ProgramCatalog and Provider contexts. The read-side
-  repository (`ProgramListingsRepository`) queries the table this projection writes.
+  ## Event handling
 
-  ## Startup Behavior
+  - `:program_created` — inserts a new listing row
+  - `:program_updated` — updates listing fields (preserves season + provider_verified)
+  - `:provider_verified` — bulk sets `provider_verified = true` for the provider's listings
+  - `:provider_unverified` — bulk sets `provider_verified = false`
 
-  On init, the GenServer:
-  1. Subscribes to program_created, program_updated, provider_verified, provider_unverified topics
-  2. Uses `handle_continue(:bootstrap)` to project all existing programs into the read table
-
-  ## Event Handling
-
-  - `:program_created` — inserts a new row into program_listings
-  - `:program_updated` — updates the existing row with changed fields
-  - `:provider_verified` — sets `provider_verified = true` for all listings of that provider
-  - `:provider_unverified` — sets `provider_verified = false` for all listings of that provider
+  Bang functions (`Repo.insert!`, `Repo.update!`) are used intentionally — if a
+  DB write fails, the GenServer crashes and the supervisor restarts it, triggering
+  a full re-bootstrap. Transient failures resolve via restart; persistent failures
+  surface as repeated crashes (hitting `max_restarts`).
   """
 
-  use GenServer
+  use KlassHero.Shared.Projection,
+    topics: [
+      "integration:program_catalog:program_created",
+      "integration:program_catalog:program_updated",
+      "integration:provider:provider_verified",
+      "integration:provider:provider_unverified"
+    ]
+
+  use KlassHero.Shared.Projection.WithBootstrapRetry
 
   import Ecto.Query
 
@@ -35,14 +37,7 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings d
   alias KlassHero.ProgramCatalog.Adapters.Driven.Persistence.Schemas.ProgramSchema
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
   alias KlassHero.Repo
-  alias KlassHero.Shared.Domain.Events.IntegrationEvent
-
-  require Logger
-
-  @program_created_topic "integration:program_catalog:program_created"
-  @program_updated_topic "integration:program_catalog:program_updated"
-  @provider_verified_topic "integration:provider:provider_verified"
-  @provider_unverified_topic "integration:provider:provider_unverified"
+  alias KlassHero.Shared.Projection
 
   # Fields shared between ProgramSchema and ProgramListingSchema
   @shared_fields [
@@ -67,168 +62,42 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings d
     :provider_id
   ]
 
-  # Client API
+  # Fields that program_updated events may change; excludes season and provider_verified
+  # which are only set during bootstrap or by provider verification events respectively.
+  @update_fields [
+    :title,
+    :description,
+    :category,
+    :age_range,
+    :price,
+    :pricing_period,
+    :location,
+    :cover_image_url,
+    :instructor_name,
+    :instructor_headshot_url,
+    :start_date,
+    :end_date,
+    :meeting_days,
+    :meeting_start_time,
+    :meeting_end_time,
+    :registration_start_date,
+    :registration_end_date,
+    :provider_id,
+    :updated_at
+  ]
 
-  @doc """
-  Starts the ProgramListings projection GenServer.
+  # Behaviour callbacks ───────────────────────────────────────────────────────
 
-  ## Options
+  @impl Projection
+  def bootstrap_impl, do: bootstrap_from_write_table()
 
-  - `:name` - Process name (defaults to `__MODULE__`)
-  """
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
-  end
+  @impl Projection
+  def handle_event(:program_created, event), do: upsert_listing_from_event(event)
+  def handle_event(:program_updated, event), do: update_listing_from_event(event)
+  def handle_event(:provider_verified, event), do: set_provider_verification(event.payload.provider_id, true)
+  def handle_event(:provider_unverified, event), do: set_provider_verification(event.payload.provider_id, false)
 
-  @doc """
-  Rebuilds the program_listings read table from the programs write table.
-
-  Useful after seeding write tables directly (bypassing integration events).
-  Blocks until the rebuild is complete.
-  """
-  @spec rebuild(GenServer.name()) :: :ok
-  def rebuild(name \\ __MODULE__) do
-    GenServer.call(name, :rebuild, :infinity)
-  end
-
-  # Server Callbacks
-
-  @impl true
-  def init(_opts) do
-    # Trigger: GenServer is starting
-    # Why: subscribe to events before bootstrapping to avoid missing events
-    #      that arrive between bootstrap completion and subscription
-    # Outcome: subscribed to all four relevant topics
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @program_created_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @program_updated_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @provider_verified_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @provider_unverified_topic)
-
-    {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
-  end
-
-  @impl true
-  def handle_continue(:bootstrap, state) do
-    # Trigger: GenServer initialization complete
-    # Why: project all existing programs from write table into read table
-    # Outcome: program_listings table populated with current program data
-    attempt_bootstrap(state)
-  end
-
-  # Trigger: external caller requests a full rebuild (e.g. after seeding)
-  # Why: seeds insert into write tables without emitting integration events
-  # Outcome: program_listings read table refreshed from programs write table
-  @impl true
-  def handle_call(:rebuild, _from, state) do
-    count = bootstrap_from_write_table()
-    Logger.info("ProgramListings rebuilt", count: count)
-    {:reply, :ok, %{state | bootstrapped: true}}
-  end
-
-  @impl true
-  def handle_info(:retry_bootstrap, state) do
-    {:noreply, state, {:continue, :bootstrap}}
-  end
-
-  # Trigger: Received a program_created integration event
-  # Why: a new program was created in the write model, the read table needs a corresponding row
-  # Outcome: new row inserted into program_listings
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :program_created} = event}, state) do
-    Logger.debug("ProgramListings projecting program_created",
-      program_id: event.entity_id,
-      event_id: event.event_id
-    )
-
-    upsert_listing_from_event(event)
-    {:noreply, state}
-  end
-
-  # Trigger: Received a program_updated integration event
-  # Why: program fields changed in the write model, the read table must reflect them
-  # Outcome: existing row in program_listings updated with new field values
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :program_updated} = event}, state) do
-    Logger.debug("ProgramListings projecting program_updated",
-      program_id: event.entity_id,
-      event_id: event.event_id
-    )
-
-    update_listing_from_event(event)
-    {:noreply, state}
-  end
-
-  # Trigger: Received a provider_verified integration event
-  # Why: provider gained verification status, all their listings should reflect this
-  # Outcome: provider_verified set to true for all listings belonging to that provider
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :provider_verified} = event}, state) do
-    provider_id = event.payload.provider_id
-
-    Logger.debug("ProgramListings setting provider_verified=true",
-      provider_id: provider_id,
-      event_id: event.event_id
-    )
-
-    set_provider_verification(provider_id, true)
-    {:noreply, state}
-  end
-
-  # Trigger: Received a provider_unverified integration event
-  # Why: provider lost verification status, all their listings should reflect this
-  # Outcome: provider_verified set to false for all listings belonging to that provider
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :provider_unverified} = event}, state) do
-    provider_id = event.payload.provider_id
-
-    Logger.debug("ProgramListings setting provider_verified=false",
-      provider_id: provider_id,
-      event_id: event.event_id
-    )
-
-    set_provider_verification(provider_id, false)
-    {:noreply, state}
-  end
-
-  # Catch-all for unhandled messages — logged so misrouted events are traceable
-  @impl true
-  def handle_info(msg, state) do
-    Logger.warning("ProgramListings received unexpected message",
-      message: inspect(msg, limit: 200)
-    )
-
-    {:noreply, state}
-  end
-
-  # Private Functions
-
-  # Trigger: bootstrap attempt with retry logic
-  # Why: transient DB failures shouldn't crash the GenServer immediately
-  # Outcome: successful bootstrap or scheduled retry (up to 3 times before crashing)
-  defp attempt_bootstrap(state) do
-    count = bootstrap_from_write_table()
-    Logger.info("ProgramListings projection started", count: count)
-    {:noreply, %{state | bootstrapped: true}}
-  rescue
-    error ->
-      retry_count = Map.get(state, :retry_count, 0) + 1
-
-      if retry_count > 3 do
-        # Trigger: exhausted retries
-        # Why: persistent failure indicates real infrastructure issue
-        # Outcome: crash to let supervisor handle with its own restart strategy
-        reraise error, __STACKTRACE__
-      else
-        Logger.error("ProgramListings: bootstrap failed, scheduling retry",
-          error: Exception.message(error),
-          retry_count: retry_count
-        )
-
-        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
-        {:noreply, Map.put(state, :retry_count, retry_count)}
-      end
-  end
+  # Private ──────────────────────────────────────────────────────────────────
 
   # Trigger: bootstrap phase — read table may be empty or stale
   # Why: cold start recovery — populate read table from authoritative write table
@@ -263,12 +132,6 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings d
       count
     end
   end
-
-  # NOTE: Event handlers use bang functions (Repo.insert!, Repo.update!) intentionally.
-  # If a DB write fails, the GenServer crashes and the supervisor restarts it,
-  # triggering a full re-bootstrap from the write table. This is the correct recovery
-  # strategy for a projection — transient failures resolve via restart, and persistent
-  # failures surface as repeated crashes (hitting max_restarts).
 
   # Note: :icon_path was removed from this projection's schema. Stale events from before
   # this change/deploy may carry :icon_path in their payload — it is intentionally
@@ -312,30 +175,6 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings d
       conflict_target: :id
     )
   end
-
-  # Fields that program_updated events may change; excludes season and provider_verified
-  # which are only set during bootstrap or by provider verification events respectively.
-  @update_fields [
-    :title,
-    :description,
-    :category,
-    :age_range,
-    :price,
-    :pricing_period,
-    :location,
-    :cover_image_url,
-    :instructor_name,
-    :instructor_headshot_url,
-    :start_date,
-    :end_date,
-    :meeting_days,
-    :meeting_start_time,
-    :meeting_end_time,
-    :registration_start_date,
-    :registration_end_date,
-    :provider_id,
-    :updated_at
-  ]
 
   # Trigger: program_updated event received
   # Why: upsert instead of get-then-update so events for listings missing from the read

--- a/lib/klass_hero/program_catalog/adapters/driven/projections/verified_providers.ex
+++ b/lib/klass_hero/program_catalog/adapters/driven/projections/verified_providers.ex
@@ -89,7 +89,9 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
   def handle_call(:rebuild, _from, state) do
     verified_ids = load_verified_ids()
     Logger.info("#{inspect(__MODULE__)} rebuilt", count: MapSet.size(verified_ids))
-    {:reply, :ok, %{state | bootstrapped: true, verified_ids: verified_ids}}
+    # Map.merge (not %{state | ...}) so rebuild stays safe even when the GenServer
+    # was started with skip_bootstrap: true (init state lacks :verified_ids).
+    {:reply, :ok, Map.merge(state, %{bootstrapped: true, verified_ids: verified_ids})}
   end
 
   # ── Override apply_bootstrap to populate the MapSet in state ──────────────

--- a/lib/klass_hero/program_catalog/adapters/driven/projections/verified_providers.ex
+++ b/lib/klass_hero/program_catalog/adapters/driven/projections/verified_providers.ex
@@ -2,184 +2,117 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
   @moduledoc """
   In-memory projection of verified provider IDs.
 
-  This GenServer maintains a MapSet of provider IDs that are verified, enabling
-  fast O(1) lookups without database queries. It bootstraps from the Provider
-  context on startup and stays in sync via integration events.
+  Maintains a `MapSet` of provider IDs that are verified, enabling fast O(1)
+  lookups without database queries. Bootstraps from the Provider context on
+  startup and stays in sync via integration events.
+
+  Built on `KlassHero.Shared.Projection` (base). Does NOT use
+  `WithBootstrapRetry`: on bootstrap failure the GenServer crashes and the
+  supervisor handles the restart, which is the established recovery pattern.
 
   ## Architecture
 
-  This is a "driven adapter" in the Ports & Adapters architecture - it's driven
-  by integration events from the Provider context. The Program Catalog context
-  uses this projection to enrich program data with provider verification status.
+  This is a driven adapter — driven by integration events from the Provider
+  context. The Program Catalog context uses this projection to enrich program
+  data with provider verification status (`ProgramListings` looks it up via
+  `verified?/2`).
 
-  ## Startup Behavior
+  ## Event handling
 
-  On init, the GenServer:
-  1. Subscribes to `integration:provider:provider_verified` topic
-  2. Subscribes to `integration:provider:provider_unverified` topic
-  3. Calls `Provider.list_verified_provider_ids/0` to bootstrap the MapSet
-
-  ## Event Handling
-
-  - `:provider_verified` events add the provider ID to the MapSet
-  - `:provider_unverified` events remove the provider ID from the MapSet
+  - `:provider_verified` — adds the provider ID to the MapSet
+  - `:provider_unverified` — removes the provider ID from the MapSet
   """
 
-  use GenServer
+  use KlassHero.Shared.Projection,
+    topics: [
+      "integration:provider:provider_verified",
+      "integration:provider:provider_unverified"
+    ]
 
   alias KlassHero.Provider
-  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+  alias KlassHero.Shared.Projection
 
-  require Logger
+  # ── Behaviour callbacks ────────────────────────────────────────────────────
 
-  @verified_topic "integration:provider:provider_verified"
-  @unverified_topic "integration:provider:provider_unverified"
-
-  # Client API
-
-  @doc """
-  Starts the VerifiedProviders GenServer.
-
-  ## Options
-
-  - `:name` - Process name (defaults to `__MODULE__`)
-  """
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+  @impl Projection
+  def bootstrap_impl do
+    MapSet.size(load_verified_ids())
   end
+
+  # The macro's handle_info dispatcher calls handle_event/2 then discards the
+  # return value (returns {:noreply, state} with unchanged state). To mutate
+  # the custom verified_ids, we cast to self() so the cast is processed as the
+  # next mailbox message — after handle_info returns — with access to state.
+  # Tests use :sys.get_state/1 as a sync fence which drains the mailbox, so
+  # cast ordering is not a concern.
+  @impl Projection
+  def handle_event(:provider_verified, event) do
+    GenServer.cast(self(), {:add_verified, event.payload.provider_id})
+  end
+
+  def handle_event(:provider_unverified, event) do
+    GenServer.cast(self(), {:remove_verified, event.payload.provider_id})
+  end
+
+  # ── Cast handlers for MapSet mutation ─────────────────────────────────────
+
+  @impl true
+  def handle_cast({:add_verified, id}, state) do
+    Logger.debug("Provider verified in projection", provider_id: id)
+    {:noreply, %{state | verified_ids: MapSet.put(state.verified_ids, id)}}
+  end
+
+  def handle_cast({:remove_verified, id}, state) do
+    Logger.debug("Provider unverified in projection", provider_id: id)
+    {:noreply, %{state | verified_ids: MapSet.delete(state.verified_ids, id)}}
+  end
+
+  # ── Custom query API ───────────────────────────────────────────────────────
 
   @doc """
   Checks if a provider is verified.
 
   Returns `true` if the provider ID is in the verified set, `false` otherwise.
-
-  ## Parameters
-
-  - `provider_id` - The UUID of the provider profile to check
-  - `name` - The GenServer name (defaults to `__MODULE__`)
-
-  ## Examples
-
-      iex> VerifiedProviders.verified?("some-uuid")
-      true
-
-      iex> VerifiedProviders.verified?("unknown-uuid")
-      false
   """
   @spec verified?(String.t(), GenServer.name()) :: boolean()
   def verified?(provider_id, name \\ __MODULE__) do
     GenServer.call(name, {:verified?, provider_id})
   end
 
-  @doc """
-  Rebuilds the in-memory verified providers cache from the database.
-
-  Useful after seeding write tables directly (bypassing integration events).
-  Blocks until the rebuild is complete.
-  """
-  @spec rebuild(GenServer.name()) :: :ok
-  def rebuild(name \\ __MODULE__) do
-    GenServer.call(name, :rebuild, :infinity)
+  # Override handle_call/3 to handle both the custom :verified? query and the
+  # :rebuild message (the macro's default :rebuild does not update verified_ids).
+  @impl true
+  def handle_call({:verified?, provider_id}, _from, state) do
+    {:reply, MapSet.member?(state.verified_ids, provider_id), state}
   end
 
-  # Server Callbacks
-
-  @impl true
-  def init(_opts) do
-    # Trigger: GenServer is starting
-    # Why: Need to subscribe to events before bootstrapping to avoid missing events
-    # Outcome: Subscribed to both verified and unverified topics
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @verified_topic)
-    Phoenix.PubSub.subscribe(KlassHero.PubSub, @unverified_topic)
-
-    # Use handle_continue to bootstrap after init completes
-    # This ensures the GenServer is fully initialized before any blocking calls
-    {:ok, %{verified_ids: MapSet.new()}, {:continue, :bootstrap}}
+  def handle_call(:rebuild, _from, state) do
+    verified_ids = load_verified_ids()
+    Logger.info("#{inspect(__MODULE__)} rebuilt", count: MapSet.size(verified_ids))
+    {:reply, :ok, %{state | bootstrapped: true, verified_ids: verified_ids}}
   end
 
-  @impl true
-  def handle_continue(:bootstrap, state) do
-    # Trigger: GenServer initialization complete
-    # Why: Bootstrap from Provider context to hydrate in-memory cache
-    # Outcome: MapSet populated with all currently verified provider IDs
-    verified_ids = bootstrap_verified_ids()
+  # ── Override apply_bootstrap to populate the MapSet in state ──────────────
+  # The base macro's default apply_bootstrap/1 returns
+  # {:noreply, %{state | bootstrapped: true}} with no hook for custom keys.
+  # This override writes verified_ids alongside the bootstrapped flag.
 
-    Logger.info("VerifiedProviders projection started",
+  defp apply_bootstrap(state) do
+    verified_ids = load_verified_ids()
+
+    Logger.info("#{inspect(__MODULE__)} projection started",
       count: MapSet.size(verified_ids)
     )
 
-    {:noreply, %{state | verified_ids: verified_ids}}
+    {:noreply, Map.merge(state, %{bootstrapped: true, verified_ids: verified_ids})}
   end
 
-  @impl true
-  def handle_call({:verified?, provider_id}, _from, state) do
-    result = MapSet.member?(state.verified_ids, provider_id)
-    {:reply, result, state}
-  end
+  # ── Private ────────────────────────────────────────────────────────────────
 
-  # Trigger: external caller requests a full rebuild (e.g. after seeding)
-  # Why: seeds insert into write tables without emitting integration events
-  # Outcome: in-memory cache refreshed from the authoritative Provider context
-  @impl true
-  def handle_call(:rebuild, _from, state) do
-    verified_ids = bootstrap_verified_ids()
-    Logger.info("VerifiedProviders rebuilt", count: MapSet.size(verified_ids))
-    {:reply, :ok, %{state | verified_ids: verified_ids}}
-  end
-
-  # Trigger: Received a provider_verified integration event
-  # Why: Provider context notifies other contexts when a provider is verified
-  # Outcome: Provider ID added to the in-memory MapSet
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :provider_verified} = event}, state) do
-    provider_id = event.payload.provider_id
-
-    Logger.debug("Provider verified in projection",
-      provider_id: provider_id,
-      event_id: event.event_id
-    )
-
-    new_ids = MapSet.put(state.verified_ids, provider_id)
-    {:noreply, %{state | verified_ids: new_ids}}
-  end
-
-  # Trigger: Received a provider_unverified integration event
-  # Why: Provider context notifies other contexts when a provider loses verification
-  # Outcome: Provider ID removed from the in-memory MapSet
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :provider_unverified} = event}, state) do
-    provider_id = event.payload.provider_id
-
-    Logger.debug("Provider unverified in projection",
-      provider_id: provider_id,
-      event_id: event.event_id
-    )
-
-    new_ids = MapSet.delete(state.verified_ids, provider_id)
-    {:noreply, %{state | verified_ids: new_ids}}
-  end
-
-  # Catch-all for unhandled messages — logged so misrouted events are traceable
-  @impl true
-  def handle_info(msg, state) do
-    Logger.debug("VerifiedProviders received unexpected message",
-      message: inspect(msg, limit: 200)
-    )
-
-    {:noreply, state}
-  end
-
-  # Trigger: GenServer needs initial state from Provider context
-  # Why: Cold start recovery - populate cache from authoritative source
-  # Outcome: Returns MapSet of verified provider IDs, or crashes to let supervisor retry
-  defp bootstrap_verified_ids do
+  defp load_verified_ids do
     case Provider.list_verified_provider_ids() do
-      {:ok, ids} ->
-        MapSet.new(ids)
-
-      {:error, reason} ->
-        raise "Failed to bootstrap verified providers: #{inspect(reason)}"
+      {:ok, ids} -> MapSet.new(ids)
+      {:error, reason} -> raise "Failed to bootstrap verified providers: #{inspect(reason)}"
     end
   end
 end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_programs.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_programs.ex
@@ -2,39 +2,29 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms do
   @moduledoc """
   Event-driven projection maintaining the `provider_programs` read table.
 
-  Subscribes to Program Catalog integration events and mirrors program
-  ownership + display metadata locally so Provider use cases never reach
-  across the context boundary at runtime.
+  Mirrors program ownership + display metadata from the Program Catalog context
+  so Provider use cases never reach across the context boundary at runtime.
 
-  ## Architecture
+  Built on `KlassHero.Shared.Projection` (base) + `Projection.WithBootstrapRetry`
+  (linear-backoff retry on transient bootstrap failure).
 
-  This is a "driven adapter" in the Ports & Adapters architecture — it's driven
-  by integration events from the Program Catalog context. The read-side
-  repository (`ProviderProgramRepository`) queries the table this projection
-  writes.
-
-  ## Startup Behavior
-
-  On init, the GenServer:
-  1. Subscribes to `integration:program_catalog:program_created` and
-     `integration:program_catalog:program_updated` PubSub topics
-  2. Uses `handle_continue(:bootstrap)` to bulk-upsert from the Program Catalog
-     `programs` write table
-
-  Pass `skip_bootstrap: true` in tests to skip both PubSub subscription and
-  bootstrap, allowing direct `send/2` of events for isolated testing.
-
-  ## Event Handling
+  ## Event handling
 
   - `:program_created` — upsert row keyed by `program_id`
   - `:program_updated` — upsert row keyed by `program_id` (replaces mutable fields)
 
-  Programs in the Program Catalog have no first-class status field today, so
-  the projection records every program as `"active"`. This column exists to
-  support future filtering (e.g. archived/draft) without requiring a migration.
+  Programs in the Program Catalog have no first-class status field today, so this
+  projection records every program as `"active"`. The column exists to support
+  future filtering (archived/draft) without requiring a migration.
   """
 
-  use GenServer
+  use KlassHero.Shared.Projection,
+    topics: [
+      "integration:program_catalog:program_created",
+      "integration:program_catalog:program_updated"
+    ]
+
+  use KlassHero.Shared.Projection.WithBootstrapRetry
 
   import Ecto.Query
 
@@ -42,159 +32,56 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms do
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProgramProjectionSchema
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
-
-  require Logger
-
-  @program_created_topic "integration:program_catalog:program_created"
-  @program_updated_topic "integration:program_catalog:program_updated"
+  alias KlassHero.Shared.Projection
 
   @default_status "active"
 
-  # ---------------------------------------------------------------------------
-  # Client API
-  # ---------------------------------------------------------------------------
+  # Behaviour callbacks ───────────────────────────────────────────────────────
 
-  @doc """
-  Starts the ProviderPrograms projection GenServer.
+  @impl Projection
+  def bootstrap_impl, do: bootstrap_from_write_table()
 
-  ## Options
-
-  - `:name` - Process name (defaults to `__MODULE__`)
-  - `:skip_bootstrap` - When `true`, skips PubSub subscription and bootstrap
-    (for isolated testing). Defaults to `false`.
-  """
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+  @impl Projection
+  def handle_event(event_type, %IntegrationEvent{} = event) when event_type in [:program_created, :program_updated] do
+    upsert_from_event(event)
   end
 
-  @doc """
-  Rebuilds the projection from the Program Catalog write table.
+  # Private ──────────────────────────────────────────────────────────────────
 
-  Useful after seeding write tables directly (bypassing integration events).
-  Blocks until the rebuild is complete.
-  """
-  @spec rebuild(GenServer.name()) :: :ok
-  def rebuild(name \\ __MODULE__) do
-    GenServer.call(name, :rebuild, :infinity)
-  end
+  defp bootstrap_from_write_table do
+    programs =
+      ProgramSchema
+      |> select([p], %{program_id: p.id, provider_id: p.provider_id, name: p.title})
+      |> Repo.all()
 
-  # ---------------------------------------------------------------------------
-  # Server Callbacks
-  # ---------------------------------------------------------------------------
-
-  @impl true
-  def init(opts) do
-    skip_bootstrap = Keyword.get(opts, :skip_bootstrap, false)
-
-    if skip_bootstrap do
-      {:ok, %{bootstrapped: false}}
+    if programs == [] do
+      0
     else
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, @program_created_topic)
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, @program_updated_topic)
-      {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      rows =
+        Enum.map(programs, fn program ->
+          Map.merge(program, %{status: @default_status, inserted_at: now, updated_at: now})
+        end)
+
+      {count, _} =
+        Repo.insert_all(
+          ProviderProgramProjectionSchema,
+          rows,
+          on_conflict: {:replace, [:provider_id, :name, :status, :updated_at]},
+          conflict_target: [:program_id]
+        )
+
+      count
     end
   end
 
-  @impl true
-  def handle_continue(:bootstrap, state) do
-    attempt_bootstrap(state)
-  end
-
-  @impl true
-  def handle_call(:rebuild, _from, state) do
-    count = bootstrap_from_write_table()
-    Logger.info("ProviderPrograms rebuilt", count: count)
-    {:reply, :ok, %{state | bootstrapped: true}}
-  end
-
-  # Trigger: scheduled retry after a transient bootstrap failure
-  # Why: re-enter handle_continue logic without crashing the GenServer outright
-  # Outcome: re-attempts bootstrap with the accumulated retry_count in state
-  @impl true
-  def handle_info(:retry_bootstrap, state) do
-    {:noreply, state, {:continue, :bootstrap}}
-  end
-
-  # Trigger: Received a program_created integration event
-  # Why: a new program was created, the projection must add a row for it
-  # Outcome: row inserted (or replaced if duplicate event arrives)
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :program_created} = event}, state) do
-    Logger.debug("ProviderPrograms projecting program_created",
-      program_id: event.entity_id,
-      event_id: event.event_id
-    )
-
-    upsert_from_event(event)
-    {:noreply, state}
-  end
-
-  # Trigger: Received a program_updated integration event
-  # Why: program fields changed, the projection's display metadata must reflect them
-  # Outcome: existing row updated (or inserted if missing due to race with bootstrap)
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :program_updated} = event}, state) do
-    Logger.debug("ProviderPrograms projecting program_updated",
-      program_id: event.entity_id,
-      event_id: event.event_id
-    )
-
-    upsert_from_event(event)
-    {:noreply, state}
-  end
-
-  # Catch-all for unhandled messages — logged so misrouted events are traceable
-  @impl true
-  def handle_info(msg, state) do
-    Logger.warning("ProviderPrograms received unexpected message",
-      message: inspect(msg, limit: 200)
-    )
-
-    {:noreply, state}
-  end
-
-  # ---------------------------------------------------------------------------
-  # Private Functions
-  # ---------------------------------------------------------------------------
-
-  # Trigger: bootstrap attempt with retry logic
-  # Why: transient DB failures shouldn't crash the GenServer immediately
-  # Outcome: successful bootstrap or scheduled retry (up to 3 times before crashing)
-  defp attempt_bootstrap(state) do
-    count = bootstrap_from_write_table()
-    Logger.info("ProviderPrograms projection started", count: count)
-    {:noreply, %{state | bootstrapped: true}}
-  rescue
-    error ->
-      retry_count = Map.get(state, :retry_count, 0) + 1
-
-      if retry_count > 3 do
-        # Trigger: exhausted retries
-        # Why: persistent failure indicates real infrastructure issue
-        # Outcome: crash to let supervisor handle with its own restart strategy
-        reraise error, __STACKTRACE__
-      else
-        Logger.error("ProviderPrograms: bootstrap failed, scheduling retry",
-          error: Exception.message(error),
-          retry_count: retry_count
-        )
-
-        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
-        {:noreply, Map.put(state, :retry_count, retry_count)}
-      end
-  end
-
-  # Trigger: program_created or program_updated event received
-  # Why: upsert keeps both events idempotent and tolerant to bootstrap races
-  # Outcome: row written keyed on program_id
   defp upsert_from_event(%IntegrationEvent{} = event) do
     payload = event.payload
-    program_id = event.entity_id
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     attrs = %{
-      program_id: program_id,
+      program_id: event.entity_id,
       provider_id: Map.fetch!(payload, :provider_id),
       name: extract_name(payload),
       status: extract_status(payload),
@@ -210,59 +97,17 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms do
     )
   end
 
-  # Trigger: bootstrap phase — read table may be empty or stale
-  # Why: cold start recovery — populate read table from Program Catalog write table
-  # Outcome: provider_programs contains one row per program with current name + provider
-  defp bootstrap_from_write_table do
-    programs =
-      ProgramSchema
-      |> select([p], %{program_id: p.id, provider_id: p.provider_id, name: p.title})
-      |> Repo.all()
-
-    if programs == [] do
-      0
-    else
-      now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-      rows =
-        Enum.map(programs, fn program ->
-          Map.merge(program, %{
-            status: @default_status,
-            inserted_at: now,
-            updated_at: now
-          })
-        end)
-
-      {count, _} =
-        Repo.insert_all(
-          ProviderProgramProjectionSchema,
-          rows,
-          on_conflict: {:replace, [:provider_id, :name, :status, :updated_at]},
-          conflict_target: [:program_id]
-        )
-
-      count
-    end
-  end
-
-  # Trigger: payload may carry program name as :title (Program Catalog convention) or :name
-  # Why: tolerate both naming styles for forward-compatibility
-  # Outcome: returns the program's display name; raises with a clear message if absent
   defp extract_name(%{title: title}) when is_binary(title), do: title
   defp extract_name(%{name: name}) when is_binary(name), do: name
 
   defp extract_name(payload) do
-    # Trigger: malformed event payload missing both :title and :name
-    # Why: silent nil would crash later as a NOT NULL violation with no diagnostic context
-    # Outcome: log the payload shape, then crash explicitly so the supervisor can recover
+    require Logger
+
     Logger.error("ProviderPrograms received event without :title or :name (payload_keys=#{inspect(Map.keys(payload))})")
 
     raise ArgumentError, "Program payload missing :title or :name field"
   end
 
-  # Trigger: payload may not include a status (Program Catalog has no status today)
-  # Why: provider_programs.status is NOT NULL — fall back to a sensible default
-  # Outcome: returns the payload status as a string, or "active" if absent
   defp extract_status(%{status: status}) when is_binary(status), do: status
 
   defp extract_status(%{status: status}) when is_atom(status) and status not in [nil, true, false],

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_programs.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_programs.ex
@@ -101,8 +101,6 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms do
   defp extract_name(%{name: name}) when is_binary(name), do: name
 
   defp extract_name(payload) do
-    require Logger
-
     Logger.error("ProviderPrograms received event without :title or :name (payload_keys=#{inspect(Map.keys(payload))})")
 
     raise ArgumentError, "Program payload missing :title or :name field"

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -1,169 +1,115 @@
 defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails do
   @moduledoc """
-  Event-driven projection maintaining `provider_session_details`.
+  Event-driven projection maintaining the `provider_session_details` read table.
 
-  Subscribes to Participation session/attendance events and Provider staff events.
-  Self-heals on every boot by replaying the bootstrap query into the read table.
+  Subscribes to Participation context integration events covering session
+  lifecycle (created/started/completed/cancelled), attendance (checked in/out,
+  marked absent), and roster + staff assignment changes. Maintains the
+  denormalised view consumed by the provider session dashboard.
+
+  Built on `KlassHero.Shared.Projection` (base) + `Projection.WithBootstrapRetry`
+  (linear-backoff retry on transient bootstrap failure).
+
+  ## Event handling
+
+  - `:session_created` — upserts a row with defaults, resolving program_title,
+    provider_id, and currently assigned staff from the write tables.
+  - `:session_started` — sets status to `:in_progress`.
+  - `:session_completed` — sets status to `:completed`.
+  - `:session_cancelled` — sets status to `:cancelled`.
+  - `:roster_seeded` — sets total_count from the seeded roster size.
+  - `:child_checked_in` — increments checked_in_count (monotonic; not reversed).
+  - `:child_checked_out` — intentional no-op (counter is monotonic).
+  - `:child_marked_absent` — intentional no-op (no effect on checked_in_count).
+  - `:staff_assigned_to_program` — bulk-updates current_assigned_staff_* on all
+    `:scheduled` rows for the program.
+  - `:staff_unassigned_from_program` — bulk-clears current_assigned_staff_* on all
+    `:scheduled` rows for the program.
   """
 
-  use GenServer
+  use KlassHero.Shared.Projection,
+    topics: [
+      "integration:participation:session_created",
+      "integration:participation:session_started",
+      "integration:participation:session_completed",
+      "integration:participation:session_cancelled",
+      "integration:participation:roster_seeded",
+      "integration:participation:child_checked_in",
+      "integration:participation:child_checked_out",
+      "integration:participation:child_marked_absent",
+      "integration:provider:staff_assigned_to_program",
+      "integration:provider:staff_unassigned_from_program"
+    ]
+
+  use KlassHero.Shared.Projection.WithBootstrapRetry
 
   import Ecto.Query
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderSessionDetailSchema
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
+  alias KlassHero.Shared.Projection
 
-  require Logger
+  # Behaviour callbacks ─────────────────────────────────────────────────────────
 
-  @session_created_topic "integration:participation:session_created"
-  @session_started_topic "integration:participation:session_started"
-  @session_completed_topic "integration:participation:session_completed"
-  @session_cancelled_topic "integration:participation:session_cancelled"
-  @roster_seeded_topic "integration:participation:roster_seeded"
-  @child_checked_in_topic "integration:participation:child_checked_in"
-  @child_checked_out_topic "integration:participation:child_checked_out"
-  @child_marked_absent_topic "integration:participation:child_marked_absent"
-  @staff_assigned_topic "integration:provider:staff_assigned_to_program"
-  @staff_unassigned_topic "integration:provider:staff_unassigned_from_program"
-
-  @topics [
-    @session_created_topic,
-    @session_started_topic,
-    @session_completed_topic,
-    @session_cancelled_topic,
-    @roster_seeded_topic,
-    @child_checked_in_topic,
-    @child_checked_out_topic,
-    @child_marked_absent_topic,
-    @staff_assigned_topic,
-    @staff_unassigned_topic
-  ]
-
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
-  end
-
-  @doc "Rebuilds the read table from write models. Useful after seeds."
-  def rebuild(name \\ __MODULE__), do: GenServer.call(name, :rebuild, :infinity)
-
-  @impl true
-  def init(_opts) do
-    Enum.each(@topics, &Phoenix.PubSub.subscribe(KlassHero.PubSub, &1))
-    {:ok, %{}, {:continue, :bootstrap}}
-  end
-
-  @impl true
-  def handle_continue(:bootstrap, state) do
-    # Self-heal the read table from write tables on every boot. Transient DB
-    # failures reschedule via :retry_bootstrap; persistent failures propagate
-    # through repeated retries until the supervisor intervenes.
-    case do_bootstrap() do
-      {:ok, count} ->
-        Logger.info("ProviderSessionDetails bootstrap complete", count: count)
-        {:noreply, state}
-
-      {:error, reason} ->
-        Logger.warning("ProviderSessionDetails bootstrap failed; retrying",
-          reason: inspect(reason)
-        )
-
-        Process.send_after(self(), :retry_bootstrap, 1_000)
-        {:noreply, state}
-    end
-  end
-
-  # Seeds bypass the event bus, so `rebuild/1` refreshes the read table from
-  # write tables via the same bootstrap path used on init.
-  @impl true
-  def handle_call(:rebuild, _from, state) do
-    {:ok, count} = do_bootstrap()
-    Logger.info("ProviderSessionDetails rebuilt", count: count)
-    {:reply, :ok, state}
-  end
-
-  @impl true
-  def handle_info(:retry_bootstrap, state) do
-    {:noreply, state, {:continue, :bootstrap}}
-  end
+  @impl Projection
+  def bootstrap_impl, do: bootstrap_session_details()
 
   # Trigger: Received a session_created integration event
   # Why: a new session exists — project a row with defaults, resolving
   #      program_title/provider_id from the programs write table and the
   #      currently assigned staff from program_staff_assignments
   # Outcome: one row upserted into provider_session_details
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_created} = event}, state) do
+  @impl Projection
+  def handle_event(:session_created, %IntegrationEvent{} = event) do
     Logger.debug("ProviderSessionDetails projecting session_created",
       session_id: event.entity_id,
       event_id: event.event_id
     )
 
     project_session_created(event.payload)
-    {:noreply, state}
   end
 
   # Trigger: session entered the live window (instructor started it)
   # Why: dashboard badge flips from scheduled → in_progress
   # Outcome: row's status column updated to :in_progress
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_started} = event}, state) do
+  def handle_event(:session_started, %IntegrationEvent{} = event) do
     update_status(event.entity_id, :in_progress)
-    {:noreply, state}
   end
 
   # Trigger: session finished (end-of-session finalization)
   # Why: dashboard badge flips from in_progress → completed
   # Outcome: row's status column updated to :completed
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_completed} = event}, state) do
+  def handle_event(:session_completed, %IntegrationEvent{} = event) do
     update_status(event.entity_id, :completed)
-    {:noreply, state}
   end
 
   # Trigger: session cancelled (by provider or system)
   # Why: dashboard badge reflects cancellation, independent of prior status
   # Outcome: row's status column updated to :cancelled
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_cancelled} = event}, state) do
+  def handle_event(:session_cancelled, %IntegrationEvent{} = event) do
     update_status(event.entity_id, :cancelled)
-    {:noreply, state}
   end
 
   # Participation seeded the roster for a session — set total_count so the
   # dashboard can render "X / Y checked in" denominators.
-  @impl true
-  def handle_info(
-        {:integration_event,
-         %IntegrationEvent{event_type: :roster_seeded, payload: %{seeded_count: seeded_count}} = event},
-        state
-      ) do
+  def handle_event(:roster_seeded, %IntegrationEvent{payload: %{seeded_count: seeded_count}} = event) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     from(d in ProviderSessionDetailSchema, where: d.session_id == ^event.entity_id)
     |> Repo.update_all(set: [total_count: seeded_count, updated_at: now])
     |> warn_if_missing("roster_seeded", session_id: event.entity_id, seeded_count: seeded_count)
-
-    {:noreply, state}
   end
 
   # Bump the monotonic checked_in counter. Check-outs and absences are
   # intentionally not reflected (see below) — once counted on check-in, a child
   # stays counted for the "how many showed up" view.
-  @impl true
-  def handle_info(
-        {:integration_event,
-         %IntegrationEvent{event_type: :child_checked_in, payload: %{session_id: session_id}} = event},
-        state
-      ) do
+  def handle_event(:child_checked_in, %IntegrationEvent{payload: %{session_id: session_id}} = event) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     from(d in ProviderSessionDetailSchema, where: d.session_id == ^session_id)
     |> Repo.update_all(inc: [checked_in_count: 1], set: [updated_at: now])
     |> warn_if_missing("child_checked_in", session_id: session_id, record_id: event.entity_id)
-
-    {:noreply, state}
   end
 
   # Trigger: attendance taker undid a check-in (child_checked_out)
@@ -171,26 +117,20 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   #      "how many showed up" view; undo events are intentionally not reflected
   #      in checked_in_count. Logged at debug to confirm the no-op is deliberate.
   # Outcome: no state change.
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_checked_out} = event}, state) do
+  def handle_event(:child_checked_out, %IntegrationEvent{} = event) do
     Logger.debug("ProviderSessionDetails ignoring child_checked_out (counter is monotonic)",
       record_id: event.entity_id
     )
-
-    {:noreply, state}
   end
 
   # Trigger: attendance taker marked a child absent
   # Why: absence is the complement of check-in and does not change the "how
   #      many showed up" count. Logged at debug to confirm the no-op is deliberate.
   # Outcome: no state change.
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :child_marked_absent} = event}, state) do
+  def handle_event(:child_marked_absent, %IntegrationEvent{} = event) do
     Logger.debug("ProviderSessionDetails ignoring child_marked_absent (no effect on checked_in_count)",
       record_id: event.entity_id
     )
-
-    {:noreply, state}
   end
 
   # Trigger: staff_assigned_to_program integration event (provider assigned a
@@ -201,15 +141,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   #      :scheduled rows only.
   # Outcome: all :scheduled rows for the program get current_assigned_staff_id
   #          and current_assigned_staff_name set to the new staff values.
-  @impl true
-  def handle_info(
-        {:integration_event,
-         %IntegrationEvent{
-           event_type: :staff_assigned_to_program,
-           payload: %{staff_member_id: staff_id, program_id: program_id}
-         }},
-        state
-      ) do
+  def handle_event(:staff_assigned_to_program, %IntegrationEvent{
+        payload: %{staff_member_id: staff_id, program_id: program_id}
+      }) do
     staff_name = lookup_staff_name(staff_id)
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -223,8 +157,6 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
         updated_at: now
       ]
     )
-
-    {:noreply, state}
   end
 
   # Trigger: staff_unassigned_from_program integration event (provider removed
@@ -234,12 +166,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   #      session's audit trail — bulk clear is scoped to :scheduled rows only.
   # Outcome: all :scheduled rows for the program have current_assigned_staff_*
   #          columns cleared to nil.
-  @impl true
-  def handle_info(
-        {:integration_event,
-         %IntegrationEvent{event_type: :staff_unassigned_from_program, payload: %{program_id: program_id}}},
-        state
-      ) do
+  def handle_event(:staff_unassigned_from_program, %IntegrationEvent{payload: %{program_id: program_id}}) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     from(d in ProviderSessionDetailSchema,
@@ -252,16 +179,133 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
         updated_at: now
       ]
     )
-
-    {:noreply, state}
   end
 
-  # Final catch-all: the projection subscribes to multiple topics, and some
-  # carry unrelated event types we explicitly do not care about. Silently drop
-  # them — matching the no-op discipline used for child_checked_out and
-  # child_marked_absent above.
-  @impl true
-  def handle_info({:integration_event, _event}, state), do: {:noreply, state}
+  # Private — Bootstrap ─────────────────────────────────────────────────────────
+
+  # Trigger: bootstrap_impl/0 called on init or rebuild
+  # Why: self-heal the read table from the authoritative write tables. Seeds
+  #      bypass the event bus, and long-running event drift can leave the read
+  #      table out of sync — a single bootstrap query rebuilds every row from
+  #      programs + program_sessions + program_staff_assignments + staff_members
+  #      + aggregated participation_records counts.
+  #
+  # Design notes:
+  #
+  # * The SQL casts UUIDs to ::text so Postgrex returns them as string UUIDs
+  #   (Ecto's :binary_id fields accept the string form directly on insert).
+  # * Staff display uses first_name/last_name columns (staff_members has no
+  #   display_name); we concatenate in Elixir via build_staff_name/2 to match
+  #   the event-handler resolution path.
+  # * Status comes back from SQL as text ("scheduled", "in_progress", ...);
+  #   the schema is Ecto.Enum, so inserting via the schema module requires an
+  #   atom — we convert via String.to_existing_atom/1 (safe: values are the
+  #   fixed four enum members).
+  # * Upsert preserves only identity-ish fields (session_id, inserted_at) and
+  #   cover_staff_* (which cannot be derived from write tables yet — rebuilding
+  #   would otherwise clobber whatever was evolved by a future cover handler).
+  #   Everything else (status, counts, assigned staff) is intentionally
+  #   refreshed, which is the whole point of rebuild/0.
+  #
+  # Outcome: integer row count on success; raises on DB failure so
+  #          WithBootstrapRetry can schedule a retry.
+  defp bootstrap_session_details do
+    # LATERAL subquery picks exactly one active staff assignment per program
+    # (earliest-assigned wins, matching resolve_program_context/1). Without it,
+    # a program with N active staff members would produce N rows per session
+    # and break the upsert's ON CONFLICT target.
+    sql = """
+    SELECT
+      ps.id::text                            AS session_id,
+      ps.program_id::text                    AS program_id,
+      p.title                                AS program_title,
+      p.provider_id::text                    AS provider_id,
+      ps.session_date,
+      ps.start_time,
+      ps.end_time,
+      ps.status::text                        AS status,
+      staff.staff_member_id::text            AS current_assigned_staff_id,
+      staff.first_name                       AS staff_first_name,
+      staff.last_name                        AS staff_last_name,
+      COALESCE(counts.checked_in, 0)         AS checked_in_count,
+      COALESCE(counts.total, 0)              AS total_count
+    FROM program_sessions ps
+    JOIN programs p ON p.id = ps.program_id
+    LEFT JOIN LATERAL (
+      SELECT psa.staff_member_id, sm.first_name, sm.last_name
+      FROM program_staff_assignments psa
+      LEFT JOIN staff_members sm ON sm.id = psa.staff_member_id
+      WHERE psa.program_id = ps.program_id
+        AND psa.unassigned_at IS NULL
+      ORDER BY psa.assigned_at ASC
+      LIMIT 1
+    ) staff ON TRUE
+    LEFT JOIN (
+      SELECT session_id,
+             COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out')) AS checked_in,
+             COUNT(*) AS total
+      FROM participation_records
+      GROUP BY session_id
+    ) counts ON counts.session_id = ps.id
+    """
+
+    case Repo.query(sql) do
+      {:ok, %{rows: []}} ->
+        0
+
+      {:ok, %{rows: rows}} ->
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+        attrs_list =
+          Enum.map(rows, fn [
+                              session_id,
+                              program_id,
+                              program_title,
+                              provider_id,
+                              session_date,
+                              start_time,
+                              end_time,
+                              status,
+                              staff_id,
+                              staff_first,
+                              staff_last,
+                              checked_in_count,
+                              total_count
+                            ] ->
+            %{
+              session_id: session_id,
+              program_id: program_id,
+              program_title: program_title,
+              provider_id: provider_id,
+              session_date: session_date,
+              start_time: start_time,
+              end_time: end_time,
+              status: String.to_existing_atom(status),
+              current_assigned_staff_id: staff_id,
+              current_assigned_staff_name: build_staff_name(staff_first, staff_last),
+              checked_in_count: checked_in_count,
+              total_count: total_count,
+              inserted_at: now,
+              updated_at: now
+            }
+          end)
+
+        {count, _} =
+          Repo.insert_all(
+            ProviderSessionDetailSchema,
+            attrs_list,
+            on_conflict: {:replace_all_except, [:session_id, :inserted_at, :cover_staff_id, :cover_staff_name]},
+            conflict_target: [:session_id]
+          )
+
+        count
+
+      {:error, reason} ->
+        raise "ProviderSessionDetails bootstrap failed: #{inspect(reason)}"
+    end
+  end
+
+  # Private — Event Projection Helpers ─────────────────────────────────────────
 
   defp project_session_created(%{session_id: session_id, program_id: program_id} = payload) do
     case resolve_program_context(program_id) do
@@ -325,128 +369,6 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
          ]},
       conflict_target: [:session_id]
     )
-  end
-
-  # Trigger: handle_continue(:bootstrap) or handle_call(:rebuild)
-  # Why: self-heal the read table from the authoritative write tables. Seeds
-  #      bypass the event bus, and long-running event drift can leave the read
-  #      table out of sync — a single bootstrap query rebuilds every row from
-  #      programs + program_sessions + program_staff_assignments + staff_members
-  #      + aggregated participation_records counts.
-  #
-  # Design notes:
-  #
-  # * The SQL casts UUIDs to ::text so Postgrex returns them as string UUIDs
-  #   (Ecto's :binary_id fields accept the string form directly on insert).
-  # * Staff display uses first_name/last_name columns (staff_members has no
-  #   display_name); we concatenate in Elixir via build_staff_name/2 to match
-  #   the event-handler resolution path.
-  # * Status comes back from SQL as text ("scheduled", "in_progress", ...);
-  #   the schema is Ecto.Enum, so inserting via the schema module requires an
-  #   atom — we convert via String.to_existing_atom/1 (safe: values are the
-  #   fixed four enum members).
-  # * Upsert preserves only identity-ish fields (session_id, inserted_at) and
-  #   cover_staff_* (which cannot be derived from write tables yet — rebuilding
-  #   would otherwise clobber whatever was evolved by a future cover handler).
-  #   Everything else (status, counts, assigned staff) is intentionally
-  #   refreshed, which is the whole point of rebuild/0.
-  #
-  # Outcome: {:ok, count} on success or {:error, reason} on DB failure; the
-  #          caller decides whether to retry (handle_continue) or raise (rebuild).
-  defp do_bootstrap do
-    # LATERAL subquery picks exactly one active staff assignment per program
-    # (earliest-assigned wins, matching resolve_program_context/1). Without it,
-    # a program with N active staff members would produce N rows per session
-    # and break the upsert's ON CONFLICT target.
-    sql = """
-    SELECT
-      ps.id::text                            AS session_id,
-      ps.program_id::text                    AS program_id,
-      p.title                                AS program_title,
-      p.provider_id::text                    AS provider_id,
-      ps.session_date,
-      ps.start_time,
-      ps.end_time,
-      ps.status::text                        AS status,
-      staff.staff_member_id::text            AS current_assigned_staff_id,
-      staff.first_name                       AS staff_first_name,
-      staff.last_name                        AS staff_last_name,
-      COALESCE(counts.checked_in, 0)         AS checked_in_count,
-      COALESCE(counts.total, 0)              AS total_count
-    FROM program_sessions ps
-    JOIN programs p ON p.id = ps.program_id
-    LEFT JOIN LATERAL (
-      SELECT psa.staff_member_id, sm.first_name, sm.last_name
-      FROM program_staff_assignments psa
-      LEFT JOIN staff_members sm ON sm.id = psa.staff_member_id
-      WHERE psa.program_id = ps.program_id
-        AND psa.unassigned_at IS NULL
-      ORDER BY psa.assigned_at ASC
-      LIMIT 1
-    ) staff ON TRUE
-    LEFT JOIN (
-      SELECT session_id,
-             COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out')) AS checked_in,
-             COUNT(*) AS total
-      FROM participation_records
-      GROUP BY session_id
-    ) counts ON counts.session_id = ps.id
-    """
-
-    case Repo.query(sql) do
-      {:ok, %{rows: []}} ->
-        {:ok, 0}
-
-      {:ok, %{rows: rows}} ->
-        now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-        attrs_list =
-          Enum.map(rows, fn [
-                              session_id,
-                              program_id,
-                              program_title,
-                              provider_id,
-                              session_date,
-                              start_time,
-                              end_time,
-                              status,
-                              staff_id,
-                              staff_first,
-                              staff_last,
-                              checked_in_count,
-                              total_count
-                            ] ->
-            %{
-              session_id: session_id,
-              program_id: program_id,
-              program_title: program_title,
-              provider_id: provider_id,
-              session_date: session_date,
-              start_time: start_time,
-              end_time: end_time,
-              status: String.to_existing_atom(status),
-              current_assigned_staff_id: staff_id,
-              current_assigned_staff_name: build_staff_name(staff_first, staff_last),
-              checked_in_count: checked_in_count,
-              total_count: total_count,
-              inserted_at: now,
-              updated_at: now
-            }
-          end)
-
-        {count, _} =
-          Repo.insert_all(
-            ProviderSessionDetailSchema,
-            attrs_list,
-            on_conflict: {:replace_all_except, [:session_id, :inserted_at, :cover_staff_id, :cover_staff_name]},
-            conflict_target: [:session_id]
-          )
-
-        {:ok, count}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
   end
 
   # Shared by session_started/completed/cancelled handlers. Missing rows

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_stats.ex
@@ -2,151 +2,50 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats do
   @moduledoc """
   Event-driven projection maintaining the `provider_session_stats` read table.
 
-  This GenServer subscribes to `session_completed` integration events from the
-  Participation context and maintains a denormalized counter of completed sessions
-  per provider+program pair.
+  Subscribes to `:session_completed` integration events from the Participation
+  context and maintains a denormalised counter of completed sessions per
+  provider+program pair.
 
-  ## Architecture
+  Built on `KlassHero.Shared.Projection` (base) + `Projection.WithBootstrapRetry`
+  (linear-backoff retry on transient bootstrap failure).
 
-  This is a "driven adapter" in the Ports & Adapters architecture — it's driven
-  by integration events from the Participation context. The read-side repository
-  (`SessionStatsRepository`) queries the table this projection writes.
-
-  ## Startup Behavior
-
-  On init, the GenServer:
-  1. Subscribes to the `integration:participation:session_completed` PubSub topic
-  2. Uses `handle_continue(:bootstrap)` to bulk-upsert initial counts from the ACL
-
-  Pass `skip_bootstrap: true` in tests to skip both PubSub subscription and
-  bootstrap, allowing direct `send/2` of events for isolated testing.
-
-  ## Event Handling
+  ## Event handling
 
   - `:session_completed` — atomic SQL increment of `sessions_completed_count`
-    via `INSERT ... ON CONFLICT DO UPDATE SET count = count + 1`
-
-  ## Dashboard Notification
-
-  After each upsert, broadcasts `:session_stats_updated` to the provider's
-  stats PubSub topic so the dashboard LiveView can refresh.
+    via `INSERT ... ON CONFLICT DO UPDATE SET count = count + 1`. Broadcasts a
+    `:session_stats_updated` PubSub message to the provider's stats topic so the
+    dashboard LiveView can refresh.
   """
 
-  use GenServer
+  use KlassHero.Shared.Projection,
+    topics: ["integration:participation:session_completed"]
+
+  use KlassHero.Shared.Projection.WithBootstrapRetry
 
   import Ecto.Query
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
-
-  require Logger
-
-  @session_completed_topic "integration:participation:session_completed"
+  alias KlassHero.Shared.Projection
 
   @acl Application.compile_env!(:klass_hero, [:provider, :for_resolving_session_stats])
 
-  # ---------------------------------------------------------------------------
-  # Client API
-  # ---------------------------------------------------------------------------
+  # Behaviour callbacks ───────────────────────────────────────────────────────
 
-  @doc """
-  Starts the ProviderSessionStats projection GenServer.
+  @impl Projection
+  def bootstrap_impl, do: bootstrap_counts()
 
-  ## Options
-
-  - `:name` - Process name (defaults to `__MODULE__`)
-  - `:skip_bootstrap` - When `true`, skips PubSub subscription and bootstrap
-    (for isolated testing). Defaults to `false`.
-  """
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
-  end
-
-  # ---------------------------------------------------------------------------
-  # Server Callbacks
-  # ---------------------------------------------------------------------------
-
-  @impl true
-  def init(opts) do
-    skip_bootstrap = Keyword.get(opts, :skip_bootstrap, false)
-
-    if skip_bootstrap do
-      {:ok, %{bootstrapped: false}}
-    else
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, @session_completed_topic)
-      {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
-    end
-  end
-
-  @impl true
-  def handle_continue(:bootstrap, state) do
-    attempt_bootstrap(state)
-  end
-
-  @impl true
-  def handle_info(:retry_bootstrap, state) do
-    {:noreply, state, {:continue, :bootstrap}}
-  end
-
-  # Trigger: Received a session_completed integration event
-  # Why: a session was completed, the counter for that provider+program must increment
-  # Outcome: atomic SQL increment of sessions_completed_count, dashboard notified
-  @impl true
-  def handle_info({:integration_event, %IntegrationEvent{event_type: :session_completed} = event}, state) do
+  @impl Projection
+  def handle_event(:session_completed, %IntegrationEvent{} = event) do
     %{provider_id: provider_id, program_id: program_id, program_title: program_title} =
       event.payload
 
-    Logger.debug("ProviderSessionStats projecting session_completed",
-      provider_id: provider_id,
-      program_id: program_id,
-      event_id: event.event_id
-    )
-
     upsert_session_count(provider_id, program_id, program_title)
     notify_dashboard(provider_id)
-
-    {:noreply, state}
   end
 
-  # Catch-all for unhandled messages
-  @impl true
-  def handle_info(msg, state) do
-    Logger.warning("ProviderSessionStats received unexpected message",
-      message: inspect(msg, limit: 200)
-    )
-
-    {:noreply, state}
-  end
-
-  # ---------------------------------------------------------------------------
-  # Private Functions
-  # ---------------------------------------------------------------------------
-
-  # Trigger: bootstrap attempt with retry logic
-  # Why: transient DB failures shouldn't crash the GenServer immediately
-  # Outcome: successful bootstrap or scheduled retry (up to 3 times before crashing)
-  defp attempt_bootstrap(state) do
-    count = bootstrap_counts()
-    Logger.info("ProviderSessionStats projection started", count: count)
-    {:noreply, %{state | bootstrapped: true}}
-  rescue
-    error ->
-      retry_count = Map.get(state, :retry_count, 0) + 1
-
-      if retry_count > 3 do
-        reraise error, __STACKTRACE__
-      else
-        Logger.error("ProviderSessionStats: bootstrap failed, scheduling retry",
-          error: Exception.message(error),
-          retry_count: retry_count
-        )
-
-        Process.send_after(self(), :retry_bootstrap, 5_000 * retry_count)
-        {:noreply, Map.put(state, :retry_count, retry_count)}
-      end
-  end
+  # Private ──────────────────────────────────────────────────────────────────
 
   # Trigger: bootstrap phase -- read table may be empty or stale
   # Why: cold start recovery -- populate read table from ACL cross-context query

--- a/lib/klass_hero/shared.ex
+++ b/lib/klass_hero/shared.ex
@@ -25,6 +25,8 @@ defmodule KlassHero.Shared do
       IntegrationEventPublishing,
       EventDispatchHelper,
       NameUtils,
+      Projection,
+      Projection.WithBootstrapRetry,
       FeatureFlags,
       Adapters.Driven.Events.EventHandlers.NotifyLiveViews,
       Adapters.Driven.Events.RetryHelpers,

--- a/lib/klass_hero/shared.ex
+++ b/lib/klass_hero/shared.ex
@@ -27,6 +27,7 @@ defmodule KlassHero.Shared do
       NameUtils,
       Projection,
       Projection.WithBootstrapRetry,
+      Projection.WithDomainEvents,
       FeatureFlags,
       Adapters.Driven.Events.EventHandlers.NotifyLiveViews,
       Adapters.Driven.Events.RetryHelpers,

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -79,6 +79,20 @@ defmodule KlassHero.Shared.Projection do
         {:noreply, state}
       end
 
+      @impl true
+      def handle_info(:retry_bootstrap, state) do
+        {:noreply, state, {:continue, :bootstrap}}
+      end
+
+      @impl true
+      def handle_info(msg, state) do
+        Logger.warning("#{inspect(__MODULE__)} received unexpected message",
+          message: inspect(msg, limit: 200)
+        )
+
+        {:noreply, state}
+      end
+
       defoverridable apply_bootstrap: 1
     end
   end

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -122,7 +122,7 @@ defmodule KlassHero.Shared.Projection do
         {:noreply, state, {:continue, :bootstrap}}
       end
 
-      defoverridable apply_bootstrap: 1
+      defoverridable apply_bootstrap: 1, handle_call: 3
     end
   end
 end

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -23,6 +23,8 @@ defmodule KlassHero.Shared.Projection do
 
       use GenServer
 
+      alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
       require Logger
 
       @projection_topics topics
@@ -49,6 +51,13 @@ defmodule KlassHero.Shared.Projection do
         count = bootstrap_impl()
         Logger.info("#{inspect(__MODULE__)} projection started", count: count)
         {:noreply, %{state | bootstrapped: true}}
+      end
+
+      @impl true
+      def handle_info({:integration_event, %IntegrationEvent{event_type: type} = event}, state) do
+        Logger.debug("#{inspect(__MODULE__)} projecting #{type}", event_id: event.event_id)
+        handle_event(type, event)
+        {:noreply, state}
       end
 
       defoverridable apply_bootstrap: 1

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -10,8 +10,10 @@ defmodule KlassHero.Shared.Projection do
   See `docs/superpowers/specs/2026-05-16-projection-macro-design.md`.
   """
 
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
   @callback bootstrap_impl() :: non_neg_integer()
-  @callback handle_event(event_type :: atom(), event :: term()) :: any()
+  @callback handle_event(event_type :: atom(), event :: IntegrationEvent.t()) :: any()
 
   defmacro __using__(opts) do
     topics = Keyword.fetch!(opts, :topics)
@@ -30,7 +32,7 @@ defmodule KlassHero.Shared.Projection do
         GenServer.start_link(__MODULE__, opts, name: name)
       end
 
-      @impl GenServer
+      @impl true
       def init(opts) do
         if Keyword.get(opts, :skip_bootstrap, false) do
           {:ok, %{bootstrapped: false}}

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -7,7 +7,29 @@ defmodule KlassHero.Shared.Projection do
   `handle_info/2` warner. The calling module supplies `bootstrap_impl/0` and
   `handle_event/2`.
 
-  See `docs/superpowers/specs/2026-05-16-projection-macro-design.md`.
+  ## Usage
+
+      defmodule MyContext.Adapters.Driven.Projections.MyProjection do
+        use KlassHero.Shared.Projection,
+          topics: ["integration:some_context:some_event"]
+
+        # Optionally add retry on transient bootstrap failure:
+        use KlassHero.Shared.Projection.WithBootstrapRetry
+
+        @impl KlassHero.Shared.Projection
+        def bootstrap_impl do
+          # populate the read table; return row count
+          42
+        end
+
+        @impl KlassHero.Shared.Projection
+        def handle_event(:some_event, %IntegrationEvent{} = event) do
+          # upsert into the read table
+        end
+      end
+
+  See `KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms` for the
+  canonical example.
   """
 
   alias KlassHero.Shared.Domain.Events.IntegrationEvent

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -37,6 +37,7 @@ defmodule KlassHero.Shared.Projection do
         if Keyword.get(opts, :skip_bootstrap, false) do
           {:ok, %{bootstrapped: false}}
         else
+          Enum.each(@projection_topics, &Phoenix.PubSub.subscribe(KlassHero.PubSub, &1))
           {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
         end
       end

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -1,0 +1,43 @@
+defmodule KlassHero.Shared.Projection do
+  @moduledoc """
+  Base macro for event-driven projections.
+
+  Injects a GenServer skeleton: `start_link/1`, `init/1`, `handle_continue(:bootstrap, _)`,
+  `handle_call(:rebuild, ...)`, an integration-event dispatcher, and a catch-all
+  `handle_info/2` warner. The calling module supplies `bootstrap_impl/0` and
+  `handle_event/2`.
+
+  See `docs/superpowers/specs/2026-05-16-projection-macro-design.md`.
+  """
+
+  @callback bootstrap_impl() :: non_neg_integer()
+  @callback handle_event(event_type :: atom(), event :: term()) :: any()
+
+  defmacro __using__(opts) do
+    topics = Keyword.fetch!(opts, :topics)
+
+    quote bind_quoted: [topics: topics] do
+      @behaviour KlassHero.Shared.Projection
+
+      use GenServer
+
+      require Logger
+
+      @projection_topics topics
+
+      def start_link(opts \\ []) do
+        name = Keyword.get(opts, :name, __MODULE__)
+        GenServer.start_link(__MODULE__, opts, name: name)
+      end
+
+      @impl GenServer
+      def init(opts) do
+        if Keyword.get(opts, :skip_bootstrap, false) do
+          {:ok, %{bootstrapped: false}}
+        else
+          {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
+        end
+      end
+    end
+  end
+end

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -40,6 +40,17 @@ defmodule KlassHero.Shared.Projection do
           {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
         end
       end
+
+      @impl true
+      def handle_continue(:bootstrap, state), do: apply_bootstrap(state)
+
+      defp apply_bootstrap(state) do
+        count = bootstrap_impl()
+        Logger.info("#{inspect(__MODULE__)} projection started", count: count)
+        {:noreply, %{state | bootstrapped: true}}
+      end
+
+      defoverridable apply_bootstrap: 1
     end
   end
 end

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -39,7 +39,10 @@ defmodule KlassHero.Shared.Projection do
         if Keyword.get(opts, :skip_bootstrap, false) do
           {:ok, %{bootstrapped: false}}
         else
-          Enum.each(@projection_topics, &Phoenix.PubSub.subscribe(KlassHero.PubSub, &1))
+          for topic <- @projection_topics do
+            Phoenix.PubSub.subscribe(KlassHero.PubSub, topic)
+          end
+
           {:ok, %{bootstrapped: false}, {:continue, :bootstrap}}
         end
       end
@@ -55,7 +58,11 @@ defmodule KlassHero.Shared.Projection do
 
       @impl true
       def handle_info({:integration_event, %IntegrationEvent{event_type: type} = event}, state) do
-        Logger.debug("#{inspect(__MODULE__)} projecting #{type}", event_id: event.event_id)
+        Logger.debug("#{inspect(__MODULE__)} projecting #{type}",
+          entity_id: event.entity_id,
+          event_id: event.event_id
+        )
+
         handle_event(type, event)
         {:noreply, state}
       end

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -37,6 +37,19 @@ defmodule KlassHero.Shared.Projection do
   @callback bootstrap_impl() :: non_neg_integer()
   @callback handle_event(event_type :: atom(), event :: IntegrationEvent.t()) :: any()
 
+  defmacro __before_compile__(_env) do
+    quote do
+      @impl true
+      def handle_info(msg, state) do
+        Logger.warning("#{inspect(__MODULE__)} received unexpected message",
+          message: inspect(msg, limit: 200)
+        )
+
+        {:noreply, state}
+      end
+    end
+  end
+
   defmacro __using__(opts) do
     topics = Keyword.fetch!(opts, :topics)
 
@@ -46,8 +59,11 @@ defmodule KlassHero.Shared.Projection do
       use GenServer
 
       alias KlassHero.Shared.Domain.Events.IntegrationEvent
+      alias KlassHero.Shared.Projection
 
       require Logger
+
+      @before_compile Projection
 
       @projection_topics topics
 
@@ -104,15 +120,6 @@ defmodule KlassHero.Shared.Projection do
       @impl true
       def handle_info(:retry_bootstrap, state) do
         {:noreply, state, {:continue, :bootstrap}}
-      end
-
-      @impl true
-      def handle_info(msg, state) do
-        Logger.warning("#{inspect(__MODULE__)} received unexpected message",
-          message: inspect(msg, limit: 200)
-        )
-
-        {:noreply, state}
       end
 
       defoverridable apply_bootstrap: 1

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -56,6 +56,17 @@ defmodule KlassHero.Shared.Projection do
         {:noreply, %{state | bootstrapped: true}}
       end
 
+      def rebuild(name \\ __MODULE__) do
+        GenServer.call(name, :rebuild, :infinity)
+      end
+
+      @impl true
+      def handle_call(:rebuild, _from, state) do
+        count = bootstrap_impl()
+        Logger.info("#{inspect(__MODULE__)} rebuilt", count: count)
+        {:reply, :ok, %{state | bootstrapped: true}}
+      end
+
       @impl true
       def handle_info({:integration_event, %IntegrationEvent{event_type: type} = event}, state) do
         Logger.debug("#{inspect(__MODULE__)} projecting #{type}",

--- a/lib/klass_hero/shared/projection.ex
+++ b/lib/klass_hero/shared/projection.ex
@@ -56,6 +56,7 @@ defmodule KlassHero.Shared.Projection do
         {:noreply, %{state | bootstrapped: true}}
       end
 
+      @spec rebuild(GenServer.name()) :: :ok
       def rebuild(name \\ __MODULE__) do
         GenServer.call(name, :rebuild, :infinity)
       end

--- a/lib/klass_hero/shared/projection/with_bootstrap_retry.ex
+++ b/lib/klass_hero/shared/projection/with_bootstrap_retry.ex
@@ -24,7 +24,7 @@ defmodule KlassHero.Shared.Projection.WithBootstrapRetry do
       defp apply_bootstrap(state) do
         count = bootstrap_impl()
         Logger.info("#{inspect(__MODULE__)} projection started", count: count)
-        {:noreply, %{state | bootstrapped: true, retry_count: 0}}
+        {:noreply, Map.merge(state, %{bootstrapped: true, retry_count: 0})}
       rescue
         error ->
           retry_count = Map.get(state, :retry_count, 0) + 1

--- a/lib/klass_hero/shared/projection/with_bootstrap_retry.ex
+++ b/lib/klass_hero/shared/projection/with_bootstrap_retry.ex
@@ -6,8 +6,10 @@ defmodule KlassHero.Shared.Projection.WithBootstrapRetry do
 
   ## Options
 
-  - `:max_attempts` — defaults to `3`. After exhausting attempts the original
-    exception is reraised so the supervisor sees it.
+  - `:max_attempts` — defaults to `3`. Maximum number of retries *after* the
+    initial bootstrap attempt. Total calls to `bootstrap_impl/0` will be at most
+    `max_attempts + 1`. After exhausting retries the original exception is
+    reraised so the supervisor sees it.
   - `:base_delay_ms` — defaults to `5_000`. Linear backoff: `base_delay_ms * retry_count`.
 
   Use immediately after `use KlassHero.Shared.Projection, ...`.

--- a/lib/klass_hero/shared/projection/with_bootstrap_retry.ex
+++ b/lib/klass_hero/shared/projection/with_bootstrap_retry.ex
@@ -1,0 +1,48 @@
+defmodule KlassHero.Shared.Projection.WithBootstrapRetry do
+  @moduledoc """
+  Opt-in mixin for `KlassHero.Shared.Projection`. Wraps `apply_bootstrap/1`
+  in a `try/rescue` with linear backoff so transient infrastructure failures
+  do not immediately crash the projection.
+
+  ## Options
+
+  - `:max_attempts` — defaults to `3`. After exhausting attempts the original
+    exception is reraised so the supervisor sees it.
+  - `:base_delay_ms` — defaults to `5_000`. Linear backoff: `base_delay_ms * retry_count`.
+
+  Use immediately after `use KlassHero.Shared.Projection, ...`.
+  """
+
+  defmacro __using__(opts) do
+    max_attempts = Keyword.get(opts, :max_attempts, 3)
+    base_delay_ms = Keyword.get(opts, :base_delay_ms, 5_000)
+
+    quote bind_quoted: [max_attempts: max_attempts, base_delay_ms: base_delay_ms] do
+      @projection_max_attempts max_attempts
+      @projection_base_delay_ms base_delay_ms
+
+      defp apply_bootstrap(state) do
+        count = bootstrap_impl()
+        Logger.info("#{inspect(__MODULE__)} projection started", count: count)
+        {:noreply, %{state | bootstrapped: true, retry_count: 0}}
+      rescue
+        error ->
+          retry_count = Map.get(state, :retry_count, 0) + 1
+
+          if retry_count > @projection_max_attempts do
+            reraise error, __STACKTRACE__
+          else
+            Logger.error("#{inspect(__MODULE__)}: bootstrap failed, scheduling retry",
+              error: Exception.message(error),
+              retry_count: retry_count
+            )
+
+            Process.send_after(self(), :retry_bootstrap, @projection_base_delay_ms * retry_count)
+            {:noreply, Map.put(state, :retry_count, retry_count)}
+          end
+      end
+
+      defoverridable apply_bootstrap: 1
+    end
+  end
+end

--- a/lib/klass_hero/shared/projection/with_domain_events.ex
+++ b/lib/klass_hero/shared/projection/with_domain_events.ex
@@ -1,0 +1,49 @@
+defmodule KlassHero.Shared.Projection.WithDomainEvents do
+  @moduledoc """
+  Opt-in mixin for `KlassHero.Shared.Projection`. Routes `{:domain_event, %DomainEvent{}}`
+  envelopes received via PubSub to a `handle_domain_event/2` callback.
+
+  Use immediately after `use KlassHero.Shared.Projection, ...` (and after
+  `WithBootstrapRetry` if used).
+
+  ## Usage
+
+      defmodule MyContext.Adapters.Driven.Projections.MyProjection do
+        use KlassHero.Shared.Projection, topics: ["..."]
+        use KlassHero.Shared.Projection.WithBootstrapRetry
+        use KlassHero.Shared.Projection.WithDomainEvents
+
+        @impl KlassHero.Shared.Projection
+        def bootstrap_impl, do: ...
+
+        @impl KlassHero.Shared.Projection
+        def handle_event(type, event), do: ...
+
+        @impl KlassHero.Shared.Projection.WithDomainEvents
+        def handle_domain_event(:some_domain_event, event), do: ...
+      end
+  """
+
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  @callback handle_domain_event(
+              event_type :: atom(),
+              event :: DomainEvent.t()
+            ) :: any()
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour KlassHero.Shared.Projection.WithDomainEvents
+
+      @impl true
+      def handle_info({:domain_event, %DomainEvent{event_type: type} = event}, state) do
+        Logger.debug("#{inspect(__MODULE__)} projecting domain event #{type}",
+          aggregate_id: event.aggregate_id
+        )
+
+        handle_domain_event(type, event)
+        {:noreply, state}
+      end
+    end
+  end
+end

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -1762,4 +1762,45 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
       )
     )
   end
+
+  describe "macro invariants after happy-path startup" do
+    test "state.retry_count == 0 after first event projects successfully" do
+      pid =
+        start_supervised!(
+          {ConversationSummaries, name: :"reg_#{System.unique_integer([:positive])}"},
+          id: :regression_projection
+        )
+
+      :sys.get_state(pid)
+
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+
+      user_1 = user_fixture(name: "Alice Macro")
+      user_2 = user_fixture(name: "Bob Macro")
+
+      conversation_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :conversation_created,
+          :messaging,
+          :conversation,
+          conversation_id,
+          %{
+            conversation_id: conversation_id,
+            participant_ids: [user_1.id, user_2.id],
+            type: "direct",
+            provider_id: provider_id,
+            program_id: nil,
+            subject: nil
+          }
+        )
+
+      send(pid, {:integration_event, event})
+      :sys.get_state(pid)
+
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+    end
+  end
 end

--- a/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
@@ -171,6 +171,52 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
     end
   end
 
+  describe "macro invariants after happy-path startup" do
+    test "state.retry_count == 0 after first event projects successfully" do
+      # Start WITHOUT skip_bootstrap to exercise the real subscribe + handle_continue path.
+      # If a KeyError-class bug got swallowed by the retry mixin's rescue, retry_count
+      # would be > 0 even though the test event still projects correctly.
+      pid =
+        start_supervised!(
+          {EnrolledChildren, name: :"reg_#{System.unique_integer([:positive])}"},
+          id: :regression_projection
+        )
+
+      # Drain handle_continue; bootstrap should succeed on the first attempt.
+      # Shared sandbox (async: false) covers the GenServer pid automatically.
+      :sys.get_state(pid)
+
+      # If any rescue path was triggered during bootstrap, retry_count would be > 0.
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+
+      # Send one well-formed enrollment_created event; confirm dispatcher path
+      # doesn't trip an internal raise.
+      enrollment_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :enrollment_created,
+          :enrollment,
+          :enrollment,
+          enrollment_id,
+          %{
+            enrollment_id: enrollment_id,
+            child_id: Ecto.UUID.generate(),
+            parent_id: Ecto.UUID.generate(),
+            parent_user_id: Ecto.UUID.generate(),
+            program_id: Ecto.UUID.generate(),
+            status: "confirmed"
+          }
+        )
+
+      send(pid, {:integration_event, event})
+      :sys.get_state(pid)
+
+      # No retry scheduled by handle_event. State invariant preserved.
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+    end
+  end
+
   # Helper to create users with specific names
   defp user_fixture(attrs) do
     KlassHero.AccountsFixtures.user_fixture(attrs)

--- a/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
@@ -438,11 +438,8 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListingsTe
           id: :regression_projection
         )
 
-      # Explicit sandbox allowance so bootstrap's Repo.all runs against the test connection
-      # even if this file is later migrated to async: true.
-      Ecto.Adapters.SQL.Sandbox.allow(KlassHero.Repo, self(), pid)
-
       # Drain handle_continue; bootstrap should succeed on the first attempt.
+      # Shared sandbox (async: false) covers the GenServer pid automatically.
       :sys.get_state(pid)
 
       # If any rescue path was triggered during bootstrap, retry_count would be > 0.

--- a/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
@@ -438,6 +438,10 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListingsTe
           id: :regression_projection
         )
 
+      # Explicit sandbox allowance so bootstrap's Repo.all runs against the test connection
+      # even if this file is later migrated to async: true.
+      Ecto.Adapters.SQL.Sandbox.allow(KlassHero.Repo, self(), pid)
+
       # Drain handle_continue; bootstrap should succeed on the first attempt.
       :sys.get_state(pid)
 

--- a/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
@@ -426,4 +426,48 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListingsTe
       assert Repo.get(ProgramListingSchema, other_listing.id).provider_verified == true
     end
   end
+
+  describe "macro invariants after happy-path startup" do
+    test "state.retry_count == 0 after first event projects successfully" do
+      # Start WITHOUT skip_bootstrap to exercise the real subscribe + handle_continue path.
+      # If a KeyError-class bug got swallowed by the retry mixin's rescue, retry_count
+      # would be > 0 even though the test event still projects correctly.
+      pid =
+        start_supervised!(
+          {ProgramListings, name: :"reg_#{System.unique_integer([:positive])}"},
+          id: :regression_projection
+        )
+
+      # Drain handle_continue; bootstrap should succeed on the first attempt.
+      :sys.get_state(pid)
+
+      # If any rescue path was triggered during bootstrap, retry_count would be > 0.
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+
+      # Send one well-formed event; confirm the dispatcher path doesn't trip an internal raise.
+      program_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :program_created,
+          :program_catalog,
+          :program,
+          program_id,
+          %{
+            program_id: program_id,
+            provider_id: provider_id,
+            title: "Regression Test Program",
+            category: "sports",
+            meeting_days: []
+          }
+        )
+
+      send(pid, {:integration_event, event})
+      :sys.get_state(pid)
+
+      # No retry was scheduled by handle_event; state invariant preserved.
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+    end
+  end
 end

--- a/test/klass_hero/program_catalog/adapters/driven/projections/verified_providers_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/verified_providers_test.exs
@@ -269,4 +269,34 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
       refute VerifiedProviders.verified?(provider_id, @test_server_name)
     end
   end
+
+  describe "macro invariants after happy-path startup" do
+    test "verified_ids is populated and event mutates the cache" do
+      name = :"reg_#{System.unique_integer([:positive])}"
+      pid = start_supervised!({VerifiedProviders, name: name}, id: :regression_projection)
+
+      # Bootstrap completes — state has the MapSet
+      state = :sys.get_state(pid)
+      assert state.bootstrapped == true
+      assert %MapSet{} = state.verified_ids
+
+      # Send a provider_verified integration event and confirm verified?/2 picks it up
+      new_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :provider_verified,
+          :provider,
+          :provider,
+          new_id,
+          %{provider_id: new_id, business_name: "Regression Business"}
+        )
+
+      send(pid, {:integration_event, event})
+      # :sys.get_state drains the mailbox (sync fence)
+      :sys.get_state(pid)
+
+      assert VerifiedProviders.verified?(new_id, name) == true
+    end
+  end
 end

--- a/test/klass_hero/program_catalog/adapters/driven/projections/verified_providers_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/verified_providers_test.exs
@@ -298,5 +298,28 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
 
       assert VerifiedProviders.verified?(new_id, name) == true
     end
+
+    test "rebuild after skip_bootstrap: true populates verified_ids without crashing" do
+      # Stealth-bug regression: handle_call(:rebuild) previously used
+      # %{state | ... , verified_ids: ...}, which raises KeyError when init state
+      # came from skip_bootstrap: true (no :verified_ids key). Map.merge guards this.
+      name = :"reg_skip_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          {VerifiedProviders, name: name, skip_bootstrap: true},
+          id: :regression_skip_bootstrap
+        )
+
+      # Initial state lacks :verified_ids (skip_bootstrap path).
+      refute Map.has_key?(:sys.get_state(pid), :verified_ids)
+
+      # Rebuild must NOT crash and must populate verified_ids.
+      assert :ok = VerifiedProviders.rebuild(name)
+
+      state = :sys.get_state(pid)
+      assert state.bootstrapped == true
+      assert %MapSet{} = state.verified_ids
+    end
   end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_programs_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_programs_test.exs
@@ -1,9 +1,11 @@
 defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderProgramsTest do
-  use KlassHero.DataCase, async: true
+  # async: false: projection GenServers run DB queries during {:continue, :bootstrap}
+  # before the test process can Sandbox.allow the spawned pid. Shared sandbox mode
+  # (DataCase default when not async) covers any spawned process automatically.
+  use KlassHero.DataCase, async: false
 
   import KlassHero.Factory
 
-  alias Ecto.Adapters.SQL.Sandbox
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.ProviderProgramProjectionSchema
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms
   alias KlassHero.Repo
@@ -30,7 +32,6 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderProgramsTest do
         skip_bootstrap: true
       )
 
-    Sandbox.allow(Repo, self(), pid)
     pid
   end
 

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -595,4 +595,45 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
 
     %{session_id: session_id}
   end
+
+  describe "macro invariants after happy-path startup" do
+    test "state.retry_count == 0 after first event projects successfully" do
+      pid =
+        start_supervised!(
+          {ProviderSessionDetails, name: :"reg_#{System.unique_integer([:positive])}"},
+          id: :regression_projection
+        )
+
+      # Synchronize: ensure bootstrap has completed
+      :sys.get_state(pid)
+
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+
+      # Build a minimal session_created event using the shared broadcast helper pattern
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Regression")
+      session_id = Ecto.UUID.generate()
+
+      event =
+        IntegrationEvent.new(
+          :session_created,
+          :participation,
+          :session,
+          session_id,
+          %{
+            session_id: session_id,
+            program_id: program.id,
+            session_date: ~D[2026-05-01],
+            start_time: ~T[09:00:00],
+            end_time: ~T[10:00:00]
+          }
+        )
+
+      send(pid, {:integration_event, event})
+      # Synchronize: ensure GenServer has processed the message
+      :sys.get_state(pid)
+
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+    end
+  end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
@@ -1,9 +1,11 @@
 defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTest do
-  use KlassHero.DataCase, async: true
+  # async: false: projection GenServers run DB queries during {:continue, :bootstrap}
+  # before the test process can Sandbox.allow the spawned pid. Shared sandbox mode
+  # (DataCase default when not async) covers any spawned process automatically.
+  use KlassHero.DataCase, async: false
 
   import Ecto.Query
 
-  alias Ecto.Adapters.SQL.Sandbox
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.SessionStatsSchema
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStats
   alias KlassHero.Repo
@@ -35,7 +37,6 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTes
         skip_bootstrap: true
       )
 
-    Sandbox.allow(Repo, self(), pid)
     pid
   end
 
@@ -149,14 +150,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTes
           id: :regression_projection
         )
 
-      # Sandbox.allow lands synchronously in the test process before :sys.get_state
-      # below blocks and yields the GenServer scheduler slot — so by the time the
-      # {:continue, :bootstrap} handler runs ACL queries, the sandbox is already
-      # transferred. This relies on BEAM not preempting the test process mid-call;
-      # if CI ever flakes here, replace with a Mox stub for the ACL.
-      Sandbox.allow(Repo, self(), pid)
-
       # Drain handle_continue; bootstrap should succeed on the first attempt.
+      # Shared sandbox (async: false) covers the GenServer pid automatically.
       :sys.get_state(pid)
 
       # If any rescue path was triggered during bootstrap, retry_count would be > 0.

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
@@ -137,4 +137,41 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTes
       assert music.sessions_completed_count == 2
     end
   end
+
+  describe "macro invariants after happy-path startup" do
+    test "state.retry_count == 0 after first event projects successfully" do
+      # Start WITHOUT skip_bootstrap to exercise the real subscribe + handle_continue path.
+      # If a KeyError-class bug got swallowed by the retry mixin's rescue, retry_count
+      # would be > 0 even though the test event still projects correctly.
+      pid =
+        start_supervised!(
+          {ProviderSessionStats, name: :"reg_#{System.unique_integer([:positive])}"},
+          id: :regression_projection
+        )
+
+      # Explicit sandbox allowance so bootstrap's ACL call (and any DB work it does)
+      # runs against the test connection even if this file later migrates to async: true.
+      Sandbox.allow(Repo, self(), pid)
+
+      # Drain handle_continue; bootstrap should succeed on the first attempt.
+      :sys.get_state(pid)
+
+      # If any rescue path was triggered during bootstrap, retry_count would be > 0.
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+
+      # Send one well-formed event; confirm the dispatcher path doesn't trip an internal raise.
+      event =
+        build_session_completed_event(
+          provider_id: Ecto.UUID.generate(),
+          program_id: Ecto.UUID.generate(),
+          program_title: "Regression Class"
+        )
+
+      send(pid, {:integration_event, event})
+      :sys.get_state(pid)
+
+      # No retry scheduled by handle_event. State invariant preserved.
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+    end
+  end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
@@ -149,8 +149,11 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTes
           id: :regression_projection
         )
 
-      # Explicit sandbox allowance so bootstrap's ACL call (and any DB work it does)
-      # runs against the test connection even if this file later migrates to async: true.
+      # Sandbox.allow lands synchronously in the test process before :sys.get_state
+      # below blocks and yields the GenServer scheduler slot — so by the time the
+      # {:continue, :bootstrap} handler runs ACL queries, the sandbox is already
+      # transferred. This relies on BEAM not preempting the test process mid-call;
+      # if CI ever flakes here, replace with a Mox stub for the ACL.
       Sandbox.allow(Repo, self(), pid)
 
       # Drain handle_continue; bootstrap should succeed on the first attempt.

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -57,6 +57,19 @@ defmodule KlassHero.Shared.ProjectionTest do
     end
   end
 
+  describe "rebuild/1" do
+    test "re-invokes bootstrap_impl/0 and stays bootstrapped" do
+      {:ok, pid} = TestProjection.start_link(name: unique_name())
+      :sys.get_state(pid)
+      assert agent_state().bootstraps == 1
+
+      assert :ok = TestProjection.rebuild(pid)
+
+      assert agent_state().bootstraps == 2
+      assert %{bootstrapped: true} = :sys.get_state(pid)
+    end
+  end
+
   describe "init/1 with default opts" do
     test "subscribes to every topic in :topics" do
       name = unique_name()

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -217,7 +217,8 @@ defmodule KlassHero.Shared.ProjectionTest do
     end
 
     test "succeeds on first attempt without retry without crashing" do
-      {:ok, _} = Agent.start_link(fn -> 0 end, name: InstantSuccessAgent)
+      {:ok, instant_pid} = Agent.start_link(fn -> 0 end, name: InstantSuccessAgent)
+      on_exit(fn -> if Process.alive?(instant_pid), do: Agent.stop(instant_pid) end)
       {:ok, pid} = InstantSuccessProjection.start_link(name: unique_name())
 
       # Drain handle_continue. With the bug present, the GenServer crashes here

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -5,6 +5,8 @@ defmodule KlassHero.Shared.ProjectionTest do
   # exercised against a synthetic module backed by an Agent, not a real schema.
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
   alias KlassHero.Shared.Projection
+  alias KlassHero.Shared.ProjectionTest.AlwaysFailAgent
+  alias KlassHero.Shared.ProjectionTest.FlakyAgent
 
   @agent_name __MODULE__.Agent
 
@@ -124,6 +126,102 @@ defmodule KlassHero.Shared.ProjectionTest do
 
       assert log =~ "received unexpected message"
       assert Process.alive?(pid)
+    end
+  end
+
+  defmodule FlakyProjection do
+    use Projection, topics: ["test:flaky:event"]
+
+    use KlassHero.Shared.Projection.WithBootstrapRetry,
+      max_attempts: 2,
+      base_delay_ms: 10
+
+    @impl Projection
+    def bootstrap_impl do
+      attempts =
+        Agent.get_and_update(
+          FlakyAgent,
+          fn n -> {n + 1, n + 1} end
+        )
+
+      if attempts == 1 do
+        raise "first attempt fails"
+      else
+        attempts
+      end
+    end
+
+    @impl Projection
+    def handle_event(_, _), do: :ok
+  end
+
+  defmodule AlwaysFailingProjection do
+    use Projection, topics: ["test:always_fails:event"]
+
+    use KlassHero.Shared.Projection.WithBootstrapRetry,
+      max_attempts: 2,
+      base_delay_ms: 5
+
+    @impl Projection
+    def bootstrap_impl do
+      Agent.update(AlwaysFailAgent, fn n -> n + 1 end)
+      raise "always fails"
+    end
+
+    @impl Projection
+    def handle_event(_, _), do: :ok
+  end
+
+  describe "WithBootstrapRetry mixin" do
+    setup do
+      {:ok, flaky_pid} =
+        Agent.start_link(fn -> 0 end, name: FlakyAgent)
+
+      on_exit(fn -> if Process.alive?(flaky_pid), do: Agent.stop(flaky_pid) end)
+      :ok
+    end
+
+    test "retries after a transient bootstrap failure and eventually succeeds" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          {:ok, pid} = FlakyProjection.start_link(name: unique_name())
+
+          # First attempt rescues; retry scheduled at base_delay * attempt = 10ms.
+          Process.sleep(50)
+          :sys.get_state(pid)
+
+          assert %{bootstrapped: true} = :sys.get_state(pid)
+        end)
+
+      assert log =~ "bootstrap failed, scheduling retry"
+      assert Agent.get(FlakyAgent, & &1) == 2
+    end
+
+    test "reraises after max_attempts consecutive failures" do
+      import ExUnit.CaptureLog
+
+      {:ok, always_fail_pid} =
+        Agent.start_link(fn -> 0 end, name: AlwaysFailAgent)
+
+      on_exit(fn ->
+        if Process.alive?(always_fail_pid), do: Agent.stop(always_fail_pid)
+      end)
+
+      Process.flag(:trap_exit, true)
+
+      capture_log(fn ->
+        {:ok, pid} = AlwaysFailingProjection.start_link(name: unique_name())
+
+        # First attempt fails inside handle_continue. Retry mixin reschedules
+        # at base_delay_ms * 1 = 5ms; second attempt fails and reschedules at 10ms;
+        # third attempt fails — reraises and crashes the GenServer.
+        assert_receive {:EXIT, ^pid, _reason}, 200
+      end)
+
+      # 3 attempts total: initial + 2 retries.
+      assert Agent.get(AlwaysFailAgent, & &1) == 3
     end
   end
 end

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -1,0 +1,29 @@
+defmodule KlassHero.Shared.ProjectionTest do
+  use ExUnit.Case, async: true
+
+  # TestProjection lives inside this file deliberately: the macro must be
+  # exercised against a synthetic module backed by an Agent, not a real schema.
+  alias KlassHero.Shared.Projection
+
+  defmodule TestProjection do
+    use Projection, topics: ["test:projection:event_a"]
+
+    @impl Projection
+    def bootstrap_impl, do: 0
+
+    @impl Projection
+    def handle_event(_type, _event), do: :ok
+  end
+
+  describe "start_link/1 with skip_bootstrap: true" do
+    test "starts a GenServer that does not subscribe and does not bootstrap" do
+      {:ok, pid} =
+        TestProjection.start_link(name: unique_name(), skip_bootstrap: true)
+
+      assert Process.alive?(pid)
+      assert %{bootstrapped: false} = :sys.get_state(pid)
+    end
+  end
+
+  defp unique_name, do: :"test_proj_#{System.unique_integer([:positive])}"
+end

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -3,6 +3,7 @@ defmodule KlassHero.Shared.ProjectionTest do
 
   # TestProjection lives inside this file deliberately: the macro must be
   # exercised against a synthetic module backed by an Agent, not a real schema.
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
   alias KlassHero.Shared.Projection
 
   @agent_name __MODULE__.Agent
@@ -53,6 +54,33 @@ defmodule KlassHero.Shared.ProjectionTest do
 
       assert %{bootstrapped: true} = :sys.get_state(pid)
       assert agent_state().bootstraps == 1
+    end
+  end
+
+  describe "init/1 with default opts" do
+    test "subscribes to every topic in :topics" do
+      name = unique_name()
+      {:ok, pid} = TestProjection.start_link(name: name)
+      :sys.get_state(pid)
+
+      # If subscription works, broadcasting to the topic delivers to the GenServer mailbox.
+      event = %IntegrationEvent{
+        event_id: Ecto.UUID.generate(),
+        event_type: :event_a,
+        source_context: :test,
+        entity_type: :thing,
+        entity_id: "id-1",
+        occurred_at: DateTime.utc_now(),
+        payload: %{},
+        metadata: %{},
+        version: 1
+      }
+
+      Phoenix.PubSub.broadcast(KlassHero.PubSub, "test:projection:event_a", {:integration_event, event})
+      :sys.get_state(pid)
+
+      # If the event was received, handle_event was called and recorded it.
+      assert [{:event_a, ^event}] = agent_state().events
     end
   end
 end

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -96,4 +96,34 @@ defmodule KlassHero.Shared.ProjectionTest do
       assert [{:event_a, ^event}] = agent_state().events
     end
   end
+
+  describe ":retry_bootstrap message" do
+    test "re-enters handle_continue(:bootstrap, _)" do
+      {:ok, pid} = TestProjection.start_link(name: unique_name())
+      :sys.get_state(pid)
+      assert agent_state().bootstraps == 1
+
+      send(pid, :retry_bootstrap)
+      :sys.get_state(pid)
+
+      assert agent_state().bootstraps == 2
+    end
+  end
+
+  describe "catch-all handle_info/2" do
+    import ExUnit.CaptureLog
+
+    test "logs a warning and continues" do
+      {:ok, pid} = TestProjection.start_link(name: unique_name(), skip_bootstrap: true)
+
+      log =
+        capture_log(fn ->
+          send(pid, {:wat, "unexpected"})
+          :sys.get_state(pid)
+        end)
+
+      assert log =~ "received unexpected message"
+      assert Process.alive?(pid)
+    end
+  end
 end

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -9,11 +9,28 @@ defmodule KlassHero.Shared.ProjectionTest do
     use Projection, topics: ["test:projection:event_a"]
 
     @impl Projection
-    def bootstrap_impl, do: 0
+    def bootstrap_impl do
+      Agent.update(:projection_test_agent, fn s -> %{s | bootstraps: s.bootstraps + 1} end)
+      42
+    end
 
     @impl Projection
-    def handle_event(_type, _event), do: :ok
+    def handle_event(type, event) do
+      Agent.update(:projection_test_agent, fn s -> %{s | events: [{type, event} | s.events]} end)
+    end
   end
+
+  setup do
+    {:ok, agent_pid} =
+      Agent.start_link(fn -> %{bootstraps: 0, events: []} end, name: :projection_test_agent)
+
+    on_exit(fn -> if Process.alive?(agent_pid), do: Agent.stop(agent_pid) end)
+    :ok
+  end
+
+  defp agent_state, do: Agent.get(:projection_test_agent, & &1)
+
+  defp unique_name, do: :"test_proj_#{System.unique_integer([:positive])}"
 
   describe "start_link/1 with skip_bootstrap: true" do
     test "starts a GenServer that does not subscribe and does not bootstrap" do
@@ -25,5 +42,13 @@ defmodule KlassHero.Shared.ProjectionTest do
     end
   end
 
-  defp unique_name, do: :"test_proj_#{System.unique_integer([:positive])}"
+  describe "handle_continue(:bootstrap, ...)" do
+    test "invokes bootstrap_impl/0 and marks state bootstrapped" do
+      {:ok, pid} = TestProjection.start_link(name: unique_name())
+      :sys.get_state(pid)
+
+      assert %{bootstrapped: true} = :sys.get_state(pid)
+      assert agent_state().bootstraps == 1
+    end
+  end
 end

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHero.Shared.ProjectionTest do
   alias KlassHero.Shared.Projection
   alias KlassHero.Shared.ProjectionTest.AlwaysFailAgent
   alias KlassHero.Shared.ProjectionTest.FlakyAgent
+  alias KlassHero.Shared.ProjectionTest.InstantSuccessAgent
 
   @agent_name __MODULE__.Agent
 
@@ -155,6 +156,23 @@ defmodule KlassHero.Shared.ProjectionTest do
     def handle_event(_, _), do: :ok
   end
 
+  defmodule InstantSuccessProjection do
+    use Projection, topics: ["test:instant_success:event"]
+
+    use KlassHero.Shared.Projection.WithBootstrapRetry,
+      max_attempts: 3,
+      base_delay_ms: 100
+
+    @impl Projection
+    def bootstrap_impl do
+      Agent.update(InstantSuccessAgent, fn n -> n + 1 end)
+      7
+    end
+
+    @impl Projection
+    def handle_event(_, _), do: :ok
+  end
+
   defmodule AlwaysFailingProjection do
     use Projection, topics: ["test:always_fails:event"]
 
@@ -188,15 +206,27 @@ defmodule KlassHero.Shared.ProjectionTest do
         capture_log(fn ->
           {:ok, pid} = FlakyProjection.start_link(name: unique_name())
 
+          # No synchronous signal for async handle_continue completion via :retry_bootstrap.
           # First attempt rescues; retry scheduled at base_delay * attempt = 10ms.
-          Process.sleep(50)
-          :sys.get_state(pid)
-
+          Process.sleep(100)
           assert %{bootstrapped: true} = :sys.get_state(pid)
         end)
 
       assert log =~ "bootstrap failed, scheduling retry"
       assert Agent.get(FlakyAgent, & &1) == 2
+    end
+
+    test "succeeds on first attempt without retry without crashing" do
+      {:ok, _} = Agent.start_link(fn -> 0 end, name: InstantSuccessAgent)
+      {:ok, pid} = InstantSuccessProjection.start_link(name: unique_name())
+
+      # Drain handle_continue. With the bug present, the GenServer crashes here
+      # with KeyError because state lacks :retry_count and the success path
+      # used %{state | retry_count: 0}.
+      :sys.get_state(pid)
+
+      assert %{bootstrapped: true, retry_count: 0} = :sys.get_state(pid)
+      assert Agent.get(InstantSuccessAgent, & &1) == 1
     end
 
     test "reraises after max_attempts consecutive failures" do

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -3,9 +3,12 @@ defmodule KlassHero.Shared.ProjectionTest do
 
   # TestProjection lives inside this file deliberately: the macro must be
   # exercised against a synthetic module backed by an Agent, not a real schema.
+  alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
   alias KlassHero.Shared.Projection
+  alias KlassHero.Shared.Projection.WithDomainEvents
   alias KlassHero.Shared.ProjectionTest.AlwaysFailAgent
+  alias KlassHero.Shared.ProjectionTest.DomainEventAgent
   alias KlassHero.Shared.ProjectionTest.FlakyAgent
   alias KlassHero.Shared.ProjectionTest.InstantSuccessAgent
 
@@ -188,6 +191,72 @@ defmodule KlassHero.Shared.ProjectionTest do
 
     @impl Projection
     def handle_event(_, _), do: :ok
+  end
+
+  defmodule DomainEventProjection do
+    use Projection, topics: ["test:domain_events:event"]
+    use WithDomainEvents
+
+    @impl Projection
+    def bootstrap_impl, do: 0
+
+    @impl Projection
+    def handle_event(_type, _event), do: :ok
+
+    @impl WithDomainEvents
+    def handle_domain_event(type, event) do
+      Agent.update(DomainEventAgent, fn s ->
+        %{s | events: [{type, event} | s.events]}
+      end)
+    end
+  end
+
+  describe "WithDomainEvents mixin" do
+    setup do
+      {:ok, _} =
+        Agent.start_link(
+          fn -> %{events: []} end,
+          name: DomainEventAgent
+        )
+
+      :ok
+    end
+
+    test "dispatches {:domain_event, %DomainEvent{}} envelopes to handle_domain_event/2" do
+      {:ok, pid} = DomainEventProjection.start_link(name: unique_name(), skip_bootstrap: true)
+
+      event = %DomainEvent{
+        event_id: Ecto.UUID.generate(),
+        event_type: :something_happened,
+        aggregate_type: :thing,
+        aggregate_id: "agg-1",
+        occurred_at: DateTime.utc_now(),
+        payload: %{detail: 1}
+      }
+
+      send(pid, {:domain_event, event})
+      :sys.get_state(pid)
+
+      state = Agent.get(DomainEventAgent, & &1)
+      assert [{:something_happened, ^event}] = state.events
+    end
+  end
+
+  describe "catch-all handle_info/2 with mixin loaded" do
+    import ExUnit.CaptureLog
+
+    test "still logs warning for messages not matched by any specific clause" do
+      {:ok, pid} = DomainEventProjection.start_link(name: unique_name(), skip_bootstrap: true)
+
+      log =
+        capture_log(fn ->
+          send(pid, {:weird_envelope, "definitely not matched"})
+          :sys.get_state(pid)
+        end)
+
+      assert log =~ "received unexpected message"
+      assert Process.alive?(pid)
+    end
   end
 
   describe "WithBootstrapRetry mixin" do

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -5,30 +5,34 @@ defmodule KlassHero.Shared.ProjectionTest do
   # exercised against a synthetic module backed by an Agent, not a real schema.
   alias KlassHero.Shared.Projection
 
+  @agent_name __MODULE__.Agent
+
   defmodule TestProjection do
     use Projection, topics: ["test:projection:event_a"]
 
+    @agent_name KlassHero.Shared.ProjectionTest.Agent
+
     @impl Projection
     def bootstrap_impl do
-      Agent.update(:projection_test_agent, fn s -> %{s | bootstraps: s.bootstraps + 1} end)
+      Agent.update(@agent_name, fn s -> %{s | bootstraps: s.bootstraps + 1} end)
       42
     end
 
     @impl Projection
     def handle_event(type, event) do
-      Agent.update(:projection_test_agent, fn s -> %{s | events: [{type, event} | s.events]} end)
+      Agent.update(@agent_name, fn s -> %{s | events: [{type, event} | s.events]} end)
     end
   end
 
   setup do
     {:ok, agent_pid} =
-      Agent.start_link(fn -> %{bootstraps: 0, events: []} end, name: :projection_test_agent)
+      Agent.start_link(fn -> %{bootstraps: 0, events: []} end, name: @agent_name)
 
     on_exit(fn -> if Process.alive?(agent_pid), do: Agent.stop(agent_pid) end)
     :ok
   end
 
-  defp agent_state, do: Agent.get(:projection_test_agent, & &1)
+  defp agent_state, do: Agent.get(@agent_name, & &1)
 
   defp unique_name, do: :"test_proj_#{System.unique_integer([:positive])}"
 


### PR DESCRIPTION
Closes #735 

## Summary

- Added `KlassHero.Shared.Projection` base macro + `WithBootstrapRetry` (linear backoff) + `WithDomainEvents` (DomainEvent dispatcher) mixins (`lib/klass_hero/shared/projection.ex` + 2 sub-files, 227 LOC). Macro absorbs the GenServer skeleton, PubSub subscribe, `handle_continue(:bootstrap)`, `handle_call(:rebuild)`, integration-event dispatcher, `:retry_bootstrap` handler, and catch-all warner.
- Migrated all 7 event-driven projections to the macro: `ProviderPrograms`, `ProgramListings`, `ProviderSessionStats`, `ProviderSessionDetails`, `EnrolledChildren`, `VerifiedProviders`, `ConversationSummaries`. Existing per-projection test files pass unchanged - that is the behavioural-parity contract.
- Each migration's test file got one silent-failure regression test (`state.retry_count == 0` after happy-path startup) that fails loudly if the retry mixin's `rescue` ever swallows a programming error - a stealth bug class that was discovered and fixed during macro development (see commit 34a6f935).
- Macro-internal evolution: refactored the catch-all `handle_info/2` clause to inject via `@before_compile` so mixins can land their own `handle_info` clauses ahead of it; added `handle_call: 3` to the base macro's `defoverridable` list so `VerifiedProviders` (in-memory variant) can override `:rebuild` to also refresh its MapSet.
- Standardised projection tests on `async: false` for sandbox-mode safety (DB-coupled bootstrap races `Sandbox.allow/3` under async); convention codified in `.claude/rules/testing.md`.
- Net delta: 21 files, +1199/-1243 (~-44 LOC), but the real shape change is that ~600 LOC of duplicated OTP plumbing now lives in 227 LOC of shared macro/mixins.

## Review Focus

- **Macro design and composition seam** - the base macro's `@callback bootstrap_impl/0` + `handle_event/2` contract, the `defoverridable apply_bootstrap: 1` slot that `WithBootstrapRetry` overrides, and the `@before_compile` catch-all injection are the load-bearing pieces (`lib/klass_hero/shared/projection.ex:40-51,118`). Mixin order at the call site matters: `use Projection` -> `use WithBootstrapRetry` -> `use WithDomainEvents`.
- **Silent-failure regression net** - the original mixin bug at `with_bootstrap_retry.ex:26-29` was `%{state | retry_count: 0}` raising `KeyError` on first-attempt success, swallowed by the rescue and reported as `retry_count: 1` - the projection looked fine but every "successful" bootstrap was actually a recovered crash. Fixed via `Map.merge` (line 29). Every migrated projection now has a per-projection regression test that asserts `state.retry_count == 0` after real bootstrap + first event (e.g. `test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs:429-452`).
- **VerifiedProviders special-case** - only in-memory MapSet projection. Opts out of `WithBootstrapRetry` (current behaviour preserved: crash on bootstrap failure -> supervisor restart). Overrides `apply_bootstrap/1` privately to thread `verified_ids: MapSet` into state (`lib/klass_hero/program_catalog/adapters/driven/projections/verified_providers.ex:100-108`). Overrides the macro's `handle_call(:rebuild, ...)` to also reload the MapSet (lines 89-93). Event handlers use `GenServer.cast(self(), ...)` indirection because `handle_event/2`'s `:any()` return doesn't surface state mutations.
- **ProviderSessionDetails retry timing change (behaviour)** - pre-migration retried indefinitely with fixed 1s delay; post-migration uses macro default (3x linear 5s backoff). Bounded retries surface persistent infrastructure issues to the supervisor sooner; existing tests pass because they only exercise the `rebuild/1` path. Worth a sanity check on transient-DB-failure scenarios in production.
- **Projection tests are now `async: false`** - projection GenServers run DB queries during `init/1`'s `{:continue, :bootstrap}` before the test process can `Sandbox.allow` the spawned pid. Shared sandbox (DataCase default when not async) covers the GenServer automatically, so the boilerplate `Sandbox.allow` calls are gone. Convention captured in `.claude/rules/testing.md:53-58`.

## Test Plan

- [x] `mix precommit` - 4858 tests pass (4857 tests + 1 property), 0 failures, clean compile + format
- [x] Test-drive backend (Tidewave) - all 7 projection GenServers alive, state shapes correct, integration + domain event dispatch verified end-to-end (report: `.test-drive-reports/test-drive-2026-05-17.md`)
- [x] Test-drive UI (Playwright) - `/programs` renders 17 program cards, provider dashboard renders Active Programs/Enrolled Kids stats + top programs list + verified badge, `/provider/messages` renders the conversation inbox, mobile layout intact at 375x667
- [x] Architecture review - 17/18 checks pass; 1 pre-existing warning about cross-context schema access in `ProviderPrograms` (not introduced by this PR; pattern documented under issue #685)
- [ ] Manual verify provider dashboard, parent inbox, and `/programs` after deploy to a non-dev environment - fresh boot, not hot-reload (note: Phoenix dev mode hot-swap preserves GenServer state across module shape changes, so dev instances may need projection restarts post-deploy)
- [ ] Spot-check production logs for `received unexpected message` warnings post-deploy (catch-all warner is the canary for any envelope shape the dispatcher doesn't recognise)
- [ ] Optional follow-up: file issue to migrate `ProviderPrograms.bootstrap_from_write_table/0` to raw-string queries matching the `EnrolledChildren` precedent (removes the pre-existing cross-context `ProgramSchema` alias; link to #685)