### PR TITLE
fix: let providers approve pending enrollments (#859)

### DIFF
--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -144,7 +144,8 @@ defmodule KlassHero.Application do
             priority: 10},
            {:enrollment_created,
             {KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
-            priority: 10}
+            priority: 10},
+           {:enrollment_confirmed, {NotifyLiveViews, :handle}}
          ]},
         id: :enrollment_domain_event_bus
       ),

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -80,6 +80,7 @@ defmodule KlassHero.Enrollment do
     GetParticipantPolicy,
     ListEnrolledIdentityIds,
     ListParentEnrollments,
+    ListPendingEnrollmentsForProvider,
     ListProgramEnrollments,
     ListProgramInvites
   }
@@ -297,6 +298,16 @@ defmodule KlassHero.Enrollment do
   """
   def list_program_enrollments(program_id) when is_binary(program_id) do
     ListProgramEnrollments.execute(program_id)
+  end
+
+  @doc """
+  Lists enriched pending enrollment entries across the given program IDs.
+
+  Used by the provider dashboard's "Pending enrollments" inbox card to
+  surface enrollments awaiting provider approval.
+  """
+  def list_pending_enrollments_for_provider(program_ids) when is_list(program_ids) do
+    ListPendingEnrollmentsForProvider.execute(program_ids)
   end
 
   @doc """

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -58,6 +58,7 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.Application.Commands.{
     CancelEnrollmentByAdmin,
     ClaimInvite,
+    ConfirmEnrollment,
     CreateEnrollment,
     DeleteInvite,
     ImportEnrollmentCsv,
@@ -138,6 +139,26 @@ defmodule KlassHero.Enrollment do
   def cancel_enrollment_by_admin(enrollment_id, admin_id, reason)
       when is_binary(enrollment_id) and is_binary(admin_id) and is_binary(reason) and byte_size(reason) > 0 do
     CancelEnrollmentByAdmin.execute(enrollment_id, admin_id, reason)
+  end
+
+  @doc """
+  Confirms a pending enrollment when the owning provider approves it.
+
+  ## Parameters
+
+  - `:enrollment_id` — UUID of the enrollment
+  - `:provider_id` — UUID of the provider performing the approval
+
+  ## Returns
+
+  - `{:ok, Enrollment.t()}` — confirmation succeeded
+  - `{:error, :not_found}` — enrollment does not exist
+  - `{:error, :unauthorized}` — provider does not own the program
+  - `{:error, :invalid_status_transition}` — enrollment is not pending
+  """
+  def confirm_enrollment(%{enrollment_id: enrollment_id, provider_id: provider_id} = params)
+      when is_binary(enrollment_id) and is_binary(provider_id) do
+    ConfirmEnrollment.execute(params)
   end
 
   @doc """

--- a/lib/klass_hero/enrollment/adapters/driven/acl/program_catalog_acl.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/acl/program_catalog_acl.ex
@@ -46,4 +46,32 @@ defmodule KlassHero.Enrollment.Adapters.Driven.ACL.ProgramCatalogACL do
       end
     end
   end
+
+  @impl true
+  def program_owned_by?(program_id, provider_id) when is_binary(program_id) and is_binary(provider_id) do
+    span do
+      set_attributes("acl",
+        source: "enrollment",
+        target: "program_catalog",
+        operation: "program_owned_by?"
+      )
+
+      with {:ok, _} <- Ecto.UUID.cast(program_id),
+           {:ok, _} <- Ecto.UUID.cast(provider_id) do
+        from(p in "programs",
+          where:
+            p.id == type(^program_id, :binary_id) and
+              p.provider_id == type(^provider_id, :binary_id),
+          select: 1
+        )
+        |> Repo.one()
+        |> case do
+          nil -> false
+          1 -> true
+        end
+      else
+        :error -> false
+      end
+    end
+  end
 end

--- a/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository.ex
@@ -246,7 +246,6 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.Enrollme
     end
   end
 
-  @impl true
   def list_pending_by_programs([]), do: []
 
   @impl true
@@ -254,7 +253,7 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.Enrollme
     EnrollmentSchema
     |> where([e], e.status == :pending and e.program_id in ^program_ids)
     |> Repo.all()
-    |> Enum.map(&EnrollmentMapper.to_domain/1)
+    |> MapperHelpers.to_domain_list(EnrollmentMapper)
   end
 
   @impl true

--- a/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository.ex
@@ -246,14 +246,18 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.Enrollme
     end
   end
 
+  @impl true
   def list_pending_by_programs([]), do: []
 
-  @impl true
   def list_pending_by_programs(program_ids) when is_list(program_ids) do
-    EnrollmentSchema
-    |> where([e], e.status == :pending and e.program_id in ^program_ids)
-    |> Repo.all()
-    |> MapperHelpers.to_domain_list(EnrollmentMapper)
+    span do
+      set_attributes("db", operation: "select", entity: "enrollment")
+
+      EnrollmentSchema
+      |> where([e], e.status == :pending and e.program_id in ^program_ids)
+      |> Repo.all()
+      |> MapperHelpers.to_domain_list(EnrollmentMapper)
+    end
   end
 
   @impl true

--- a/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository.ex
@@ -247,6 +247,17 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.Enrollme
   end
 
   @impl true
+  def list_pending_by_programs([]), do: []
+
+  @impl true
+  def list_pending_by_programs(program_ids) when is_list(program_ids) do
+    EnrollmentSchema
+    |> where([e], e.status == :pending and e.program_id in ^program_ids)
+    |> Repo.all()
+    |> Enum.map(&EnrollmentMapper.to_domain/1)
+  end
+
+  @impl true
   @doc """
   Lists active enrollments for a program from the database.
 

--- a/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
+++ b/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
@@ -52,7 +52,8 @@ defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollment do
           | {:error, :not_found | :unauthorized | :invalid_status_transition | term()}
   def execute(%{enrollment_id: enrollment_id, provider_id: provider_id})
       when is_binary(enrollment_id) and is_binary(provider_id) do
-    with {:ok, enrollment} <- @enrollment_reader.get_by_id(enrollment_id),
+    with {:ok, enrollment_id} <- cast_uuid_or_not_found(enrollment_id),
+         {:ok, enrollment} <- @enrollment_reader.get_by_id(enrollment_id),
          :ok <- authorize(enrollment, provider_id),
          {:ok, confirmed} <- Enrollment.confirm(enrollment),
          {:ok, persisted} <- @enrollment_repo.update(enrollment_id, to_update_attrs(confirmed)),
@@ -63,6 +64,18 @@ defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollment do
       )
 
       {:ok, persisted}
+    end
+  end
+
+  # `enrollment_id` arrives from the LiveView `phx-value-id` (DOM-tamperable). Without this
+  # guard, `Repo.get/2` raises `Ecto.Query.CastError` on malformed input. `provider_id` is
+  # server-trusted (read from `current_scope`), so only the enrollment id needs guarding;
+  # any invalid `provider_id` is already handled by `ProgramCatalogACL.program_owned_by?/2`
+  # returning false, which translates to `{:error, :unauthorized}`.
+  defp cast_uuid_or_not_found(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, _} -> {:ok, id}
+      :error -> {:error, :not_found}
     end
   end
 

--- a/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
+++ b/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
@@ -1,0 +1,96 @@
+defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollment do
+  @moduledoc """
+  Confirms a pending enrollment when approved by the owning provider.
+
+  Pipeline:
+    1. Fetch the enrollment.
+    2. Verify the provider owns the program (ProgramCatalog ACL).
+    3. Apply the domain `pending → confirmed` transition.
+    4. Persist the new status + confirmed_at timestamp.
+    5. Dispatch an `:enrollment_confirmed` domain event.
+  """
+
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Enrollment.Domain.Models.Enrollment
+  alias KlassHero.Shared.EventDispatchHelper
+
+  require Logger
+
+  @context KlassHero.Enrollment
+
+  @enrollment_reader Application.compile_env!(:klass_hero, [
+                       :enrollment,
+                       :for_querying_enrollments
+                     ])
+  @enrollment_repo Application.compile_env!(:klass_hero, [
+                     :enrollment,
+                     :for_managing_enrollments
+                   ])
+  @program_catalog Application.compile_env!(:klass_hero, [
+                     :enrollment,
+                     :for_resolving_program_catalog
+                   ])
+
+  @doc """
+  Confirms a pending enrollment.
+
+  ## Parameters
+
+  - `:enrollment_id` — UUID of the enrollment
+  - `:provider_id` — UUID of the provider attempting to approve
+
+  ## Returns
+
+  - `{:ok, Enrollment.t()}` — confirmation succeeded
+  - `{:error, :not_found}` — enrollment does not exist
+  - `{:error, :unauthorized}` — provider does not own the program
+  - `{:error, :invalid_status_transition}` — enrollment is not pending
+  - `{:error, term()}` — persistence failure
+  """
+  @spec execute(%{enrollment_id: String.t(), provider_id: String.t()}) ::
+          {:ok, Enrollment.t()}
+          | {:error, :not_found | :unauthorized | :invalid_status_transition | term()}
+  def execute(%{enrollment_id: enrollment_id, provider_id: provider_id})
+      when is_binary(enrollment_id) and is_binary(provider_id) do
+    with {:ok, enrollment} <- @enrollment_reader.get_by_id(enrollment_id),
+         :ok <- authorize(enrollment, provider_id),
+         {:ok, confirmed} <- Enrollment.confirm(enrollment),
+         {:ok, persisted} <- @enrollment_repo.update(enrollment_id, to_update_attrs(confirmed)),
+         {:ok, persisted} <- dispatch_event(persisted, provider_id) do
+      Logger.info("[Enrollment.ConfirmEnrollment] Enrollment confirmed",
+        enrollment_id: enrollment_id,
+        provider_id: provider_id
+      )
+
+      {:ok, persisted}
+    end
+  end
+
+  defp authorize(%Enrollment{program_id: program_id}, provider_id) do
+    if @program_catalog.program_owned_by?(program_id, provider_id) do
+      :ok
+    else
+      {:error, :unauthorized}
+    end
+  end
+
+  defp to_update_attrs(%Enrollment{} = enrollment) do
+    %{status: enrollment.status, confirmed_at: enrollment.confirmed_at}
+  end
+
+  defp dispatch_event(%Enrollment{} = persisted, _provider_id) do
+    persisted.id
+    |> EnrollmentEvents.enrollment_confirmed(%{
+      enrollment_id: persisted.id,
+      program_id: persisted.program_id,
+      child_id: persisted.child_id,
+      parent_id: persisted.parent_id,
+      confirmed_at: persisted.confirmed_at
+    })
+    |> EventDispatchHelper.dispatch_or_error(@context)
+    |> case do
+      :ok -> {:ok, persisted}
+      {:error, _} = err -> err
+    end
+  end
+end

--- a/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
+++ b/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
@@ -78,17 +78,31 @@ defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollment do
     %{status: enrollment.status, confirmed_at: enrollment.confirmed_at}
   end
 
-  defp dispatch_event(%Enrollment{} = persisted, _provider_id) do
-    persisted.id
-    |> EnrollmentEvents.enrollment_confirmed(%{
-      enrollment_id: persisted.id,
-      program_id: persisted.program_id,
-      child_id: persisted.child_id,
-      parent_id: persisted.parent_id,
-      confirmed_at: persisted.confirmed_at
-    })
-    |> EventDispatchHelper.dispatch_or_error(@context)
-    |> case do
+  defp dispatch_event(%Enrollment{} = persisted, provider_id) do
+    # Publish the canonical enrollment:enrollment_confirmed domain event to PubSub.
+    # The generic NotifyLiveViews handler derives the topic as "enrollment:enrollment_confirmed",
+    # which is not provider-scoped. We also broadcast a provider-scoped notification so that
+    # the provider DashboardLive can subscribe to their own topic and refresh the pending list
+    # without receiving events from other providers.
+    dispatch_result =
+      persisted.id
+      |> EnrollmentEvents.enrollment_confirmed(%{
+        enrollment_id: persisted.id,
+        program_id: persisted.program_id,
+        child_id: persisted.child_id,
+        parent_id: persisted.parent_id,
+        confirmed_at: persisted.confirmed_at
+      })
+      |> EventDispatchHelper.dispatch_or_error(@context)
+
+    # Supplementary provider-scoped broadcast — best-effort (mirrors PubSub best-effort policy).
+    Phoenix.PubSub.broadcast(
+      KlassHero.PubSub,
+      "enrollment:provider:#{provider_id}:pending_changed",
+      :enrollment_pending_changed
+    )
+
+    case dispatch_result do
       :ok -> {:ok, persisted}
       {:error, _} = err -> err
     end

--- a/lib/klass_hero/enrollment/application/queries/list_pending_enrollments_for_provider.ex
+++ b/lib/klass_hero/enrollment/application/queries/list_pending_enrollments_for_provider.ex
@@ -1,0 +1,100 @@
+defmodule KlassHero.Enrollment.Application.Queries.ListPendingEnrollmentsForProvider do
+  @moduledoc """
+  Lists enriched pending enrollment entries for a provider's programs.
+
+  Single repo round-trip filters by `status: :pending` and any of the given
+  program IDs. Enrichment resolves child names (Family ACL), parent IDs, and
+  program titles (ProgramCatalog ACL) for display. Missing metadata falls back
+  to "Unknown" so a stale ACL row never breaks the dashboard.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  @enrollment_reader Application.compile_env!(:klass_hero, [
+                       :enrollment,
+                       :for_querying_enrollments
+                     ])
+  @child_info_adapter Application.compile_env!(:klass_hero, [
+                        :enrollment,
+                        :for_resolving_child_info
+                      ])
+
+  @type entry :: %{
+          enrollment_id: String.t(),
+          program_id: String.t(),
+          program_title: String.t(),
+          child_id: String.t(),
+          child_name: String.t(),
+          parent_id: String.t(),
+          enrolled_at: DateTime.t()
+        }
+
+  @spec execute([binary()]) :: [entry()]
+  def execute([]), do: []
+
+  def execute(program_ids) when is_list(program_ids) do
+    Logger.info("[Enrollment.ListPendingEnrollmentsForProvider] Listing",
+      program_count: length(program_ids)
+    )
+
+    case @enrollment_reader.list_pending_by_programs(program_ids) do
+      [] ->
+        []
+
+      enrollments ->
+        child_ids = enrollments |> Enum.map(& &1.child_id) |> Enum.uniq()
+        children = @child_info_adapter.get_children_by_ids(child_ids)
+        child_map = Map.new(children, fn c -> {c.id, c} end)
+
+        program_map = program_titles_map(program_ids)
+
+        Enum.map(enrollments, &build_entry(&1, child_map, program_map))
+    end
+  end
+
+  defp program_titles_map(program_ids) do
+    # Trigger: ProgramCatalog depends on Enrollment (for capacity ACL), so calling
+    #          back into ProgramCatalog would create a dependency cycle.
+    # Why: query the `programs` table directly — acceptable in the query layer,
+    #      mirrors the approach in ProgramCatalogACL.
+    # Outcome: returns a map of %{program_id_string => title}
+    valid_ids =
+      program_ids
+      |> Enum.filter(fn id -> match?({:ok, _}, Ecto.UUID.cast(id)) end)
+
+    case valid_ids do
+      [] ->
+        %{}
+
+      ids ->
+        from(p in "programs",
+          where: p.id in ^Enum.map(ids, &Ecto.UUID.dump!/1),
+          select: {type(p.id, :binary_id), p.title}
+        )
+        |> KlassHero.Repo.all()
+        |> Map.new()
+    end
+  end
+
+  defp build_entry(enrollment, child_map, program_map) do
+    child_name =
+      case Map.get(child_map, enrollment.child_id) do
+        nil -> "Unknown"
+        child -> "#{child.first_name} #{child.last_name}"
+      end
+
+    program_title = Map.get(program_map, enrollment.program_id, "Unknown")
+
+    %{
+      enrollment_id: enrollment.id,
+      program_id: enrollment.program_id,
+      program_title: program_title,
+      child_id: enrollment.child_id,
+      child_name: child_name,
+      parent_id: enrollment.parent_id,
+      enrolled_at: enrollment.enrolled_at
+    }
+  end
+end

--- a/lib/klass_hero/enrollment/domain/events/enrollment_events.ex
+++ b/lib/klass_hero/enrollment/domain/events/enrollment_events.ex
@@ -20,6 +20,7 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEvents do
     an enrollment invite email.
   - `:enrollment_cancelled` - Emitted when an admin cancels an enrollment.
   - `:enrollment_created` - Emitted when a new enrollment is persisted.
+  - `:enrollment_confirmed` - Emitted when a provider approves a pending enrollment.
   """
 
   alias KlassHero.Shared.Domain.Events.DomainEvent
@@ -215,5 +216,34 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEvents do
   def enrollment_created(enrollment_id, _payload, _opts) do
     raise ArgumentError,
           "enrollment_created/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
+  end
+
+  @doc """
+  Creates an `:enrollment_confirmed` event when a provider approves a pending enrollment.
+
+  ## Parameters
+
+  - `enrollment_id` — the confirmed enrollment's ID
+  - `payload` — event data including `program_id`, `child_id`, `parent_id`, `confirmed_at`
+  - `opts` — forwarded to `DomainEvent.new/5` (e.g. `:correlation_id`)
+  """
+  def enrollment_confirmed(enrollment_id, payload \\ %{}, opts \\ [])
+
+  def enrollment_confirmed(enrollment_id, payload, opts)
+      when is_binary(enrollment_id) and byte_size(enrollment_id) > 0 do
+    base_payload = %{enrollment_id: enrollment_id}
+
+    DomainEvent.new(
+      :enrollment_confirmed,
+      enrollment_id,
+      @aggregate_type,
+      Map.merge(payload, base_payload),
+      opts
+    )
+  end
+
+  def enrollment_confirmed(enrollment_id, _payload, _opts) do
+    raise ArgumentError,
+          "enrollment_confirmed/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
   end
 end

--- a/lib/klass_hero/enrollment/domain/ports/for_querying_enrollments.ex
+++ b/lib/klass_hero/enrollment/domain/ports/for_querying_enrollments.ex
@@ -68,4 +68,12 @@ defmodule KlassHero.Enrollment.Domain.Ports.ForQueryingEnrollments do
   Returns list of Enrollment.t(), ordered by enrolled_at descending.
   """
   @callback list_by_program(program_id :: binary()) :: [Enrollment.t()]
+
+  @doc """
+  Returns all enrollments with status `:pending` that belong to any of the
+  given program IDs.
+
+  Empty list of program IDs short-circuits to an empty result.
+  """
+  @callback list_pending_by_programs(program_ids :: [binary()]) :: [Enrollment.t()]
 end

--- a/lib/klass_hero/enrollment/domain/ports/for_resolving_program_catalog.ex
+++ b/lib/klass_hero/enrollment/domain/ports/for_resolving_program_catalog.ex
@@ -14,4 +14,11 @@ defmodule KlassHero.Enrollment.Domain.Ports.ForResolvingProgramCatalog do
   Returns `%{"Program Title" => "program-uuid", ...}`.
   """
   @callback list_program_titles_for_provider(binary()) :: %{String.t() => binary()}
+
+  @doc """
+  Returns true if the given program is owned by the given provider.
+
+  Returns false for unknown programs and for programs owned by other providers.
+  """
+  @callback program_owned_by?(program_id :: binary(), provider_id :: binary()) :: boolean()
 end

--- a/lib/klass_hero_web/components/provider_layout_components.ex
+++ b/lib/klass_hero_web/components/provider_layout_components.ex
@@ -546,6 +546,39 @@ defmodule KlassHeroWeb.ProviderLayoutComponents do
     """
   end
 
+  @doc """
+  Pending enrollment card with an Approve button.
+
+  `entry` keys: `:enrollment_id, :child_name, :program_title, :enrolled_at`.
+  """
+  attr :entry, :map, required: true
+
+  def pv_pending_enrollment_card(assigns) do
+    ~H"""
+    <div
+      id={"pending-enrollment-#{@entry.enrollment_id}"}
+      class="flex items-center justify-between gap-3 rounded-xl border border-hero-grey-200 p-3"
+    >
+      <div class="min-w-0">
+        <div class="font-semibold truncate">{@entry.child_name}</div>
+        <div class="text-xs text-hero-grey-600 truncate">{@entry.program_title}</div>
+        <div class="text-xs text-hero-grey-500">
+          {gettext("Enrolled")} {Calendar.strftime(@entry.enrolled_at, "%b %d")}
+        </div>
+      </div>
+      <button
+        id={"approve-enrollment-#{@entry.enrollment_id}"}
+        type="button"
+        phx-click="approve_enrollment"
+        phx-value-id={@entry.enrollment_id}
+        class="rounded-lg bg-[var(--brand-primary)] px-3 py-1.5 text-sm font-bold text-white hover:opacity-90"
+      >
+        {gettext("Approve")}
+      </button>
+    </div>
+    """
+  end
+
   ## ---------------------------------------------------------------------------
   ## Internal helpers
   ## ---------------------------------------------------------------------------

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -1231,6 +1231,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
                 active_program_count={@programs_count}
                 enrolled_total={@enrolled_total}
                 pending_requests={@pending_requests}
+                pending_enrollments={@pending_enrollments}
                 top_programs={@top_programs}
               />
             <% :team -> %>
@@ -1468,6 +1469,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   attr :active_program_count, :integer, required: true
   attr :enrolled_total, :integer, required: true
   attr :pending_requests, :list, required: true
+  attr :pending_enrollments, :list, required: true
   attr :top_programs, :list, required: true
 
   defp overview_section(assigns) do
@@ -1512,8 +1514,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
         <.pv_earnings_chart data={[]} />
       </section>
 
-      <%!-- Top programs + pending requests side-by-side on desktop. --%>
-      <section class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <%!-- Top programs + pending invites + pending enrollments side-by-side on desktop. --%>
+      <section class="grid grid-cols-1 lg:grid-cols-3 gap-4">
         <.kh_card class="p-5">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg">{gettext("Your top programs")}</h3>
@@ -1544,6 +1546,24 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
           </div>
           <div class="space-y-3">
             <.pv_request_card :for={r <- @pending_requests} request={r} />
+          </div>
+        </.kh_card>
+
+        <.kh_card id="pending-enrollments-card" class="p-5">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg">{gettext("Pending enrollments")}</h3>
+            <span class="text-xs text-hero-grey-600 font-semibold">
+              {length(@pending_enrollments)} {gettext("pending")}
+            </span>
+          </div>
+          <div :if={@pending_enrollments == []} class="text-sm text-hero-grey-600">
+            {gettext("No pending enrollments right now.")}
+          </div>
+          <div class="space-y-3">
+            <.pv_pending_enrollment_card
+              :for={entry <- @pending_enrollments}
+              entry={entry}
+            />
           </div>
         </.kh_card>
       </section>

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -130,6 +130,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
           |> assign(total_sessions_completed: 0)
           |> assign(enrolled_total: 0)
           |> assign(pending_requests: [])
+          |> assign(pending_enrollments: [])
           |> assign(top_programs: [])
           |> allow_upload(:logo,
             accept: ~w(.jpg .jpeg .png .webp),
@@ -203,10 +204,21 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     enrolled_total = enrollment_counts |> Map.values() |> Enum.sum()
 
     pending_requests = load_pending_requests(program_ids)
+    pending_enrollments = Enrollment.list_pending_enrollments_for_provider(program_ids)
     top_programs = build_top_programs(program_listings, enrollment_counts)
 
     if connected?(socket) do
       Phoenix.PubSub.subscribe(KlassHero.PubSub, "provider:#{provider.id}:stats_updated")
+
+      # Subscribe to the provider-scoped pending-changed topic so the dashboard
+      # refreshes automatically when a pending enrollment is confirmed.
+      # The generic NotifyLiveViews topic ("enrollment:enrollment_confirmed") is
+      # not provider-scoped, so ConfirmEnrollment also broadcasts a supplementary
+      # message on this topic to enable targeted, per-provider subscriptions.
+      Phoenix.PubSub.subscribe(
+        KlassHero.PubSub,
+        "enrollment:provider:#{provider.id}:pending_changed"
+      )
     end
 
     {:noreply,
@@ -216,6 +228,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
      |> assign(total_sessions_completed: total_sessions)
      |> assign(enrolled_total: enrolled_total)
      |> assign(pending_requests: pending_requests)
+     |> assign(pending_enrollments: pending_enrollments)
      |> assign(top_programs: top_programs)}
   end
 

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -276,7 +276,53 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     end
   end
 
+  @impl true
+  def handle_info(:enrollment_pending_changed, socket) do
+    {:noreply, refresh_pending_enrollments(socket)}
+  end
+
   def handle_info(_message, socket), do: {:noreply, socket}
+
+  # ============================================================================
+  # Pending Enrollment Events
+  # ============================================================================
+
+  @impl true
+  def handle_event("approve_enrollment", %{"id" => enrollment_id}, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    case Enrollment.confirm_enrollment(%{
+           enrollment_id: enrollment_id,
+           provider_id: provider_id
+         }) do
+      {:ok, _enrollment} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Enrollment approved"))
+         |> refresh_pending_enrollments()}
+
+      {:error, :unauthorized} ->
+        {:noreply, put_flash(socket, :error, gettext("Not allowed to approve this enrollment"))}
+
+      {:error, :invalid_status_transition} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, gettext("Enrollment is not pending"))
+         |> refresh_pending_enrollments()}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, gettext("Enrollment not found"))}
+
+      {:error, reason} ->
+        Logger.error("[Dashboard.approve_enrollment] Failed",
+          enrollment_id: enrollment_id,
+          provider_id: provider_id,
+          reason: inspect(reason)
+        )
+
+        {:noreply, put_flash(socket, :error, gettext("Failed to approve"))}
+    end
+  end
 
   # ============================================================================
   # Staff Member CRUD Events
@@ -2381,5 +2427,11 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
       {:error, :not_found} ->
         to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
     end
+  end
+
+  defp refresh_pending_enrollments(socket) do
+    provider = socket.assigns.current_scope.provider
+    program_ids = ProgramCatalog.list_programs_for_provider(provider.id) |> Enum.map(& &1.id)
+    assign(socket, :pending_enrollments, Enrollment.list_pending_enrollments_for_provider(program_ids))
   end
 end

--- a/test/klass_hero/enrollment/adapters/driven/acl/program_catalog_acl_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/acl/program_catalog_acl_test.exs
@@ -44,4 +44,33 @@ defmodule KlassHero.Enrollment.Adapters.Driven.ACL.ProgramCatalogACLTest do
       assert ProgramCatalogACL.list_program_titles_for_provider(Ecto.UUID.generate()) == %{}
     end
   end
+
+  describe "program_owned_by?/2" do
+    test "returns true when the program belongs to the provider" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      assert ProgramCatalogACL.program_owned_by?(program.id, provider.id)
+    end
+
+    test "returns false when the program belongs to another provider" do
+      other_provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: other_provider.id)
+      provider = insert(:provider_profile_schema)
+
+      refute ProgramCatalogACL.program_owned_by?(program.id, provider.id)
+    end
+
+    test "returns false for an unknown program id" do
+      provider = insert(:provider_profile_schema)
+
+      refute ProgramCatalogACL.program_owned_by?(Ecto.UUID.generate(), provider.id)
+    end
+
+    test "returns false for an invalid uuid" do
+      provider = insert(:provider_profile_schema)
+
+      refute ProgramCatalogACL.program_owned_by?("not-a-uuid", provider.id)
+    end
+  end
 end

--- a/test/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/persistence/repositories/enrollment_repository_test.exs
@@ -435,6 +435,49 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.Enrollme
     end
   end
 
+  describe "list_pending_by_programs/1" do
+    test "returns only pending enrollments across the given programs" do
+      program_a = insert(:program_schema)
+      program_b = insert(:program_schema)
+      program_c = insert(:program_schema)
+
+      pending_a = insert(:enrollment_schema, program_id: program_a.id, status: :pending)
+      pending_b = insert(:enrollment_schema, program_id: program_b.id, status: :pending)
+      _confirmed_a = insert(:enrollment_schema, program_id: program_a.id, status: :confirmed)
+      _cancelled_b = insert(:enrollment_schema, program_id: program_b.id, status: :cancelled)
+      _completed_a = insert(:enrollment_schema, program_id: program_a.id, status: :completed)
+      _other_program = insert(:enrollment_schema, program_id: program_c.id, status: :pending)
+
+      ids =
+        EnrollmentRepository.list_pending_by_programs([program_a.id, program_b.id])
+        |> MapSet.new(& &1.id)
+
+      assert MapSet.equal?(ids, MapSet.new([to_string(pending_a.id), to_string(pending_b.id)]))
+    end
+
+    test "returns Enrollment domain structs (not Ecto schemas)" do
+      program = insert(:program_schema)
+      insert(:enrollment_schema, program_id: program.id, status: :pending)
+
+      [enrollment] = EnrollmentRepository.list_pending_by_programs([program.id])
+
+      assert %Enrollment{status: :pending} = enrollment
+    end
+
+    test "returns [] for empty program_ids" do
+      insert(:enrollment_schema, status: :pending)
+
+      assert EnrollmentRepository.list_pending_by_programs([]) == []
+    end
+
+    test "returns [] when no pending enrollments match" do
+      program = insert(:program_schema)
+      insert(:enrollment_schema, program_id: program.id, status: :confirmed)
+
+      assert EnrollmentRepository.list_pending_by_programs([program.id]) == []
+    end
+  end
+
   describe "concurrent create/1" do
     # Verifies that the unique constraint on (program_id, child_id) for active
     # enrollments is handled gracefully when two requests race to enroll the

--- a/test/klass_hero/enrollment/application/commands/confirm_enrollment_test.exs
+++ b/test/klass_hero/enrollment/application/commands/confirm_enrollment_test.exs
@@ -1,0 +1,82 @@
+defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollmentTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment.Application.Commands.ConfirmEnrollment
+  alias KlassHero.Enrollment.Domain.Models.Enrollment
+
+  describe "execute/1" do
+    test "confirms a pending enrollment owned by the provider" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      schema = insert(:enrollment_schema, program_id: program.id, status: :pending)
+
+      assert {:ok, enrollment} =
+               ConfirmEnrollment.execute(%{enrollment_id: schema.id, provider_id: provider.id})
+
+      assert %Enrollment{status: :confirmed} = enrollment
+      assert enrollment.confirmed_at != nil
+    end
+
+    test "returns :unauthorized when program belongs to a different provider" do
+      owner = insert(:provider_profile_schema)
+      other = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: owner.id)
+      schema = insert(:enrollment_schema, program_id: program.id, status: :pending)
+
+      assert {:error, :unauthorized} =
+               ConfirmEnrollment.execute(%{enrollment_id: schema.id, provider_id: other.id})
+
+      assert Enrollment.pending?(reload_enrollment(schema.id))
+    end
+
+    test "returns :not_found for unknown enrollment id" do
+      provider = insert(:provider_profile_schema)
+
+      assert {:error, :not_found} =
+               ConfirmEnrollment.execute(%{
+                 enrollment_id: Ecto.UUID.generate(),
+                 provider_id: provider.id
+               })
+    end
+
+    test "returns :invalid_status_transition when already confirmed" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      schema = insert(:enrollment_schema, program_id: program.id, status: :confirmed)
+
+      assert {:error, :invalid_status_transition} =
+               ConfirmEnrollment.execute(%{enrollment_id: schema.id, provider_id: provider.id})
+    end
+
+    test "returns :invalid_status_transition when cancelled" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      schema = insert(:enrollment_schema, program_id: program.id, status: :cancelled)
+
+      assert {:error, :invalid_status_transition} =
+               ConfirmEnrollment.execute(%{enrollment_id: schema.id, provider_id: provider.id})
+    end
+
+    test "publishes an :enrollment_confirmed event on success" do
+      setup_test_events()
+
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      schema = insert(:enrollment_schema, program_id: program.id, status: :pending)
+
+      assert {:ok, _} =
+               ConfirmEnrollment.execute(%{enrollment_id: schema.id, provider_id: provider.id})
+
+      event = assert_event_published(:enrollment_confirmed)
+      assert event.aggregate_id == schema.id
+    end
+  end
+
+  defp reload_enrollment(id) do
+    {:ok, enrollment} = KlassHero.Enrollment.get_enrollment(id)
+    enrollment
+  end
+end

--- a/test/klass_hero/enrollment/application/commands/confirm_enrollment_test.exs
+++ b/test/klass_hero/enrollment/application/commands/confirm_enrollment_test.exs
@@ -42,6 +42,13 @@ defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollmentTest do
                })
     end
 
+    test "returns :not_found for malformed enrollment id (no crash)" do
+      provider = insert(:provider_profile_schema)
+
+      assert {:error, :not_found} =
+               ConfirmEnrollment.execute(%{enrollment_id: "not-a-uuid", provider_id: provider.id})
+    end
+
     test "returns :invalid_status_transition when already confirmed" do
       provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: provider.id)

--- a/test/klass_hero/enrollment/application/queries/list_pending_enrollments_for_provider_test.exs
+++ b/test/klass_hero/enrollment/application/queries/list_pending_enrollments_for_provider_test.exs
@@ -1,0 +1,86 @@
+defmodule KlassHero.Enrollment.Application.Queries.ListPendingEnrollmentsForProviderTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment.Application.Queries.ListPendingEnrollmentsForProvider
+
+  describe "execute/1" do
+    test "returns [] for empty program_ids" do
+      assert ListPendingEnrollmentsForProvider.execute([]) == []
+    end
+
+    test "returns enriched entries for pending enrollments in the given programs" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Soccer Camp")
+      {child, parent} = insert_child_with_guardian(first_name: "Ada", last_name: "Lovelace")
+
+      enrollment =
+        insert(:enrollment_schema,
+          program_id: program.id,
+          parent_id: parent.id,
+          child_id: child.id,
+          status: :pending
+        )
+
+      [entry] = ListPendingEnrollmentsForProvider.execute([program.id])
+
+      assert entry.enrollment_id == enrollment.id
+      assert entry.program_id == program.id
+      assert entry.program_title == "Soccer Camp"
+      assert entry.child_id == to_string(child.id)
+      assert entry.child_name == "Ada Lovelace"
+      assert entry.parent_id == to_string(parent.id)
+      assert %DateTime{} = entry.enrolled_at
+    end
+
+    test "excludes non-pending enrollments" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {child1, parent1} = insert_child_with_guardian()
+      {child2, parent2} = insert_child_with_guardian()
+      {child3, parent3} = insert_child_with_guardian()
+
+      insert(:enrollment_schema, program_id: program.id, child_id: child1.id, parent_id: parent1.id, status: :confirmed)
+      insert(:enrollment_schema, program_id: program.id, child_id: child2.id, parent_id: parent2.id, status: :cancelled)
+      insert(:enrollment_schema, program_id: program.id, child_id: child3.id, parent_id: parent3.id, status: :completed)
+
+      assert ListPendingEnrollmentsForProvider.execute([program.id]) == []
+    end
+
+    test "gracefully handles missing child and program metadata" do
+      # Trigger: enrollment exists but its program has been deleted (simulate orphan via FK bypass)
+      # Why: program_id FK is :restrict so we insert real records then delete the program to orphan
+      # Outcome: entry.program_title falls back to "Unknown"; child_name falls back to "Unknown"
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      {child, parent} = insert_child_with_guardian()
+
+      enrollment =
+        insert(:enrollment_schema,
+          program_id: program.id,
+          child_id: child.id,
+          parent_id: parent.id,
+          status: :pending
+        )
+
+      program_id = program.id
+      program_id_bin = Ecto.UUID.dump!(program.id)
+      child_id_bin = Ecto.UUID.dump!(child.id)
+
+      # Disable FK checks so we can orphan the enrollment
+      KlassHero.Repo.query!("SET session_replication_role = 'replica'")
+      KlassHero.Repo.query!("DELETE FROM children_guardians WHERE child_id = $1", [child_id_bin])
+      KlassHero.Repo.query!("DELETE FROM children WHERE id = $1", [child_id_bin])
+      KlassHero.Repo.query!("DELETE FROM programs WHERE id = $1", [program_id_bin])
+      KlassHero.Repo.query!("SET session_replication_role = 'origin'")
+
+      [entry] = ListPendingEnrollmentsForProvider.execute([program_id])
+
+      assert entry.enrollment_id == enrollment.id
+      assert entry.child_name == "Unknown"
+      assert entry.program_title == "Unknown"
+    end
+  end
+end

--- a/test/klass_hero/enrollment/domain/events/enrollment_events_test.exs
+++ b/test/klass_hero/enrollment/domain/events/enrollment_events_test.exs
@@ -204,4 +204,39 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEventsTest do
                    fn -> EnrollmentEvents.enrollment_cancelled("", %{}) end
     end
   end
+
+  describe "enrollment_confirmed/3" do
+    test "builds an event with the canonical payload" do
+      enrollment_id = "11111111-1111-1111-1111-111111111111"
+      program_id = "22222222-2222-2222-2222-222222222222"
+      child_id = "33333333-3333-3333-3333-333333333333"
+      parent_id = "44444444-4444-4444-4444-444444444444"
+      confirmed_at = DateTime.utc_now()
+
+      assert %DomainEvent{
+               event_type: :enrollment_confirmed,
+               aggregate_id: ^enrollment_id,
+               aggregate_type: :enrollment,
+               payload: %{
+                 enrollment_id: ^enrollment_id,
+                 program_id: ^program_id,
+                 child_id: ^child_id,
+                 parent_id: ^parent_id,
+                 confirmed_at: ^confirmed_at
+               }
+             } =
+               EnrollmentEvents.enrollment_confirmed(enrollment_id, %{
+                 program_id: program_id,
+                 child_id: child_id,
+                 parent_id: parent_id,
+                 confirmed_at: confirmed_at
+               })
+    end
+
+    test "raises on empty enrollment_id" do
+      assert_raise ArgumentError, ~r/non-empty enrollment_id/, fn ->
+        EnrollmentEvents.enrollment_confirmed("", %{})
+      end
+    end
+  end
 end

--- a/test/klass_hero_web/live/provider/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_live_test.exs
@@ -1433,4 +1433,87 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
       assert has_element?(view, ~s(a[href="/provider/complete-profile"]))
     end
   end
+
+  describe "pending enrollments card" do
+    test "shows empty state when no pending enrollments", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      assert has_element?(view, "#pending-enrollments-card")
+      assert render(view) =~ "No pending enrollments right now."
+    end
+
+    test "renders a row per pending enrollment for this provider", %{conn: conn, provider: provider} do
+      program = insert_program_with_listing(provider_id: provider.id, title: "Soccer Camp")
+      {child, parent} = KlassHero.Factory.insert_child_with_guardian()
+
+      enrollment =
+        KlassHero.Factory.insert(:enrollment_schema,
+          program_id: program.id,
+          parent_id: parent.id,
+          child_id: child.id,
+          status: :pending
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      assert has_element?(view, "#pending-enrollment-#{enrollment.id}")
+      assert has_element?(view, "#approve-enrollment-#{enrollment.id}")
+      assert render(view) =~ "Soccer Camp"
+    end
+
+    test "does not show pending enrollments from another provider", %{conn: conn} do
+      other_provider = KlassHero.Factory.insert(:provider_profile_schema)
+      other_program = KlassHero.Factory.insert(:program_schema, provider_id: other_provider.id)
+
+      enrollment =
+        KlassHero.Factory.insert(:enrollment_schema, program_id: other_program.id, status: :pending)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
+    end
+
+    test "approving a pending enrollment confirms it and removes it from the card",
+         %{conn: conn, provider: provider} do
+      program = insert_program_with_listing(provider_id: provider.id)
+      {child, parent} = KlassHero.Factory.insert_child_with_guardian()
+
+      enrollment =
+        KlassHero.Factory.insert(:enrollment_schema,
+          program_id: program.id,
+          parent_id: parent.id,
+          child_id: child.id,
+          status: :pending
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      view
+      |> element("#approve-enrollment-#{enrollment.id}")
+      |> render_click()
+
+      refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
+
+      {:ok, reloaded} = KlassHero.Enrollment.get_enrollment(enrollment.id)
+      assert reloaded.status == :confirmed
+    end
+
+    test "approving an enrollment for another provider's program flashes an error",
+         %{conn: conn} do
+      other_provider = KlassHero.Factory.insert(:provider_profile_schema)
+      other_program = KlassHero.Factory.insert(:program_schema, provider_id: other_provider.id)
+
+      enrollment =
+        KlassHero.Factory.insert(:enrollment_schema, program_id: other_program.id, status: :pending)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      render_hook(view, "approve_enrollment", %{"id" => enrollment.id})
+
+      assert render(view) =~ "Not allowed"
+
+      {:ok, reloaded} = KlassHero.Enrollment.get_enrollment(enrollment.id)
+      assert reloaded.status == :pending
+    end
+  end
 end


### PR DESCRIPTION
Closes #859.

## Summary

- Added a "Pending enrollments" inbox card to `/provider/dashboard` (overview tab) showing each pending enrollment with an Approve button — sits next to the existing "Pending booking requests" card in a 3-up grid.
- New `KlassHero.Enrollment.confirm_enrollment/1` use case (`Application.Commands.ConfirmEnrollment`) that transitions `:pending → :confirmed`, authorising via the ProgramCatalog ACL before persisting and dispatching an `:enrollment_confirmed` domain event.
- New `KlassHero.Enrollment.list_pending_enrollments_for_provider/1` query enriched with child names (Family ACL) and program titles (direct table read to avoid the ProgramCatalog → Enrollment dependency cycle).
- New `program_owned_by?/2` callback on the ProgramCatalog ACL port + implementation as the authorisation primitive.
- New `enrollment_confirmed/3` domain event factory and registration of `NotifyLiveViews` for that event in the Enrollment DomainEventBus.
- Supplementary per-provider PubSub broadcast (`"enrollment:provider:<id>:pending_changed"`) emitted from the command so multiple open dashboard tabs auto-refresh on approve.

## Notable design notes for reviewers

- **Issue reframed**: the original ticket asked to put the action in the session roster view; pending enrollments are program-scoped and don't appear on any session roster (rosters derive from `:confirmed` enrollments). The dashboard inbox is the correct surface.
- **Authorization lives in the use case**, not the LiveView. Any future caller — Oban job, admin tool, API controller — gets the same provider-ownership guarantee.
- **No capacity revalidation needed**: active counters include `:pending`, so the `pending → confirmed` transition leaves the active count unchanged.

## Review Focus

- **Authorisation primitive** — `lib/klass_hero/enrollment/adapters/driven/acl/program_catalog_acl.ex:41` adds `program_owned_by?/2`. It hits the `programs` table directly with the same pattern as the existing `list_program_titles_for_provider/1` (ProgramCatalog already depends on Enrollment, so a context call back would cycle). UUID-cast guards on both args; invalid casts return `false`.
- **Use-case pipeline order** — `lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex:60` runs authz BEFORE the domain transition and dispatches the event LAST. Each `with` step on its own line so a failure short-circuits without partial side effects.
- **Per-provider broadcast** — `lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex:99` adds a best-effort `Phoenix.PubSub.broadcast/3` on top of the canonical domain-event path. `NotifyLiveViews` broadcasts on a global `"enrollment:enrollment_confirmed"` topic, which would deliver across all providers — the supplementary per-provider topic keeps the dashboard refresh isolated.
- **Double-refresh on approve (info, optional follow-up)** — `lib/klass_hero_web/live/provider/dashboard_live.ex` triggers `refresh_pending_enrollments/1` in both the `:ok` branch of the click handler and in `handle_info(:enrollment_pending_changed, _)`, because the originating socket is also subscribed to the broadcast topic. Idempotent (no incorrect state), but issues the read queries twice per approve. Easiest fix is to drop the in-handler refresh and trust the broadcast loopback.
- **Query enrichment fallback** — `lib/klass_hero/enrollment/application/queries/list_pending_enrollments_for_provider.ex:78` returns `"Unknown"` for missing child/program metadata so a stale row never breaks the dashboard render. Mirrors the pattern in the existing `ListProgramEnrollments`.

## Test Plan

- [x] `mix precommit` green (4890 tests pass, 0 warnings).
- [x] `mix test test/klass_hero/enrollment/` — 637+ tests green.
- [x] `mix test test/klass_hero_web/live/provider/dashboard_live_test.exs` — 66 tests green (5 new for the card).
- [x] Tidewave smoke: `Enrollment.confirm_enrollment/1` happy path + cross-provider authz + broadcast emission verified against seeded data.
- [x] Playwright UI: card renders for `robert.braun@example.com`, Approve transitions to `:confirmed` + flash `"Enrollment approved"`, row disappears, badge updates to "0 pending".
- [x] Mobile responsive at 375x667: child name truncates, Approve button stays right-aligned.
- [ ] Manual multi-tab smoke: open `/provider/dashboard` in two tabs as the same provider; approve in one; verify the card refreshes in the other within a second.
- [ ] Manual decline-attempt as another provider via dev tools push to confirm flash error and unchanged DB state.

## Follow-ups

- #623 — decline / reject action (companion to this approve flow) is still open; comment added there noting the approve half landed here.
- Integration event for `:enrollment_confirmed` when a cross-context consumer needs it (parent notification, etc.).
- Bulk approve UX if volume warrants.