### PR TITLE
fix: dispatch participant_added on broadcast (closes #887)

### DIFF
--- a/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
+++ b/lib/klass_hero/messaging/application/commands/broadcast_to_program.ex
@@ -15,6 +15,7 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
   alias KlassHero.Messaging.Application.Commands.AddAssignedStaff
   alias KlassHero.Messaging.Application.Commands.SendMessage
   alias KlassHero.Messaging.Application.Shared
+  alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Domain.Models.Conversation
   alias KlassHero.Messaging.Domain.Models.Message
   alias KlassHero.Repo
@@ -137,25 +138,27 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
     end
   end
 
-  # Trigger: broadcast participants need to be present before SendMessage runs
-  # Why: SendMessage.verify_participant rejects senders not in the conversation —
-  #      provider/staff sender must be added before delegation. AddAssignedStaff
-  #      now returns its :participant_added domain event as data; dispatch
-  #      happens after the transaction commits so the projection on a separate
-  #      DB connection can read-your-own-writes.
+  # Trigger: broadcast participants need to be present before SendMessage runs.
+  # Why: SendMessage.verify_participant rejects senders not in the conversation;
+  #      parents and sender are inserted via a single add_batch so its
+  #      "only-newly-inserted" return list is the exact set the :broadcast_setup
+  #      :participant_added event should carry. Empty new-list ⇒ no event,
+  #      preserving idempotency on re-broadcast. AddAssignedStaff returns its
+  #      own :participant_added domain event as data; dispatch happens after
+  #      the transaction commits so projections on a separate DB connection
+  #      can read-their-own-writes.
   # Outcome: parents, sender, and assigned staff added in a single transaction;
   #          on commit, all collected events fan out via EventDispatchHelper.
   defp setup_participants(conversation, scope, parent_user_ids) do
+    # De-dupe sender against parents — degenerate case where provider's user
+    # account is also enrolled as a parent of the program.
+    candidate_ids = Enum.uniq([scope.user.id | parent_user_ids])
+
     Repo.transaction(fn ->
-      with {:ok, _} <- @participant_repo.add_batch(conversation.id, parent_user_ids),
-           {:ok, _} <-
-             @participant_repo.add_or_get(%{
-               conversation_id: conversation.id,
-               user_id: scope.user.id
-             }),
+      with {:ok, inserted} <- @participant_repo.add_batch(conversation.id, candidate_ids),
            {:ok, {_staff_ids, staff_events}} <-
              AddAssignedStaff.execute(conversation.id, conversation.program_id, scope.user.id) do
-        staff_events
+        build_broadcast_event(conversation.id, inserted) ++ staff_events
       else
         {:error, reason} -> Repo.rollback(reason)
       end
@@ -168,6 +171,13 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgram do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp build_broadcast_event(_conversation_id, []), do: []
+
+  defp build_broadcast_event(conversation_id, inserted) do
+    user_ids = Enum.map(inserted, & &1.user_id)
+    [MessagingEvents.participant_added(conversation_id, user_ids, :broadcast_setup)]
   end
 
   defp get_or_create_broadcast_conversation(provider_id, program_id, subject) do

--- a/lib/klass_hero/messaging/domain/events/messaging_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_events.ex
@@ -188,7 +188,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   end
 
   @typedoc "Provenance of a participant_added event."
-  @type participant_added_source :: :initial_staff | :later_assignment
+  @type participant_added_source :: :initial_staff | :later_assignment | :broadcast_setup
 
   @doc """
   Creates a participant_added event.

--- a/lib/klass_hero/messaging/domain/events/messaging_integration_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_integration_events.ex
@@ -80,7 +80,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEvents do
         }
 
   @typedoc "Source of a `:participant_added` event."
-  @type participant_added_source :: :initial_staff | :later_assignment
+  @type participant_added_source :: :initial_staff | :later_assignment | :broadcast_setup
 
   @typedoc "Payload for `:participant_added` events."
   @type participant_added_payload :: %{

--- a/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
+++ b/test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs
@@ -1,13 +1,15 @@
 defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgramTest do
-  use KlassHero.DataCase, async: true
+  use KlassHero.DataCase, async: false
 
   import KlassHero.EventTestHelper
   import KlassHero.Factory
 
   alias KlassHero.Accounts.Scope
   alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ConversationSummariesRepository
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ParticipantRepository
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Repositories.ProgramStaffParticipantRepository
+  alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
   alias KlassHero.Messaging.Application.Commands.BroadcastToProgram
   alias KlassHero.Messaging.Domain.Models.{Conversation, Message}
   alias KlassHero.Provider.Domain.Models.ProviderProfile
@@ -413,6 +415,179 @@ defmodule KlassHero.Messaging.Application.Commands.BroadcastToProgramTest do
 
       published_types = Enum.map(get_published_events(), & &1.event_type)
       refute :broadcast_sent in published_types
+    end
+  end
+
+  describe "execute/4 — :participant_added event dispatch" do
+    setup do
+      setup_test_integration_events()
+      :ok
+    end
+
+    test "first broadcast emits :participant_added with source :broadcast_setup carrying sender + parent user_ids" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent1_user = AccountsFixtures.user_fixture()
+      parent2_user = AccountsFixtures.user_fixture()
+      parent1 = insert(:parent_profile_schema, identity_id: parent1_user.id)
+      parent2 = insert(:parent_profile_schema, identity_id: parent2_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent1.id,
+        status: "confirmed"
+      )
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent2.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, conversation, _msg, _count} =
+               BroadcastToProgram.execute(scope, program.id, "Hi")
+
+      event =
+        get_published_integration_events()
+        |> Enum.find(
+          &match?(
+            %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+            &1
+          )
+        )
+
+      assert event,
+             "expected a :participant_added integration event with source :broadcast_setup to be published"
+
+      assert event.entity_id == conversation.id
+
+      assert Enum.sort(event.payload.participant_user_ids) ==
+               Enum.sort([scope.user.id, parent1_user.id, parent2_user.id])
+    end
+
+    test "re-broadcast on existing conversation with same participants emits NO :broadcast_setup event" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent_user = AccountsFixtures.user_fixture()
+      parent = insert(:parent_profile_schema, identity_id: parent_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, _, _, _} = BroadcastToProgram.execute(scope, program.id, "first")
+
+      clear_integration_events()
+
+      assert {:ok, _, _, _} = BroadcastToProgram.execute(scope, program.id, "second")
+
+      refute Enum.any?(
+               get_published_integration_events(),
+               &match?(
+                 %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+                 &1
+               )
+             ),
+             "expected no :broadcast_setup event on re-broadcast when participants are unchanged"
+    end
+
+    test "re-broadcast that adds a NEW enrolled parent emits :broadcast_setup with only the new user_id" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent1_user = AccountsFixtures.user_fixture()
+      parent1 = insert(:parent_profile_schema, identity_id: parent1_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent1.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, _, _, _} = BroadcastToProgram.execute(scope, program.id, "first")
+
+      clear_integration_events()
+
+      # New parent enrolled between broadcasts
+      parent2_user = AccountsFixtures.user_fixture()
+      parent2 = insert(:parent_profile_schema, identity_id: parent2_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent2.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, _, _, _} = BroadcastToProgram.execute(scope, program.id, "second")
+
+      event =
+        get_published_integration_events()
+        |> Enum.find(
+          &match?(
+            %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+            &1
+          )
+        )
+
+      assert event,
+             "expected a :participant_added event with source :broadcast_setup for the newly-enrolled parent"
+
+      assert event.payload.participant_user_ids == [parent2_user.id]
+    end
+
+    test "sender and each parent see broadcast in inbox after projection runs (no server restart)" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      scope = build_scope_with_provider(provider, :professional)
+
+      parent1_user = AccountsFixtures.user_fixture()
+      parent2_user = AccountsFixtures.user_fixture()
+      parent1 = insert(:parent_profile_schema, identity_id: parent1_user.id)
+      parent2 = insert(:parent_profile_schema, identity_id: parent2_user.id)
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent1.id,
+        status: "confirmed"
+      )
+
+      insert(:enrollment_schema,
+        program_id: program.id,
+        parent_id: parent2.id,
+        status: "confirmed"
+      )
+
+      assert {:ok, conversation, _msg, _count} =
+               BroadcastToProgram.execute(scope, program.id, "Important")
+
+      event =
+        get_published_integration_events()
+        |> Enum.find(
+          &match?(
+            %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+            &1
+          )
+        )
+
+      assert event, "expected :broadcast_setup event to be dispatched"
+
+      # Drive the projection directly — deterministic, avoids PubSub timing.
+      ConversationSummaries.handle_event(:participant_added, event)
+
+      for user_id <- [scope.user.id, parent1_user.id, parent2_user.id] do
+        {:ok, summaries, _has_more} = ConversationSummariesRepository.list_for_user(user_id, [])
+
+        assert Enum.any?(summaries, &(&1.conversation_id == conversation.id)),
+               "expected user #{user_id} to see broadcast conversation #{conversation.id} in inbox; " <>
+                 "got #{inspect(Enum.map(summaries, & &1.conversation_id))}"
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #887 — broadcast threads now appear in the messages inbox immediately after sending (sender + enrolled parents), without requiring a server restart.

**Root cause**: `BroadcastToProgram.setup_participants/3` inserted parents and the sender into `messaging_participants` but never emitted a `:participant_added` event. The `ConversationSummaries` read projection therefore never saw them, and inbox rows only materialised on next bootstrap (server restart re-reads the write tables).

**Fix**: collapse the parent `add_batch` and sender `add_or_get` into a single `add_batch([sender | parents])` call. Its returned rows (`returning: true, on_conflict: :nothing` ⇒ exactly the newly-inserted rows) are the source-of-truth for the `:participant_added` event payload — empty list ⇒ no event (idempotency on re-broadcast). Tag the new event with a fresh `:broadcast_setup` source variant for provenance.

## Review Focus

- **`lib/klass_hero/messaging/application/commands/broadcast_to_program.ex`** — `setup_participants/3` rewrite. Uses `Enum.uniq` to handle the degenerate "provider is also enrolled as a parent" case. Removes the now-redundant `add_or_get` for sender.
- **`lib/klass_hero/messaging/domain/events/messaging_events.ex`** + **`messaging_integration_events.ex`** — additive: `:broadcast_setup` joins `:initial_staff | :later_assignment` in the `participant_added_source` union. Projection is source-agnostic — no projection changes needed.

## Test Plan

- [x] TDD red → green: 4 new tests in `broadcast_to_program_test.exs` covering first-broadcast emission, idempotency on no-op re-broadcast, new-parent-only emission when participants change, and end-to-end inbox visibility for sender + all parents
- [x] `mix test test/klass_hero/messaging/application/commands/broadcast_to_program_test.exs` — 19/19 PASS
- [x] Pattern-parity: `add_assigned_staff_test.exs` + all projection tests + `start_program_conversation_test.exs` + `reply_privately_to_broadcast_test.exs` — 51/51 PASS
- [x] `mix precommit` — 4899 passed, 5 skipped, 18 excluded
- [x] **UI test-drive**: sent a broadcast as Robert Braun via `/provider/programs/.../broadcast` → redirected to thread → navigated back to `/provider/messages` → new thread visible at top with "Now" timestamp and "Broadcast" badge. Enrolled parent (Petra Becker) also sees it via the read repository
- [x] Mobile responsive (375×667): inbox layout intact with bottom-nav

## Known Pre-existing Issue (not a regression)

Broadcast inbox rows display "Unknown" as the sender label (avatar "U") because `ConversationSummaries.resolve_other_participant_name/4` returns `nil` for non-`direct` conversation types. Surfaced now because the fix makes broadcast rows visible at all. Filed as #892 for follow-up.

## Edge Cases Handled

- Sender is also enrolled as a parent: `Enum.uniq` de-dupes
- Re-broadcast with same participants: empty new-rows list ⇒ no event emitted
- Re-broadcast with one newly enrolled parent: event carries only the new user_id

## Out of Scope

- `:conversation_created` parity with `StartProgramConversation` — not needed; the projection is keyed on `:participant_added`
- Refactoring `get_or_create_broadcast_conversation/3` to live inside the participant transaction — pre-existing concern, separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)