### PR TITLE
fix: dashboard KeyError :body for parents with recent messages

### DIFF
--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -161,7 +161,7 @@ defmodule KlassHeroWeb.DashboardLive do
           %{
             id: conv.id,
             from: from,
-            preview: (msg && msg.body) || gettext("New conversation"),
+            preview: (msg && msg.content) || gettext("New conversation"),
             time: msg && relative_time(msg.inserted_at),
             color: Enum.at(palette, rem(idx, length(palette))),
             unread?: entry.unread_count > 0

--- a/test/klass_hero_web/live/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/dashboard_live_test.exs
@@ -89,6 +89,23 @@ defmodule KlassHeroWeb.DashboardLiveTest do
 
       assert html =~ "No messages yet."
     end
+
+    test "renders latest message preview when the user has a conversation summary",
+         %{conn: conn, user: user} do
+      # Regression: #897 — dashboard crashed with `KeyError :body` because the
+      # LiveView read `msg.body` while the read-model DTO exposes `:content`.
+      preview_text = "Spring recital reminder for Saturday"
+
+      insert(:conversation_summary_schema,
+        user_id: user.id,
+        latest_message_content: preview_text,
+        latest_message_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      {:ok, _view, html} = live(conn, ~p"/dashboard")
+
+      assert html =~ preview_text
+    end
   end
 
   describe "Contact Provider flow" do


### PR DESCRIPTION
## Summary

- `DashboardLive.load_recent_messages/1` was reading `msg.body`, but `ListConversations.to_enriched_map/1` now exposes the latest message under `:content` (renamed during the #806 design-system migration).
- The bug stayed dormant while seed parents had no recent messages; PR #893 / #895 made broadcast threads visible with non-nil `latest_message`, surfacing a 500 on `/dashboard` for any active parent.
- One-line fix in `dashboard_live.ex:164` plus a regression test that seeds a `conversation_summary` for the logged-in user and asserts the preview renders.

## Review Focus

- `lib/klass_hero_web/live/dashboard_live.ex:164` — read-model key matches the DTO shape in `lib/klass_hero/messaging/application/queries/list_conversations.ex:90-97`.
- `test/klass_hero_web/live/dashboard_live_test.exs` — new test exercises the consumer side of the projection seam; should fail pre-fix with the exact `KeyError :body` stack trace.

## Test Plan

- [x] `mix test test/klass_hero_web/live/dashboard_live_test.exs` (11 passed)
- [x] `mix precommit` (4905 passed, 5 skipped)
- [x] Manual: log in as a parent with broadcast threads, `/dashboard` renders the recent-messages widget without the Phoenix error overlay.

Closes #897