### PR TITLE
refactor: collapse pending-enrollments refresh to single channel

### DIFF
--- a/.claude/agents/regression-analyzer.md
+++ b/.claude/agents/regression-analyzer.md
@@ -1,0 +1,254 @@
+---
+name: regression-analyzer
+description: >-
+  Analyse a code diff for behaviour-preservation issues — places where the
+  change subtly alters semantics relative to the pre-change baseline. Catches
+  widened pattern matches, dropped guards, reordered clauses, default-value
+  flips, producer/consumer topic and envelope drift, removed type guards,
+  module attribute changes that flow into runtime values, event handler
+  registration drift, and unsafe DB schema changes. Run as a subagent for
+  PR review or post-refactor verification.
+---
+
+# Regression Analyzer
+
+Detect behaviour drift in a diff that tests and the compiler will miss.
+
+**Type:** Diff-driven analysis. Compare BEFORE and AFTER states.
+
+---
+
+## Scope
+
+This agent supports three scan modes, specified by the caller:
+
+- **`pr-diff`** (default) — diff against the PR base branch:
+  ```bash
+  BASE=$(git merge-base HEAD main 2>/dev/null || git rev-parse HEAD)
+  git diff "$BASE"...HEAD
+  ```
+  If `git merge-base` fails (e.g. shallow clone), fall back to `git diff HEAD` and note the limitation in the report.
+- **`unstaged`** — `git diff HEAD` — for post-edit, pre-commit verification.
+- **`commit-range`** — caller-supplied range (e.g. `git diff abc123...def456`) — for forensic audits or reviewing a single squash-merged commit.
+
+For each modified file, read the diff hunks to obtain BEFORE and AFTER states. Apply the checks to the pair, not just to the AFTER state.
+
+---
+
+## Context
+
+The job is to ask **"did this change preserve the behaviour of the unchanged callers, subscribers, and downstream consumers?"** This lens catches a specific failure mode the project has hit before:
+
+A refactor in PR #872 changed `Enrollment.NotifyLiveViews.derive_topic/1` from a clause that implicitly relied on `aggregate_type` and `event_type` to a clause that only matched `payload: %{provider_id: pid}`. Tests passed (`:enrollment_confirmed` still routed correctly). The compiler had nothing to say (the pattern was valid). But `:invite_deleted`, which also carries `provider_id` in its payload today via `delete_invite.ex:40-44`, silently re-routed from `"invite:invite_deleted"` to `"enrollment:invite_deleted:provider:<id>"`. No active subscriber today, but a broken contract.
+
+Assumptions:
+- Tests only cover what's tested — silent drifts in callers/subscribers slip through.
+- Compiler warnings catch type mismatches but not scope-drift in pattern matches.
+- Author intent does not always match the actual scope of the change.
+
+Each check produces concrete examples of what could break, not just style notes.
+
+---
+
+## Check 1: Pattern-Match Scope Drift
+
+**Rule:** A function clause's pattern must not be silently widened or narrowed by the diff. Widening lets in inputs that previously fell through to a different clause; narrowing rejects inputs the function previously handled.
+
+**How to verify:**
+1. For each modified `def`/`defp` head in the diff, compare the BEFORE and AFTER patterns
+2. Look for: removed atom literals (`event_type: :foo` → `event_type: _`), removed map-key constraints, removed `is_*` guards, added wildcards (`_`)
+3. Cross-reference with the next clause(s) in the same function — if the now-broader pattern matches inputs that USED to fall through to a later clause, those inputs now hit the changed clause instead
+
+**Violations to flag:**
+- A `def handle_info(:enrollment_pending_changed, …)` becoming `def handle_info(_msg, …)` — now swallows all messages
+- A `def derive_topic(%{event_type: :foo, payload: %{x: x}})` becoming `def derive_topic(%{payload: %{x: x}})` — matches any event type with that payload shape
+- A `def execute(%{user_id: id} = params) when is_binary(id)` losing `when is_binary(id)` — now accepts nil and non-binary ids
+
+**Severity:** `error` if a concrete other-clause input now misroutes; `warning` if the broadening is theoretical.
+
+## Check 2: Function Clause Ordering
+
+**Rule:** Pattern-matched function clauses dispatch in source order. Reordering can silently change which clause matches.
+
+**How to verify:**
+1. For each modified function with multiple clauses, check whether the diff reorders them
+2. If clauses were reordered, identify any input that now matches a different clause than it did before
+3. Pay special attention to a wildcard / catch-all clause being moved earlier — it shadows everything below it
+
+**Violations to flag:**
+- A `handle_info(_, socket)` catch-all moved above specific clauses — specifics now never match
+- Reordered guards in `cond` / `with` chains
+- Reordered `case` clauses where a broader pattern moves up
+
+**Severity:** `error` if a previously-matching specific clause is now shadowed; `warning` if the new order is observably equivalent.
+
+## Check 3: Public API Contract Changes
+
+**Rule:** Public functions (`def` in modules, `defdelegate`, `@spec`) must not change their arity, default argument values, or return shape without a deprecation shim. Renames must keep the old name as a delegate or be explicitly noted in the diff.
+
+**How to verify:**
+1. For each modified module, list public functions with their arity, default args, and `@spec` return shapes
+2. Compare BEFORE vs AFTER
+3. If arity changed: grep the codebase for all callers — every site must be in the diff
+4. If a default arg value flipped (`opts \\ %{retries: 3}` → `opts \\ %{retries: 5}`): flag and check callers that omit the arg
+5. If the return shape changed (`{:ok, x}` → `{:ok, x, y}` or `:ok` → `{:ok, term}`): grep for callers' pattern-matches against the old shape
+6. If a public function was deleted: grep for callers
+
+**Violations to flag:**
+- `def foo(x, y)` → `def foo(x, y, z)` without updating all `foo(a, b)` callers in the same PR
+- Default arg flips that change behaviour for callers passing no value
+- Return-shape changes where callers match on the old shape (`{:ok, result}` patterns)
+- Public function deletion / rename without a `defdelegate` shim or `@deprecated`
+
+**Severity:** `error` if existing callers (outside the diff) still use the old contract; `warning` if all callers are in the diff but the change is non-obvious.
+
+## Check 4: Producer / Consumer Pair Drift
+
+**Rule:** When a producer's output shape changes — PubSub topic string, broadcast message envelope, `send/2` payload, `GenServer.cast/2` shape — every matching consumer must still match. This requires a **codebase-wide grep**, not just same-file or same-context inspection.
+
+**Producer/consumer pairs to scan:**
+- `Phoenix.PubSub.broadcast(_, topic, msg)` ↔ `Phoenix.PubSub.subscribe(_, topic)` + `handle_info(msg, _)`
+- `send(pid, msg)` ↔ `handle_info(msg, _)`
+- `GenServer.cast(pid, msg)` ↔ `handle_cast(msg, _)`
+- `GenServer.call(pid, msg)` ↔ `handle_call(msg, _, _)`
+- Domain events: `EventPublishing.publish(event, topic)` ↔ subscriber pattern + topic-derivation functions
+
+**How to verify:**
+1. For each diff hunk that modifies a producer call, extract the new topic / message shape
+2. Grep the codebase for the previous topic string OR for matching `handle_info`/`handle_cast` clauses
+3. **For shared topic-derivation / dispatch functions (e.g. `derive_topic/1`, `handle/1` registered against multiple event types):** enumerate every event type routed through the changed function (read `lib/klass_hero/application.ex` `handlers:` lists and `config/config.exs` `:critical_event_handlers`) and trace the topic / message shape produced for each one BEFORE and AFTER. The PR #872 class hides here — the diff's narrative example may only show one event type while the function actually fans out to several.
+4. Verify each match still pattern-matches the new shape; flag mismatches
+5. For PubSub topics: if a topic string changed, check that ALL subscribers updated to the new string in the same diff
+6. For `handle_info` envelope changes: check that the matching `send`/`broadcast` shape is in the diff
+
+**Violations to flag:**
+- A producer publishes `{:domain_event, event}` but a remaining subscriber matches on raw `event`
+- A topic format changes (`"foo:bar"` → `"foo:bar:scope"`) but a subscriber still subscribes to `"foo:bar"`
+- A `send(pid, :old_atom)` is renamed but a `handle_info(:old_atom, _)` clause remains untouched in another module
+- A topic-derivation function's pattern was widened (PR #872 case) and now produces a different topic for an unrelated event type whose subscribers expect the old topic
+
+**Severity:** `error` if any consumer becomes unreachable; `warning` if the consumer is still reachable but receives unexpected shapes.
+
+## Check 5: Removed Guards or Type Constraints
+
+**Rule:** Removing `when is_binary(x)`, `is_atom(x)`, `is_struct(x, T)`, `is_list(x)`, `is_map(x)`, or similar guards from a function head widens the input domain. The function now accepts values that previously failed with `FunctionClauseError`.
+
+**How to verify:**
+1. For each modified function head, compare BEFORE and AFTER guard sequences
+2. Note any guard removal
+3. If callers rely on the guard for input validation (i.e. they pass user input expecting the function to reject bad types), flag it
+
+**Violations to flag:**
+- `def execute(%{user_id: id}) when is_binary(id)` → `def execute(%{user_id: id})` — now accepts `nil` and atoms
+- `def handle(event) when is_struct(event, DomainEvent)` → `def handle(event)` — now accepts any term
+
+**Severity:** `warning` by default (since silently accepting bad input usually still fails later); `error` if a previously-rejected input now succeeds with wrong-shape output.
+
+## Check 6: Module Attribute Changes that Affect Runtime Values
+
+**Rule:** Module attributes that flow into runtime values (used in function bodies, struct defaults, configuration, topic prefixes, timeouts, retry counts) must not change without auditing downstream impact.
+
+**Common attributes to scrutinize:**
+- `@aggregate_type`, `@topic_prefix`, `@event_type` (events / messaging)
+- `@default_timeout`, `@retry_attempts`, `@max_retries` (resilience)
+- `@table`, `@primary_key` (Ecto schemas — schema-shape changes)
+- `@derive` (Jason/JSON serialization shape)
+- `@behaviour` (contract changes)
+
+**How to verify:**
+1. For each modified module, list module attributes added/removed/changed
+2. For each changed attribute, grep the rest of the file for usages
+3. If the attribute is used in a struct default, function body, or `@spec`, trace what changes downstream
+4. Cross-reference with consumers if the attribute affects external contracts (e.g. `@aggregate_type` flows into `DomainEvent.aggregate_type`)
+
+**Violations to flag:**
+- `@aggregate_type :invite` → `@aggregate_type :enrollment` — events now report wrong aggregate
+- `@default_timeout 5_000` → `@default_timeout 30_000` — silently 6x slower failure detection
+- `@derive {Jason.Encoder, only: [:id, :name]}` → `@derive {Jason.Encoder, only: [:id]}` — `name` no longer serialized
+
+**Severity:** `error` if downstream consumers rely on the attribute value; `warning` for less-coupled cases.
+
+## Check 7: Event / Handler Registration Drift
+
+**Rule:** Changes to `lib/klass_hero/application.ex` (`DomainEventBus` handler specs), `config/config.exs` (DI bindings, `critical_event_handlers` registry, scope configs), or any supervision-tree child spec are silently-breaking — the supervision tree reads these at startup and code reloading does not refresh them. Removing or replacing a handler severs side effects.
+
+**How to verify:**
+1. Check the diff for changes to:
+   - `lib/klass_hero/application.ex` — `handlers:` lists per context
+   - `config/config.exs` — `:klass_hero, :<context>` DI keys, `:critical_event_handlers` map, `:scopes` config
+   - Any child spec changes in the supervision tree
+2. For each removed/changed handler entry, identify what side effect is no longer fired
+3. For each removed DI binding, grep for `Application.compile_env!(:klass_hero, [...])` references — they will raise at compile time
+
+**Violations to flag:**
+- A `{:event_type, {Handler, :fn}}` removed from `application.ex` without a replacement — side effect dropped
+- A DI key removed from `config.exs` while the corresponding `Application.compile_env!` remains in a use case
+- A `critical_event_handlers` entry removed — durable cross-context delivery dropped
+
+**Severity:** `error` (handler/DI drift is always a silent breakage); `warning` if the registration is for an event type the diff also removed entirely.
+
+## Check 8: DB Schema Changes Without Migration Safety Review
+
+**Rule:** Column adds, drops, renames, default-value flips, nullability changes, and index drops in `priv/repo/migrations/` or in `Ecto.Schema` modules must be reviewed for migration safety: zero-downtime sequencing, backfill strategy, application-level compatibility during deploy.
+
+**How to verify:**
+1. Diff `priv/repo/migrations/` for new migration files
+2. Diff `lib/klass_hero/**/schemas/*.ex` for `field`/`belongs_to`/`has_many`/`@primary_key` changes
+3. Cross-reference each schema change with the matching migration
+4. Check for:
+   - NOT NULL column added without a default → existing rows fail
+   - Column renamed → old name still referenced in code = runtime crash
+   - Default value flipped → existing INSERTs that omit the column behave differently
+   - Index dropped → query plan regression
+   - `belongs_to` association changed → preload sites may break
+
+**Violations to flag:**
+- New `NOT NULL` column without `default:` in the migration AND no backfill step
+- Schema field rename without a corresponding migration rename (or vice versa)
+- Default value flip in either migration or schema not matching the other
+- Dropped index without confirmation that no query relies on it
+
+**Severity:** `error` for irreversible or production-breaking migrations; `warning` for compatible-but-risky changes.
+
+---
+
+## Output Format
+
+```
+# Regression Analysis Report
+
+## Summary
+- Diff scope: [pr-diff | unstaged | commit-range <range>]
+- Files reviewed: N
+- Checks passed: N/8
+- Regressions found: N (M error, K warning)
+
+## Regressions
+
+### [CHECK_NAME] — [severity: error | warning | info]
+- **File:** path/to/file.ex:line (or hunk range)
+- **Before:** [the relevant BEFORE snippet]
+- **After:** [the relevant AFTER snippet]
+- **Drift:** [what behaviour changed]
+- **Impact:** [what breaks — concrete caller/subscriber if found, "no current caller affected but contract broken" if not]
+- **Fix:** [tighten the pattern back, add a clause for the previously-handled case, etc.]
+
+## Passed Checks
+- [list of checks that found no regressions]
+
+## Diff Coverage Notes
+- [files that could not be fully analyzed due to git access issues, if any]
+```
+
+---
+
+## Rules
+
+- **Always read BEFORE and AFTER from the actual diff.** Never infer from filenames or commit messages — diff hunks are the source of truth.
+- **For Check 4 (producer/consumer pairs), grep the codebase.** Same-file or same-context inspection is insufficient; that's exactly where this lens earns its keep.
+- **Severity discipline:** `error` only when a concrete current caller/subscriber is broken or definitely will be. `warning` for "contract widened, no current caller affected but a future one would be." `info` for "this is worth a human look but probably fine."
+- **Don't flag pure refactors that preserve behaviour.** Renaming a private function, inlining a helper, extracting a constant — if BEFORE and AFTER are observably equivalent, it's not a regression.
+- **Cross-reference, don't speculate.** If you flag a producer/consumer pair drift, name the matching subscriber file and line. If you can't find one, downgrade to `warning` ("no current consumer found").
+- **The PR #872 regression is the calibration example.** Check 1 (pattern-match scope drift) + Check 4 (producer/consumer pair drift) should both catch that class of bug. If your run misses it on a similar diff, your application of these checks is under-specified.
+- **Git access required.** This agent runs `git diff` and `git merge-base`. If those fail (no git, shallow clone, detached HEAD), note the limitation and degrade gracefully.
+- **Avoid duplicate flags.** If a single change triggers multiple checks (e.g. pattern drift AND producer/consumer drift), report it once under the most specific check.

--- a/.claude/skills/review-architecture/SKILL.md
+++ b/.claude/skills/review-architecture/SKILL.md
@@ -2,16 +2,17 @@
 name: review-architecture
 description: >-
   Review code changes for DDD/Ports & Adapters architecture compliance by
-  spawning the architecture-reviewer (12 structural checks) and boundary-checker
-  (6 semantic violation checks) agents in parallel. Consolidates findings into
-  a unified report. Use when: reviewing a PR, checking architecture before merge,
+  spawning the architecture-reviewer (12 structural checks), boundary-checker
+  (6 semantic violation checks), and regression-analyzer (8 behaviour-
+  preservation checks) agents in parallel. Consolidates findings into a unified
+  report. Use when: reviewing a PR, checking architecture before merge,
   validating structural changes, or after modifying bounded context code.
   Invoke with: /review-architecture
 ---
 
 # Review Architecture
 
-Run a comprehensive DDD/Ports & Adapters architecture review by dispatching two
+Run a comprehensive DDD/Ports & Adapters architecture review by dispatching three
 specialized agents in parallel, then consolidating their reports.
 
 **Type:** Rigid workflow. Follow steps exactly.
@@ -57,9 +58,9 @@ Display: `Affected contexts: Enrollment, Family, Shared`
 
 This helps the user understand the review scope.
 
-## Step 3: Spawn Both Agents in Parallel
+## Step 3: Spawn All Three Agents in Parallel
 
-Launch both agents **in the same message** so they run concurrently.
+Launch all three agents **in the same message** so they run concurrently.
 
 ### Agent 1: Architecture Reviewer
 
@@ -105,15 +106,41 @@ Run all 6 checks scoped to these files and their immediate references.
 Report findings in your standard output format.
 ```
 
+### Agent 3: Regression Analyzer
+
+Use the `regression-analyzer` subagent. In the prompt, provide:
+
+- The diff base (default `main` for PR reviews, `HEAD` for unstaged)
+- Explicit scope mode: `pr-diff` (default) or `unstaged`
+- The list of changed files (the agent can re-derive it but passing it helps)
+
+Example prompt:
+
+```
+Analyse the diff for behaviour-preservation regressions.
+
+Scope: pr-diff (base: main)
+
+Changed files:
+<file list>
+
+Run all 8 checks against the diff. For producer/consumer pair checks (#4),
+grep the codebase for matching subscribers — same-context inspection is
+insufficient. Report findings in your standard output format.
+```
+
 ## Step 4: Consolidate Reports
 
 Once both agents complete, merge their findings into a single unified report.
 
 ### Deduplication
 
-Both agents may flag the same issue (e.g., a cross-context schema access would be caught
-by both Check 8 of architecture-reviewer and Check 2 of boundary-checker). Deduplicate
-by matching on the same file + line + violation type. Keep the more detailed description.
+Agents may flag the same issue from different angles:
+- Cross-context schema access → caught by architecture-reviewer Check 8 AND boundary-checker Check 2
+- Domain model purity drift → caught by architecture-reviewer Check 11 AND boundary-checker Check 5
+- A pattern widened in a use case → may surface as regression-analyzer Check 1 AND architecture-reviewer Check 5 (use case structure)
+
+Deduplicate by matching on the same file + line + violation type. Keep the more detailed description. For overlaps between regression-analyzer and the other two, prefer the regression-analyzer's framing — it speaks specifically to behaviour preservation, which is the action-shaping concern.
 
 ### Unified Report Format
 
@@ -130,7 +157,8 @@ by matching on the same file + line + violation type. Keep the more detailed des
 |--------|--------|--------|------------|----------|
 | Structure (architecture-reviewer) | 12 | N | N | N |
 | Boundaries (boundary-checker) | 6 | N | N | N |
-| **Total** | **18** | **N** | **N** | **N** |
+| Behaviour (regression-analyzer) | 8 | N | N | N |
+| **Total** | **26** | **N** | **N** | **N** |
 
 ## Violations
 
@@ -159,8 +187,8 @@ After presenting the report:
 
 ## Rules
 
-- **Always spawn both agents in parallel.** They are independent and run faster concurrently.
-- **Always scope to changed files.** Pass the file list to both agents — do not run full-codebase scans from this skill (the user can run the agents standalone for that).
-- **Deduplicate across agents.** The same violation should not appear twice in the report.
+- **Always spawn all three agents in parallel.** They are independent and run faster concurrently.
+- **Always scope to changed files.** Pass the file list to all three agents — do not run full-codebase scans from this skill (the user can run the agents standalone for that). Exception: regression-analyzer's Check 4 (producer/consumer pair drift) does grep codebase-wide for matching subscribers — that's intentional and the agent handles it internally.
+- **Deduplicate across agents.** The same violation should not appear three times in the report — prefer the regression-analyzer framing when behaviour is at stake.
 - **Never auto-fix without confirmation.** Present findings first, then offer to fix.
 - **Include the full check count.** Even if all checks pass, list them so the user knows what was verified.

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -54,6 +54,7 @@ defmodule KlassHero.Enrollment do
     ]
 
   alias KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.EnrollmentPolicySchema
+  alias KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.NotifyLiveViews
 
   alias KlassHero.Enrollment.Application.Commands.{
     CancelEnrollmentByAdmin,
@@ -330,6 +331,14 @@ defmodule KlassHero.Enrollment do
   def list_pending_enrollments_for_provider(program_ids) when is_list(program_ids) do
     ListPendingEnrollmentsForProvider.execute(program_ids)
   end
+
+  @doc """
+  Returns the provider-scoped PubSub topic for an Enrollment domain event.
+
+  Subscribers (e.g. `DashboardLive`) call this to subscribe to the same
+  topic the publisher (`Enrollment.NotifyLiveViews`) derives.
+  """
+  defdelegate provider_scoped_topic(event_type, provider_id), to: NotifyLiveViews
 
   @doc """
   Counts active enrollments for a parent in the current month.

--- a/lib/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views.ex
@@ -2,9 +2,9 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.NotifyLiveV
   @moduledoc """
   Routes Enrollment domain events to PubSub topics for LiveView updates.
 
-  When an event payload carries `provider_id`, the topic is scoped per-provider
-  so only that provider's `DashboardLive` receives the message. Other events
-  fall back to the shared default topic (`"<aggregate>:<event>"`).
+  `:enrollment_confirmed` events are scoped per-provider via
+  `provider_scoped_topic/2`. All other events fall back to the shared default
+  topic (`"<aggregate>:<event>"`).
   """
 
   alias KlassHero.Shared.Adapters.Driven.Events.EventHandlers.NotifyLiveViews,
@@ -29,8 +29,8 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.NotifyLiveV
   end
 
   @spec derive_topic(DomainEvent.t()) :: String.t()
-  def derive_topic(%DomainEvent{event_type: evt, payload: %{provider_id: pid}}) when is_binary(pid),
-    do: provider_scoped_topic(evt, pid)
+  def derive_topic(%DomainEvent{event_type: :enrollment_confirmed, payload: %{provider_id: pid}}) when is_binary(pid),
+    do: provider_scoped_topic(:enrollment_confirmed, pid)
 
   def derive_topic(%DomainEvent{} = event), do: SharedNotifyLiveViews.derive_topic(event)
 

--- a/lib/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views.ex
@@ -1,10 +1,38 @@
 defmodule KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.NotifyLiveViews do
-  @moduledoc "Delegates Enrollment event notifications to shared NotifyLiveViews handler."
+  @moduledoc """
+  Routes Enrollment domain events to PubSub topics for LiveView updates.
+
+  When an event payload carries `provider_id`, the topic is scoped per-provider
+  so only that provider's `DashboardLive` receives the message. Other events
+  fall back to the shared default topic (`"<aggregate>:<event>"`).
+  """
 
   alias KlassHero.Shared.Adapters.Driven.Events.EventHandlers.NotifyLiveViews,
     as: SharedNotifyLiveViews
 
-  defdelegate handle(event), to: SharedNotifyLiveViews
-  defdelegate derive_topic(event), to: SharedNotifyLiveViews
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  @spec handle(DomainEvent.t()) :: :ok
+  def handle(%DomainEvent{} = event) do
+    SharedNotifyLiveViews.safe_publish(event, derive_topic(event))
+  end
+
+  @doc """
+  Single source of truth for the provider-scoped Enrollment topic format.
+
+  Both publisher (`derive_topic/1`) and subscribers (e.g. `DashboardLive`)
+  call this so the topic string never drifts between sides.
+  """
+  @spec provider_scoped_topic(atom(), String.t()) :: String.t()
+  def provider_scoped_topic(event_type, provider_id) when is_atom(event_type) and is_binary(provider_id) do
+    "enrollment:#{event_type}:provider:#{provider_id}"
+  end
+
+  @spec derive_topic(DomainEvent.t()) :: String.t()
+  def derive_topic(%DomainEvent{event_type: evt, payload: %{provider_id: pid}}) when is_binary(pid),
+    do: provider_scoped_topic(evt, pid)
+
+  def derive_topic(%DomainEvent{} = event), do: SharedNotifyLiveViews.derive_topic(event)
+
   defdelegate build_topic(aggregate_type, event_type), to: SharedNotifyLiveViews
 end

--- a/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
+++ b/lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex
@@ -92,28 +92,17 @@ defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollment do
   end
 
   defp dispatch_event(%Enrollment{} = persisted, provider_id) do
-    # Publish the canonical enrollment:enrollment_confirmed domain event to PubSub.
-    # The generic NotifyLiveViews handler derives the topic as "enrollment:enrollment_confirmed",
-    # which is not provider-scoped. We also broadcast a provider-scoped notification so that
-    # the provider DashboardLive can subscribe to their own topic and refresh the pending list
-    # without receiving events from other providers.
     dispatch_result =
       persisted.id
       |> EnrollmentEvents.enrollment_confirmed(%{
         enrollment_id: persisted.id,
         program_id: persisted.program_id,
+        provider_id: provider_id,
         child_id: persisted.child_id,
         parent_id: persisted.parent_id,
         confirmed_at: persisted.confirmed_at
       })
       |> EventDispatchHelper.dispatch_or_error(@context)
-
-    # Supplementary provider-scoped broadcast — best-effort (mirrors PubSub best-effort policy).
-    Phoenix.PubSub.broadcast(
-      KlassHero.PubSub,
-      "enrollment:provider:#{provider_id}:pending_changed",
-      :enrollment_pending_changed
-    )
 
     case dispatch_result do
       :ok -> {:ok, persisted}

--- a/lib/klass_hero_web/live/provider/dashboard_live.ex
+++ b/lib/klass_hero_web/live/provider/dashboard_live.ex
@@ -20,6 +20,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   alias KlassHero.Provider
   alias KlassHero.Provider.Domain.Models.PayRate
   alias KlassHero.Provider.Domain.Models.ProviderProfile
+  alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHero.Shared.Entitlements
   alias KlassHero.Shared.Storage
   alias KlassHeroWeb.Helpers.TaskHelpers
@@ -210,14 +211,9 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(KlassHero.PubSub, "provider:#{provider.id}:stats_updated")
 
-      # Subscribe to the provider-scoped pending-changed topic so the dashboard
-      # refreshes automatically when a pending enrollment is confirmed.
-      # The generic NotifyLiveViews topic ("enrollment:enrollment_confirmed") is
-      # not provider-scoped, so ConfirmEnrollment also broadcasts a supplementary
-      # message on this topic to enable targeted, per-provider subscriptions.
       Phoenix.PubSub.subscribe(
         KlassHero.PubSub,
-        "enrollment:provider:#{provider.id}:pending_changed"
+        Enrollment.provider_scoped_topic(:enrollment_confirmed, provider.id)
       )
     end
 
@@ -277,7 +273,7 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
   end
 
   @impl true
-  def handle_info(:enrollment_pending_changed, socket) do
+  def handle_info({:domain_event, %DomainEvent{event_type: :enrollment_confirmed}}, socket) do
     {:noreply, refresh_pending_enrollments(socket)}
   end
 
@@ -296,10 +292,8 @@ defmodule KlassHeroWeb.Provider.DashboardLive do
            provider_id: provider_id
          }) do
       {:ok, _enrollment} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, gettext("Enrollment approved"))
-         |> refresh_pending_enrollments()}
+        # No refresh here — :enrollment_confirmed loopback drives it (handle_info/2).
+        {:noreply, put_flash(socket, :info, gettext("Enrollment approved"))}
 
       {:error, :unauthorized} ->
         {:noreply, put_flash(socket, :error, gettext("Not allowed to approve this enrollment"))}

--- a/test/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views_test.exs
+++ b/test/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views_test.exs
@@ -42,5 +42,17 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.NotifyLiveV
       assert NotifyLiveViews.derive_topic(event) ==
                "enrollment:enrollment_confirmed:provider:#{provider_id}"
     end
+
+    test "does not provider-scope non-enrollment_confirmed events even when payload has provider_id" do
+      provider_id = Ecto.UUID.generate()
+
+      event =
+        DomainEvent.new(:invite_deleted, Ecto.UUID.generate(), :invite, %{
+          provider_id: provider_id,
+          invite_id: "some-id"
+        })
+
+      assert NotifyLiveViews.derive_topic(event) == "invite:invite_deleted"
+    end
   end
 end

--- a/test/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views_test.exs
+++ b/test/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views_test.exs
@@ -26,9 +26,21 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.NotifyLiveV
   end
 
   describe "derive_topic/1" do
-    test "delegates to shared handler" do
+    test "falls back to shared derivation when payload omits provider_id" do
       event = DomainEvent.new(:participant_policy_set, "id", :enrollment, %{})
       assert NotifyLiveViews.derive_topic(event) == "enrollment:participant_policy_set"
+    end
+
+    test "appends provider scope when payload carries provider_id" do
+      provider_id = Ecto.UUID.generate()
+
+      event =
+        DomainEvent.new(:enrollment_confirmed, Ecto.UUID.generate(), :enrollment, %{
+          provider_id: provider_id
+        })
+
+      assert NotifyLiveViews.derive_topic(event) ==
+               "enrollment:enrollment_confirmed:provider:#{provider_id}"
     end
   end
 end

--- a/test/klass_hero/enrollment/application/commands/confirm_enrollment_test.exs
+++ b/test/klass_hero/enrollment/application/commands/confirm_enrollment_test.exs
@@ -67,7 +67,7 @@ defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollmentTest do
                ConfirmEnrollment.execute(%{enrollment_id: schema.id, provider_id: provider.id})
     end
 
-    test "publishes an :enrollment_confirmed event on success" do
+    test "publishes an :enrollment_confirmed event on success with provider-scoped payload" do
       setup_test_events()
 
       provider = insert(:provider_profile_schema)
@@ -77,7 +77,12 @@ defmodule KlassHero.Enrollment.Application.Commands.ConfirmEnrollmentTest do
       assert {:ok, _} =
                ConfirmEnrollment.execute(%{enrollment_id: schema.id, provider_id: provider.id})
 
-      event = assert_event_published(:enrollment_confirmed)
+      event =
+        assert_event_published(:enrollment_confirmed, %{
+          provider_id: provider.id,
+          program_id: program.id
+        })
+
       assert event.aggregate_id == schema.id
     end
   end

--- a/test/klass_hero_web/live/provider/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_live_test.exs
@@ -9,6 +9,7 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
   alias KlassHero.ProviderFixtures
   alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.DomainEvent
 
   setup :register_and_log_in_provider
 
@@ -1473,7 +1474,7 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
       refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
     end
 
-    test "approving a pending enrollment confirms it and removes it from the card",
+    test "approving a pending enrollment confirms it in the DB and flashes success",
          %{conn: conn, provider: provider} do
       program = insert_program_with_listing(provider_id: provider.id)
       {child, parent} = KlassHero.Factory.insert_child_with_guardian()
@@ -1492,10 +1493,48 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
       |> element("#approve-enrollment-#{enrollment.id}")
       |> render_click()
 
-      refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
+      assert render(view) =~ "Enrollment approved"
 
       {:ok, reloaded} = KlassHero.Enrollment.get_enrollment(enrollment.id)
       assert reloaded.status == :confirmed
+    end
+
+    test "card refreshes when an :enrollment_confirmed event arrives for this provider",
+         %{conn: conn, provider: provider} do
+      program = insert_program_with_listing(provider_id: provider.id)
+      {child, parent} = KlassHero.Factory.insert_child_with_guardian()
+
+      enrollment =
+        KlassHero.Factory.insert(:enrollment_schema,
+          program_id: program.id,
+          parent_id: parent.id,
+          child_id: child.id,
+          status: :pending
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      assert has_element?(view, "#pending-enrollment-#{enrollment.id}")
+
+      enrollment
+      |> Ecto.Changeset.change(%{
+        status: :confirmed,
+        confirmed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+      |> Repo.update!()
+
+      event =
+        DomainEvent.new(
+          :enrollment_confirmed,
+          enrollment.id,
+          :enrollment,
+          %{provider_id: provider.id}
+        )
+
+      send(view.pid, {:domain_event, event})
+      _ = render(view)
+
+      refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
     end
 
     test "approving an enrollment for another provider's program flashes an error",


### PR DESCRIPTION
Closes #867.

## Summary

- Collapse the dashboard's pending-enrollment refresh from two parallel publish channels (canonical `:enrollment_confirmed` domain event + supplementary `Phoenix.PubSub.broadcast/3` on `enrollment:provider:<id>:pending_changed`) into one: the canonical event now carries `provider_id` in its payload, and `Enrollment.NotifyLiveViews` routes it to a provider-scoped topic.
- Drop the eager `refresh_pending_enrollments/1` call from `handle_event("approve_enrollment", …)`'s `:ok` branch. The LiveView observes its own approve via the loopback, same path as any other tab — exactly one refresh per click.
- Add `Enrollment.provider_scoped_topic/2` as the single source of truth for the provider-scoped topic format. Both the publisher (`derive_topic/1` in the shim) and the subscriber (`DashboardLive`) call it, so the producer/consumer topic string can never drift.
- Rewrite the dashboard's `:enrollment_pending_changed` atom handler to pattern-match the canonical `{:domain_event, %DomainEvent{event_type: :enrollment_confirmed}}` envelope.
- Split the existing "approving a pending enrollment confirms it and removes it from the card" LiveView test into two narrower tests — one for DB + flash side-effects, one for the event-driven refresh path (using the `send(view.pid, {:domain_event, event})` pattern from `sessions_live_test.exs`).

## Review Focus

- **Topic single-sourcing** — `lib/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views.ex:21-27` introduces `provider_scoped_topic/2`; `lib/klass_hero/enrollment.ex:335-342` exposes it through the umbrella; `lib/klass_hero_web/live/provider/dashboard_live.ex:214-217` consumes it. The topic string `enrollment:<event>:provider:<id>` now lives in one function only.
- **Domain event payload change** — `lib/klass_hero/enrollment/application/commands/confirm_enrollment.ex:98` adds `provider_id` to the `:enrollment_confirmed` payload. This is a payload extension, not a struct migration: domain events are open maps (`KlassHero.Shared.Domain.Events.DomainEvent.payload :: map()`) and are not persisted, so no schema migration is required.
- **Subscriber pattern change** — `lib/klass_hero_web/live/provider/dashboard_live.ex:276` now matches the standard `{:domain_event, %DomainEvent{event_type: :enrollment_confirmed}}` envelope used by `PubSubEventPublisher.publish/2`, replacing the bespoke `:enrollment_pending_changed` atom. Worth confirming the catch-all clause directly below still swallows unrelated messages cleanly.
- **No-refresh comment is load-bearing** — `lib/klass_hero_web/live/provider/dashboard_live.ex:295`: the one-line comment in the `:ok` branch (`# No refresh here — :enrollment_confirmed loopback drives it (handle_info/2).`) prevents a future regression where someone "adds the missing refresh" and reintroduces the double-query.
- **Test path for event-driven LV behaviour** — `test/klass_hero_web/live/provider/dashboard_live_test.exs:1500-1539`: the new test simulates the PubSub fan-out via `send(view.pid, {:domain_event, event})` because in tests `TestEventPublisher` records events but does not broadcast on Phoenix.PubSub. The pattern matches established usage in `sessions_live_test.exs:181,213,479,520`. A follow-up issue (#869) tracks extracting a helper.

## Test Plan

- [x] `mix test test/klass_hero/enrollment/application/commands/confirm_enrollment_test.exs` — 7 pass
- [x] `mix test test/klass_hero/enrollment/adapters/driving/events/event_handlers/notify_live_views_test.exs` — 3 pass
- [x] `mix test test/klass_hero_web/live/provider/dashboard_live_test.exs` — 67 pass (5 pending-enrollments tests + the new event-driven refresh test)
- [x] `mix precommit` — 4893 passed, 5 skipped, 18 excluded
- [x] Live test-drive on `/provider/dashboard` (report at `.test-drive-reports/test-drive-2026-05-18-0716-867.md`): verified exactly one `[Enrollment.ListPendingEnrollmentsForProvider] Listing` per approve via `:erlang.trace/3` on the LiveView pid. Note in the report: the running local Phoenix server needs a hard restart after pulling PR #866 because `DomainEventBus` reads handlers only at supervisor `init/1`.
- [ ] Reviewer manual check: open `/provider/dashboard` in two tabs as the same provider, approve in tab A, verify tab B's pending list updates.
- [ ] Reviewer manual check: trigger `:invalid_status_transition` (race two browsers approving the same enrollment) — second approver should see the "Enrollment is not pending" flash AND the card refreshes (stale-data recovery path).

## Follow-ups

Filed as separate issues (do not block this PR):

- #869 — Extract `emit_domain_event` LV test helper (deduplicate the `send(view.pid, {:domain_event, event})` pattern)
- #870 — Eliminate the second DB round-trip in `refresh_pending_enrollments/1` (push provider_id filtering down to the Enrollment query)
- #871 — In-memory dedup of the confirmed enrollment in the LV event handler (zero DB queries on the originator)