### PR TITLE
feat: add safety standards section to /for-providers

### DIFF
--- a/lib/klass_hero_web/live/for_providers_live.ex
+++ b/lib/klass_hero_web/live/for_providers_live.ex
@@ -20,6 +20,7 @@ defmodule KlassHeroWeb.ForProvidersLive do
     <.dark_hero />
     <.benefits_section benefits={benefits()} />
     <.how_it_works_section steps={steps()} />
+    <.safety_standards_section standards={safety_standards()} />
     <.pricing_section tiers={@provider_tiers} />
     <.faq_section faqs={faqs()} />
     <.final_cta />
@@ -125,6 +126,37 @@ defmodule KlassHeroWeb.ForProvidersLive do
             <h4 class="font-bold text-lg">{s.title}</h4>
             <p class="text-white/70 mt-2 leading-relaxed text-sm">{s.desc}</p>
           </div>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  attr :standards, :list, required: true
+
+  defp safety_standards_section(assigns) do
+    ~H"""
+    <section id="for-providers-safety-standards" class="py-16 lg:py-24 bg-white">
+      <div class="max-w-7xl mx-auto px-6">
+        <div class="text-center max-w-2xl mx-auto mb-14">
+          <.kh_pill tone={:primary} class="mb-3">{gettext("Trust & Safety")}</.kh_pill>
+          <h2 class={[Theme.typography(:page_title)]}>
+            {gettext("The bar to teach on Klass Hero")}
+          </h2>
+          <p class="text-hero-grey-600 text-lg mt-3">
+            {gettext("Every Hero clears the same checks. Here's what that means.")}
+          </p>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <.kh_card
+            :for={s <- @standards}
+            data-role="safety-card"
+            class="p-7 hover:shadow-lg hover:-translate-y-1"
+          >
+            <.kh_icon_chip icon={s.icon} gradient={:primary} />
+            <h3 class={["mt-5", Theme.typography(:card_title), "text-xl"]}>{s.title}</h3>
+            <p class="mt-2 text-hero-grey-600 leading-relaxed">{s.desc}</p>
+          </.kh_card>
         </div>
       </div>
     </section>
@@ -374,6 +406,51 @@ defmodule KlassHeroWeb.ForProvidersLive do
         icon: "hero-chart-bar",
         title: gettext("Insights that matter"),
         desc: gettext("Track signups, retention, no-shows, and revenue. Identify what's working and double down.")
+      }
+    ]
+  end
+
+  defp safety_standards do
+    [
+      %{
+        icon: "hero-identification",
+        title: gettext("Age & Identity"),
+        desc: gettext("18+, government-ID verified before listing.")
+      },
+      %{
+        icon: "hero-academic-cap",
+        title: gettext("Teaching Experience"),
+        desc: gettext("Minimum one year working with children, validated.")
+      },
+      %{
+        icon: "hero-shield-exclamation",
+        title: gettext("Extended Police Check"),
+        desc: gettext("Erweitertes Führungszeugnis — refreshed annually.")
+      },
+      %{
+        icon: "hero-video-camera",
+        title: gettext("Pedagogical Interview"),
+        desc: gettext("Live video screen with our safeguarding lead.")
+      },
+      %{
+        icon: "hero-heart",
+        title: gettext("Safeguarding Training"),
+        desc: gettext("Mandatory child-protection course before going live.")
+      },
+      %{
+        icon: "hero-document-check",
+        title: gettext("Qualifications"),
+        desc: gettext("Degrees, certs, and references reviewed.")
+      },
+      %{
+        icon: "hero-check-badge",
+        title: gettext("Community Standards"),
+        desc: gettext("Signed agreement on conduct and quality bar.")
+      },
+      %{
+        icon: "hero-shield-check",
+        title: gettext("Liability Insurance"),
+        desc: gettext("Active policy required to teach.")
       }
     ]
   end

--- a/lib/klass_hero_web/live/for_providers_live.ex
+++ b/lib/klass_hero_web/live/for_providers_live.ex
@@ -425,7 +425,7 @@ defmodule KlassHeroWeb.ForProvidersLive do
       %{
         icon: "hero-shield-exclamation",
         title: gettext("Extended Police Check"),
-        desc: gettext("Erweitertes Führungszeugnis — refreshed annually.")
+        desc: gettext("Erweitertes Führungszeugnis (extended background check), refreshed annually.")
       },
       %{
         icon: "hero-video-camera",
@@ -467,7 +467,7 @@ defmodule KlassHeroWeb.ForProvidersLive do
         n: "02",
         icon: "hero-shield-check",
         title: gettext("Get verified"),
-        desc: gettext("Complete our 6-step Hero verification. We handle background checks, references and screening.")
+        desc: gettext("Complete Hero verification. We handle background checks, references and screening.")
       },
       %{
         n: "03",
@@ -497,7 +497,7 @@ defmodule KlassHeroWeb.ForProvidersLive do
         q: gettext("How quickly can I start accepting bookings?"),
         a:
           gettext(
-            "Once your listing is live and you've completed the 6-step verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
+            "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
           )
       },
       %{
@@ -511,7 +511,7 @@ defmodule KlassHeroWeb.ForProvidersLive do
         q: gettext("What's the verification process like?"),
         a:
           gettext(
-            "It's our 6-step Hero standard: identity & age verification, experience validation, extended police background check, video interview, child safeguarding training, and signing our community standards. See the Trust & Safety page for the full breakdown."
+            "It's the Hero standard: identity & age verification, experience validation, extended police background check (Erweitertes Führungszeugnis), video interview, child safeguarding training, and signing our community standards. See the Trust & Safety page for the full breakdown."
           )
       },
       %{

--- a/test/klass_hero_web/live/for_providers_live_test.exs
+++ b/test/klass_hero_web/live/for_providers_live_test.exs
@@ -20,12 +20,13 @@ defmodule KlassHeroWeb.ForProvidersLiveTest do
       assert has_element?(view, "#for-providers-hero")
     end
 
-    test "renders the four marketing sections in order", %{conn: conn} do
+    test "renders the marketing sections in order", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/for-providers")
 
       assert html =~ ~s|id="for-providers-hero"|
       assert html =~ ~s|id="for-providers-benefits"|
       assert html =~ ~s|id="for-providers-how-it-works"|
+      assert html =~ ~s|id="for-providers-safety-standards"|
       assert html =~ ~s|id="for-providers-pricing"|
       assert html =~ ~s|id="for-providers-faq"|
 
@@ -34,13 +35,21 @@ defmodule KlassHeroWeb.ForProvidersLiveTest do
       benefits_pos =
         String.split(html, ~s|id="for-providers-benefits"|) |> hd() |> String.length()
 
+      how_it_works_pos =
+        String.split(html, ~s|id="for-providers-how-it-works"|) |> hd() |> String.length()
+
+      safety_pos =
+        String.split(html, ~s|id="for-providers-safety-standards"|) |> hd() |> String.length()
+
       pricing_pos =
         String.split(html, ~s|id="for-providers-pricing"|) |> hd() |> String.length()
 
       faq_pos = String.split(html, ~s|id="for-providers-faq"|) |> hd() |> String.length()
 
       assert hero_pos < benefits_pos
-      assert benefits_pos < pricing_pos
+      assert benefits_pos < how_it_works_pos
+      assert how_it_works_pos < safety_pos
+      assert safety_pos < pricing_pos
       assert pricing_pos < faq_pos
     end
 
@@ -78,6 +87,21 @@ defmodule KlassHeroWeb.ForProvidersLiveTest do
       assert html =~ "Get verified"
       assert html =~ "Receive bookings"
       assert html =~ "Get paid weekly"
+    end
+
+    test "renders the 8-up safety standards grid", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/for-providers")
+
+      assert has_element?(view, "#for-providers-safety-standards")
+      assert html =~ "The bar to teach on Klass Hero"
+      assert html =~ "Age &amp; Identity"
+      assert html =~ "Teaching Experience"
+      assert html =~ "Extended Police Check"
+      assert html =~ "Pedagogical Interview"
+      assert html =~ "Safeguarding Training"
+      assert html =~ "Qualifications"
+      assert html =~ "Community Standards"
+      assert html =~ "Liability Insurance"
     end
 
     test "renders one pricing tier per backed Entitlements provider tier", %{conn: conn} do


### PR DESCRIPTION
## Summary

Adds an 8-card **Safety Standards** section to `/for-providers`, slotted between the dark `how_it_works_section` and the cream `pricing_section`. Closes #653.

The original ticket predates the #806 design-system migration. This PR filters it through current page reality:

- **Drops Section 4 (Application Process)** — `how_it_works_section/1` already ships the same 4-step flow (List → Verify → Bookings → Paid) in the new vocabulary. Building a second one would contradict the page.
- **Drops `bg-hero-pink-200` + `provider_step_card`** — both off-rhythm with current dark/white/cream cycle. New section uses `kh_card`, `kh_icon_chip`, and `Theme.typography` to match `benefits_section/1`'s cadence.
- **De-dupes the spec's 8 icons** — original had `hero-shield-check` twice.

The semantic gap this fills: today step 02 of how-it-works says "Complete our 6-step Hero verification" with zero detail. Providers couldn't *see* the bar. This makes the rigor visible right before the pricing slab.

## Review Focus

- **Page order** — `lib/klass_hero_web/live/for_providers_live.ex` `render/1`. Section sits between `how_it_works_section` and `pricing_section`. Verified by `for_providers_live_test.exs:23` ordering assertions.
- **Component reuse** — uses existing `kh_pill`, `kh_card`, `kh_icon_chip` exactly as `benefits_section/1` does. No new components, no new theme tokens.
- **i18n** — 11 new `gettext/1` calls render via msgid fallback for both EN and DE. Full extraction deferred to existing #876 (gettext-drift backlog) to keep this PR atomic; running `mix gettext.extract --merge` here would have introduced ~7800 lines of unrelated drift.

## Test Plan

- [x] `mix test test/klass_hero_web/live/for_providers_live_test.exs` — 15 pass (new "renders the 8-up safety standards grid" + updated ordering test)
- [x] `mix precommit` — 4895 tests pass, typography lint clean, EXIT=0
- [x] Playwright desktop @ 1280px — 4-col grid, section between dark how-it-works and cream pricing
- [x] Playwright mobile @ 375px — single-column stack, no overflow, vertical rhythm intact
- [x] Tidewave logs — no template errors, no missing-icon warnings during render

## Out of scope

- DE translations — covered by existing #876
- Application Process section (Section 4 of #653) — intentionally not built; redundant with shipped how-it-works
- `provider_step_card` legacy cleanup — separate refactor