### PR TITLE
feat: update homepage provider CTA copy and link to /for-providers

### DIFF
--- a/lib/klass_hero_web/components/marketing_components.ex
+++ b/lib/klass_hero_web/components/marketing_components.ex
@@ -544,10 +544,13 @@ defmodule KlassHeroWeb.MarketingComponents do
                 "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
               )}
             </p>
+            <p id="mk-provider-cta-subtitle" class="text-white/90 text-base font-semibold mt-6">
+              {gettext("Are you an educator, coach, or artist?")}
+            </p>
             <div class="mt-8 flex gap-3 flex-wrap">
               <.link navigate={~p"/for-providers"}>
-                <.kh_button variant={:primary} size={:lg}>
-                  {gettext("Start Teaching Today →")}
+                <.kh_button variant={:primary} size={:lg} id="mk-provider-cta-primary">
+                  {gettext("Learn How to Become a Hero →")}
                 </.kh_button>
               </.link>
               <.link navigate={~p"/for-providers"}>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1731,10 +1731,15 @@ msgstr ""
 msgid "Sports"
 msgstr "Sport"
 
-#: lib/klass_hero_web/live/home_live.ex:325
+#: lib/klass_hero_web/components/marketing_components.ex:548
 #, elixir-autogen, elixir-format
-msgid "Start Teaching Today →"
-msgstr ""
+msgid "Are you an educator, coach, or artist?"
+msgstr "Bist du Pädagog:in, Coach oder Künstler:in?"
+
+#: lib/klass_hero_web/components/marketing_components.ex:553
+#, elixir-autogen, elixir-format
+msgid "Learn How to Become a Hero →"
+msgstr "Werde zum Hero →"
 
 #: lib/klass_hero_web/live/about_live.ex:173
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1731,9 +1731,14 @@ msgstr ""
 msgid "Sports"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:325
+#: lib/klass_hero_web/components/marketing_components.ex:548
 #, elixir-autogen, elixir-format
-msgid "Start Teaching Today →"
+msgid "Are you an educator, coach, or artist?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:553
+#, elixir-autogen, elixir-format
+msgid "Learn How to Become a Hero →"
 msgstr ""
 
 #: lib/klass_hero_web/live/about_live.ex:173

--- a/test/klass_hero_web/live/home_live_test.exs
+++ b/test/klass_hero_web/live/home_live_test.exs
@@ -141,7 +141,8 @@ defmodule KlassHeroWeb.HomeLiveTest do
 
       assert has_element?(view, "#mk-provider-cta")
       assert has_element?(view, "h2", "How to Grow Your Youth Program")
-      assert has_element?(view, "button", "Start Teaching Today")
+      assert has_element?(view, "#mk-provider-cta-subtitle", "Are you an educator, coach, or artist?")
+      assert has_element?(view, "#mk-provider-cta-primary", "Learn How to Become a Hero")
 
       # Three numbered step cards.
       assert has_element?(view, "h4", "List Your Program")


### PR DESCRIPTION
## Summary
- Adds subtitle paragraph "Are you an educator, coach, or artist?" above the provider CTA button in `mk_provider_cta/1`
- Changes primary button label from "Start Teaching Today →" to "Learn How to Become a Hero →"
- Button navigation to `/for-providers` was already in place from the design-system migration; no link change needed

## Review Focus
- `lib/klass_hero_web/components/marketing_components.ex` (mk_provider_cta/1): new subtitle `<p>` styled `text-white/90 text-base font-semibold mt-6`, sitting between the existing description and the CTA row. Subtitle gets `id="mk-provider-cta-subtitle"`, primary button gets `id="mk-provider-cta-primary"` for stable test selectors.
- `test/klass_hero_web/live/home_live_test.exs`: existing `"renders provider CTA section"` test updated to assert on the two new DOM ids (replaces the bare-`button` text-match).
- `priv/gettext/{en,de}/LC_MESSAGES/default.po`: two new msgids added, old `"Start Teaching Today →"` removed. German strings filled inline: `"Bist du Pädagog:in, Coach oder Künstler:in?"` and `"Werde zum Hero →"`.

## Test Plan
- [x] `mix test test/klass_hero_web/live/home_live_test.exs:139` — green
- [x] `mix precommit` — 4894 tests passed, no compile or lint regressions
- [ ] Visual check on dev: scroll to `#mk-provider-cta`, confirm subtitle reads as a lead-in question and the button navigates to `/for-providers`

Closes #650